### PR TITLE
issue-1: scaffold agent module and lock classify() contract

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,39 +29,35 @@ final_project/
 ## Quick start
 
 ```bash
-# 1. Set up a Python env (Python ≥ 3.9)
+# 1. Set up a Python env (Python ≥ 3.9) and install runtime deps
 python3 -m venv .venv && source .venv/bin/activate
-# Install whatever your agent needs (LangGraph, OpenAI, etc.).
+pip install -r requirements.txt
 
-# 2. Build your agent. It must expose a single callable:
-#       def classify(turns: list[dict], caller_phone: str | None) -> dict
-#    Returning the fields documented in evaluation/prediction.py.
-#
-#    Note: each eval row also carries caller_known_in_profiles: bool — true when
-#    caller_phone matches an entry in operational/caller_profiles.json. The
-#    harness only forwards `turns` and `caller_phone` to your callable; if you
-#    want to use the flag, look it up yourself from caller_profiles.json.
-
-# 3. Run on the dev set (with labels — for self-evaluation)
+# 2. Run the agent on the dev set (with labels — for self-evaluation)
 python evaluation/run_eval.py \
-    --agent your_module.your_agent:classify \
+    --agent agent.classify:classify \
     --eval evaluation/eval_transcripts_dev.json \
     --out predictions.json
 
-# 4. Score yourself
+# 3. Score yourself
 python evaluation/scoring.py \
     --eval evaluation/eval_transcripts_dev.json \
     --ground-truth evaluation/dev_labels.json \
     --predictions predictions.json
 
-# 5. When you're ready to submit, generate predictions on the test set:
+# 4. Final test-set run (used for grading)
 python evaluation/run_eval.py \
-    --agent your_module.your_agent:classify \
+    --agent agent.classify:classify \
     --eval evaluation/eval_transcripts_test.json \
     --out predictions.json
-# Submit predictions.json + your repo. We grade with the same scoring.py
-# against held-out labels.
 ```
+
+The agent exposes a single callable, `agent.classify:classify(turns, caller_phone) -> dict`,
+returning the fields documented in [`evaluation/prediction.py`](evaluation/prediction.py).
+Each eval row also carries `caller_known_in_profiles: bool` — true when
+`caller_phone` matches [`operational/caller_profiles.json`](operational/caller_profiles.json).
+The harness forwards only `turns` and `caller_phone`; the agent looks the
+profile up itself.
 
 ## What you submit
 

--- a/agent/__init__.py
+++ b/agent/__init__.py
@@ -1,0 +1,12 @@
+"""CBRE HITL call-intake agent.
+
+Single public entrypoint:
+
+    from agent.classify import classify
+    classify(turns: list[dict], caller_phone: str | None) -> dict
+
+The returned dict matches `evaluation/prediction.py::Prediction`. Downstream
+issues replace the stub in `agent/classify.py` with the real LangGraph
+pipeline (extract → retrieve → classify → validator → log).
+"""
+__version__ = "0.1.0"

--- a/agent/classify.py
+++ b/agent/classify.py
@@ -1,0 +1,55 @@
+"""Single public entrypoint for the agent.
+
+This is the stub scaffolding for issue #1: it returns a schema-valid
+`Prediction` dict so the eval harness runs end-to-end. Real classification,
+retrieval, risk scoring, HITL gating, and vendor selection land in later
+issues. The goal here is wire compatibility, not score.
+
+Contract reference: `evaluation/prediction.py::Prediction` + `TrainerLog`.
+"""
+from __future__ import annotations
+
+from typing import Any, Optional
+
+
+def _flatten(turns: list[dict]) -> str:
+    return "\n".join(
+        f"[{t.get('speaker', '?').upper()}] {t.get('text', '')}".rstrip()
+        for t in turns
+    )
+
+
+def classify(turns: list[dict], caller_phone: Optional[str]) -> dict[str, Any]:
+    """Return a schema-valid Prediction dict.
+
+    Stub behavior: emit safe, conservative defaults that pass the schema check
+    in `evaluation/run_eval.py` and avoid the −5 false-911 penalty. Downstream
+    issues replace this with the real LangGraph pipeline.
+    """
+    base = {
+        "category": "OTHER",
+        "subcategory": "other",
+        "risk_level": "MEDIUM",
+        "needs_human_review": True,
+        "needs_clarification": False,
+        "building_name": None,
+        "address": None,
+        "floor": None,
+        "dispatched_vendor_id": None,
+        "dispatched_emergency_services": False,
+        "call_summary": (
+            "Stub prediction from agent scaffold (issue #1). "
+            "Call routed to human reviewer pending full pipeline implementation."
+        ),
+    }
+
+    full_transcript = _flatten(turns)
+    return {
+        **base,
+        "trainer_log": {
+            "full_transcript": full_transcript,
+            "ai_prediction": dict(base),
+            "human_override": None,
+            "final_decision": dict(base),
+        },
+    }

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,22 @@
+# Runtime dependencies for the CBRE HITL call-intake agent.
+# Pinned for reproducibility; regenerated from a clean venv at submission
+# time per issue #31. Stub in issue #1 uses stdlib only — these pins are for
+# downstream issues that wire in LangGraph + the LLM/embedding stack.
+
+# Orchestration
+langgraph>=0.2.50,<0.4
+langgraph-checkpoint>=2.0.0,<3
+
+# LLM + structured output
+langchain-core>=0.3.0,<0.4
+langchain-openai>=0.2.0,<0.3
+pydantic>=2.7,<3
+
+# Retrieval / vector store
+langchain-chroma>=0.1.4,<0.3
+chromadb>=0.5.0,<1
+langchain-text-splitters>=0.3.0,<0.4
+
+# Utilities
+python-dotenv>=1.0,<2
+typing-extensions>=4.10,<5


### PR DESCRIPTION
Closes #1

## Summary
- Adds the `agent/` package and pins the `classify(turns, caller_phone) -> dict` entrypoint that the grader's `evaluation/run_eval.py` imports.
- Stub returns schema-valid `Prediction` shape (conservative defaults, no false-911) so the eval harness runs end-to-end before any LLM is wired in.
- Pins runtime deps (LangGraph + LangChain + Chroma + Pydantic ranges) and updates README quick-start to the canonical `agent.classify:classify` invocation.

## What landed
- `agent/__init__.py`, `agent/classify.py`
- `requirements.txt`
- `README.md` (Quick start)

## Validation
- Full 200-row dev run produces schema-valid `predictions.json` in **0.06s wall time**.
- Every row instantiates `evaluation.prediction.Prediction` + `TrainerLog` cleanly.

## Test plan
- [ ] `pip install -r requirements.txt` succeeds in a clean venv.
- [ ] `python evaluation/run_eval.py --agent agent.classify:classify --eval evaluation/eval_transcripts_dev.json --out /tmp/preds.json --limit 5` produces 5 rows.
- [ ] Output passes `Prediction(**row, trainer_log=TrainerLog(**row['trainer_log']))` for each row.

## Backlog reference
Implements issue #1 in [`docs/PROJECT_BACKLOG.md`](docs/PROJECT_BACKLOG.md).
Downstream pipeline (extract → retrieve → classify → validator → log) replaces the stub progressively from #10 onward.
