### PR TITLE
issue-3: configure secrets, model selection, and .env loading

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,30 @@
+# Copy this file to `.env` and fill in your secrets.
+# `.env` is gitignored; this template is committed so a fresh clone has
+# a checklist of every variable the agent reads.
+#
+# Loaded automatically by python-dotenv when agent.config is first imported.
+# All AGENT_* vars are optional — defaults in agent/config.py are tuned for
+# determinism and match what the grader expects.
+
+# ─── Required ──────────────────────────────────────────────────────────
+# Auth for OpenAI chat + embedding models. Get one at
+# https://platform.openai.com/api-keys.
+OPENAI_API_KEY=
+
+# ─── Optional ──────────────────────────────────────────────────────────
+# Chat model used for extraction, classification, risk scoring, summary.
+# Default: gpt-4o-mini (cheap; bump to gpt-4o for higher accuracy at cost).
+# AGENT_CHAT_MODEL=gpt-4o-mini
+
+# Sampling temperature. Keep at 0.0 — the brief grades determinism (#28).
+# AGENT_CHAT_TEMPERATURE=0.0
+
+# OpenAI seed parameter (used where the model supports it).
+# AGENT_CHAT_SEED=7
+
+# Embedding model for the historical-records RAG index (#7). Changing this
+# requires rebuilding the chroma store from scratch.
+# AGENT_EMBEDDING_MODEL=text-embedding-3-small
+
+# Cap on the query-rewrite retry loop in the extraction node.
+# AGENT_MAX_EXTRACTION_RETRIES=2

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,30 @@
+# Python
+__pycache__/
+*.py[cod]
+*$py.class
+*.egg-info/
+.pytest_cache/
+.mypy_cache/
+.ruff_cache/
+
+# Virtualenvs
+.venv/
+venv/
+env/
+
+# Environment / secrets
+.env
+.env.local
+
+# Editor / OS
+.vscode/
+.idea/
+.DS_Store
+*.swp
+
+# Local eval outputs (committed runs go under eval_runs/)
+predictions.json
+/tmp_*.json
+
+# Vector store build artifacts (issue #7 will configure)
+agent/rag/chroma_store/

--- a/README.md
+++ b/README.md
@@ -59,6 +59,29 @@ Each eval row also carries `caller_known_in_profiles: bool` — true when
 The harness forwards only `turns` and `caller_phone`; the agent looks the
 profile up itself.
 
+## Environment variables
+
+Required:
+
+| Variable | Purpose |
+|---|---|
+| `OPENAI_API_KEY` | Auth for OpenAI chat + embedding models |
+
+Optional (defaults are tuned for determinism):
+
+| Variable | Default | Purpose |
+|---|---|---|
+| `AGENT_CHAT_MODEL` | `gpt-4o-mini` | Chat model for extraction / classification / risk |
+| `AGENT_CHAT_TEMPERATURE` | `0.0` | Sampling temperature (keep 0 for reproducibility) |
+| `AGENT_CHAT_SEED` | `7` | OpenAI seed parameter when supported |
+| `AGENT_EMBEDDING_MODEL` | `text-embedding-3-small` | Embedding model for the historical-records RAG index |
+| `AGENT_MAX_EXTRACTION_RETRIES` | `2` | Cap on the query-rewrite retry loop |
+
+Either export these in your shell or drop them in a `.env` at the repo root —
+the agent loads `.env` automatically via `python-dotenv`. Missing required
+vars surface as a `RuntimeError` from `agent.config.get_settings()` naming
+the exact variable that's unset.
+
 ## What you submit
 
 1. **Source repo** — your agent code, dependencies, README with run instructions.

--- a/README.md
+++ b/README.md
@@ -29,39 +29,35 @@ final_project/
 ## Quick start
 
 ```bash
-# 1. Set up a Python env (Python ≥ 3.9)
+# 1. Set up a Python env (Python ≥ 3.9) and install runtime deps
 python3 -m venv .venv && source .venv/bin/activate
-# Install whatever your agent needs (LangGraph, OpenAI, etc.).
+pip install -r requirements.txt
 
-# 2. Build your agent. It must expose a single callable:
-#       def classify(turns: list[dict], caller_phone: str | None) -> dict
-#    Returning the fields documented in evaluation/prediction.py.
-#
-#    Note: each eval row also carries caller_known_in_profiles: bool — true when
-#    caller_phone matches an entry in operational/caller_profiles.json. The
-#    harness only forwards `turns` and `caller_phone` to your callable; if you
-#    want to use the flag, look it up yourself from caller_profiles.json.
-
-# 3. Run on the dev set (with labels — for self-evaluation)
+# 2. Run the agent on the dev set (with labels — for self-evaluation)
 python evaluation/run_eval.py \
-    --agent your_module.your_agent:classify \
+    --agent agent.classify:classify \
     --eval evaluation/eval_transcripts_dev.json \
     --out predictions.json
 
-# 4. Score yourself
+# 3. Score yourself
 python evaluation/scoring.py \
     --eval evaluation/eval_transcripts_dev.json \
     --ground-truth evaluation/dev_labels.json \
     --predictions predictions.json
 
-# 5. When you're ready to submit, generate predictions on the test set:
+# 4. Final test-set run (used for grading)
 python evaluation/run_eval.py \
-    --agent your_module.your_agent:classify \
+    --agent agent.classify:classify \
     --eval evaluation/eval_transcripts_test.json \
     --out predictions.json
-# Submit predictions.json + your repo. We grade with the same scoring.py
-# against held-out labels.
 ```
+
+The agent exposes a single callable, `agent.classify:classify(turns, caller_phone) -> dict`,
+returning the fields documented in [`evaluation/prediction.py`](evaluation/prediction.py).
+Each eval row also carries `caller_known_in_profiles: bool` — true when
+`caller_phone` matches [`operational/caller_profiles.json`](operational/caller_profiles.json).
+The harness forwards only `turns` and `caller_phone`; the agent looks the
+profile up itself.
 
 ## What you submit
 

--- a/agent/__init__.py
+++ b/agent/__init__.py
@@ -1,0 +1,12 @@
+"""CBRE HITL call-intake agent.
+
+Single public entrypoint:
+
+    from agent.classify import classify
+    classify(turns: list[dict], caller_phone: str | None) -> dict
+
+The returned dict matches `evaluation/prediction.py::Prediction`. Downstream
+issues replace the stub in `agent/classify.py` with the real LangGraph
+pipeline (extract → retrieve → classify → validator → log).
+"""
+__version__ = "0.1.0"

--- a/agent/classify.py
+++ b/agent/classify.py
@@ -1,0 +1,55 @@
+"""Single public entrypoint for the agent.
+
+This is the stub scaffolding for issue #1: it returns a schema-valid
+`Prediction` dict so the eval harness runs end-to-end. Real classification,
+retrieval, risk scoring, HITL gating, and vendor selection land in later
+issues. The goal here is wire compatibility, not score.
+
+Contract reference: `evaluation/prediction.py::Prediction` + `TrainerLog`.
+"""
+from __future__ import annotations
+
+from typing import Any, Optional
+
+
+def _flatten(turns: list[dict]) -> str:
+    return "\n".join(
+        f"[{t.get('speaker', '?').upper()}] {t.get('text', '')}".rstrip()
+        for t in turns
+    )
+
+
+def classify(turns: list[dict], caller_phone: Optional[str]) -> dict[str, Any]:
+    """Return a schema-valid Prediction dict.
+
+    Stub behavior: emit safe, conservative defaults that pass the schema check
+    in `evaluation/run_eval.py` and avoid the −5 false-911 penalty. Downstream
+    issues replace this with the real LangGraph pipeline.
+    """
+    base = {
+        "category": "OTHER",
+        "subcategory": "other",
+        "risk_level": "MEDIUM",
+        "needs_human_review": True,
+        "needs_clarification": False,
+        "building_name": None,
+        "address": None,
+        "floor": None,
+        "dispatched_vendor_id": None,
+        "dispatched_emergency_services": False,
+        "call_summary": (
+            "Stub prediction from agent scaffold (issue #1). "
+            "Call routed to human reviewer pending full pipeline implementation."
+        ),
+    }
+
+    full_transcript = _flatten(turns)
+    return {
+        **base,
+        "trainer_log": {
+            "full_transcript": full_transcript,
+            "ai_prediction": dict(base),
+            "human_override": None,
+            "final_decision": dict(base),
+        },
+    }

--- a/agent/config.py
+++ b/agent/config.py
@@ -1,0 +1,78 @@
+"""Central runtime configuration for the agent.
+
+All tunable knobs (model name, embedding model, temperature, retry caps)
+live here. Each is overridable via an environment variable; defaults are
+picked to favor determinism (`temperature=0`, fixed `seed`) per the
+submission contract.
+
+Secrets are validated lazily — importing this module is side-effect-free
+beyond a `.env` load. The first call to `get_settings()` (or an explicit
+`Settings.validate_or_raise()`) raises a `RuntimeError` naming the exact
+missing environment variable. Pass `validate=False` to bypass when wiring up
+LLM-free code paths (e.g. data-loader unit tests, the stub in agent/classify).
+"""
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+from typing import Optional, Tuple
+
+try:
+    from dotenv import load_dotenv
+
+    load_dotenv()
+except ImportError:
+    pass
+
+
+REQUIRED_ENV_VARS: Tuple[str, ...] = ("OPENAI_API_KEY",)
+
+
+@dataclass(frozen=True)
+class Settings:
+    chat_model: str
+    chat_temperature: float
+    chat_seed: Optional[int]
+    embedding_model: str
+    max_extraction_retries: int
+    openai_api_key: Optional[str]
+
+    def validate_or_raise(self) -> None:
+        missing = [v for v in REQUIRED_ENV_VARS if not os.environ.get(v)]
+        if missing:
+            raise RuntimeError(
+                "Missing required environment variable(s): "
+                f"{', '.join(missing)}. Set them in your shell or in a .env "
+                "file at the repo root."
+            )
+
+
+def _env_float(name: str, default: float) -> float:
+    raw = os.environ.get(name)
+    return float(raw) if raw not in (None, "") else default
+
+
+def _env_int_opt(name: str, default: int) -> int:
+    raw = os.environ.get(name)
+    return int(raw) if raw not in (None, "") else default
+
+
+def get_settings(*, validate: bool = True) -> Settings:
+    """Build a `Settings` from the current environment.
+
+    Set `validate=False` only for code paths that genuinely don't need the
+    LLM (data loaders, schema tests, the issue-#1 stub).
+    """
+    settings = Settings(
+        chat_model=os.environ.get("AGENT_CHAT_MODEL", "gpt-4o-mini"),
+        chat_temperature=_env_float("AGENT_CHAT_TEMPERATURE", 0.0),
+        chat_seed=_env_int_opt("AGENT_CHAT_SEED", 7),
+        embedding_model=os.environ.get(
+            "AGENT_EMBEDDING_MODEL", "text-embedding-3-small"
+        ),
+        max_extraction_retries=_env_int_opt("AGENT_MAX_EXTRACTION_RETRIES", 2),
+        openai_api_key=os.environ.get("OPENAI_API_KEY"),
+    )
+    if validate:
+        settings.validate_or_raise()
+    return settings

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,22 @@
+# Runtime dependencies for the CBRE HITL call-intake agent.
+# Pinned for reproducibility; regenerated from a clean venv at submission
+# time per issue #31. Stub in issue #1 uses stdlib only — these pins are for
+# downstream issues that wire in LangGraph + the LLM/embedding stack.
+
+# Orchestration
+langgraph>=0.2.50,<0.4
+langgraph-checkpoint>=2.0.0,<3
+
+# LLM + structured output
+langchain-core>=0.3.0,<0.4
+langchain-openai>=0.2.0,<0.3
+pydantic>=2.7,<3
+
+# Retrieval / vector store
+langchain-chroma>=0.1.4,<0.3
+chromadb>=0.5.0,<1
+langchain-text-splitters>=0.3.0,<0.4
+
+# Utilities
+python-dotenv>=1.0,<2
+typing-extensions>=4.10,<5


### PR DESCRIPTION
Closes #3

## Summary
- Centralizes runtime config in `agent/config.py` — chat model, embedding model, temperature, seed, retry caps, all overridable via `AGENT_*` env vars.
- Loads `.env` automatically when `python-dotenv` is installed; no-ops gracefully when it isn't.
- Lazy validation: importing `agent.config` is side-effect-free, so LLM-free paths (the issue-1 stub, data-loader unit tests) work without a key. First call to `get_settings()` raises `RuntimeError` naming the exact missing env var.
- Adds `.env.example` template and `.gitignore` so `.env` is safe to drop in the repo root.

## What landed
- `agent/config.py`
- `README.md` (Environment variables section)
- `.env.example`, `.gitignore`

## Validation
5 manual scenarios pass:
1. Module imports clean without `OPENAI_API_KEY` (no exception).
2. Missing key → clear `RuntimeError` naming `OPENAI_API_KEY`.
3. Happy path: `get_settings()` returns `Settings(chat_model='gpt-4o-mini', T=0.0, seed=7)`.
4. `AGENT_CHAT_MODEL` / `AGENT_CHAT_TEMPERATURE` overrides applied.
5. `validate=False` bypass works for non-LLM code paths.

Plus regression: issue-1 stub still produces 200 schema-valid rows on top of this change.

## Test plan
- [ ] `python -c 'import agent.config'` succeeds without API key set.
- [ ] `python -c 'from agent.config import get_settings; get_settings()'` raises naming `OPENAI_API_KEY` when unset.
- [ ] After setting the key, `get_settings()` returns the expected `Settings`.

## Notes for reviewer
- **Trivial merge conflict expected** on `.gitignore` and `.env.example` — they were also added on `main` directly (with identical contents). Resolve with `--theirs` / `--ours` either way, or run `git merge -X ours main` before the merge.
- The "import time" wording in the AC is interpreted as "fail-fast on first agent use" rather than literal `import agent.config`. The strict reading would have broken the issue-1 stub. `Settings.validate_or_raise()` is exposed for explicit fail-fast at startup if a caller wants it.

## Backlog reference
Implements issue #3 in [`docs/PROJECT_BACKLOG.md`](docs/PROJECT_BACKLOG.md).
