### PR TITLE
issue-5: building registry with floor-count sanity check

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,30 @@
+# Python
+__pycache__/
+*.py[cod]
+*$py.class
+*.egg-info/
+.pytest_cache/
+.mypy_cache/
+.ruff_cache/
+
+# Virtualenvs
+.venv/
+venv/
+env/
+
+# Environment / secrets
+.env
+.env.local
+
+# Editor / OS
+.vscode/
+.idea/
+.DS_Store
+*.swp
+
+# Local eval outputs (committed runs go under eval_runs/)
+predictions.json
+/tmp_*.json
+
+# Vector store build artifacts (issue #7 will configure)
+agent/rag/chroma_store/

--- a/README.md
+++ b/README.md
@@ -29,39 +29,35 @@ final_project/
 ## Quick start
 
 ```bash
-# 1. Set up a Python env (Python ≥ 3.9)
+# 1. Set up a Python env (Python ≥ 3.9) and install runtime deps
 python3 -m venv .venv && source .venv/bin/activate
-# Install whatever your agent needs (LangGraph, OpenAI, etc.).
+pip install -r requirements.txt
 
-# 2. Build your agent. It must expose a single callable:
-#       def classify(turns: list[dict], caller_phone: str | None) -> dict
-#    Returning the fields documented in evaluation/prediction.py.
-#
-#    Note: each eval row also carries caller_known_in_profiles: bool — true when
-#    caller_phone matches an entry in operational/caller_profiles.json. The
-#    harness only forwards `turns` and `caller_phone` to your callable; if you
-#    want to use the flag, look it up yourself from caller_profiles.json.
-
-# 3. Run on the dev set (with labels — for self-evaluation)
+# 2. Run the agent on the dev set (with labels — for self-evaluation)
 python evaluation/run_eval.py \
-    --agent your_module.your_agent:classify \
+    --agent agent.classify:classify \
     --eval evaluation/eval_transcripts_dev.json \
     --out predictions.json
 
-# 4. Score yourself
+# 3. Score yourself
 python evaluation/scoring.py \
     --eval evaluation/eval_transcripts_dev.json \
     --ground-truth evaluation/dev_labels.json \
     --predictions predictions.json
 
-# 5. When you're ready to submit, generate predictions on the test set:
+# 4. Final test-set run (used for grading)
 python evaluation/run_eval.py \
-    --agent your_module.your_agent:classify \
+    --agent agent.classify:classify \
     --eval evaluation/eval_transcripts_test.json \
     --out predictions.json
-# Submit predictions.json + your repo. We grade with the same scoring.py
-# against held-out labels.
 ```
+
+The agent exposes a single callable, `agent.classify:classify(turns, caller_phone) -> dict`,
+returning the fields documented in [`evaluation/prediction.py`](evaluation/prediction.py).
+Each eval row also carries `caller_known_in_profiles: bool` — true when
+`caller_phone` matches [`operational/caller_profiles.json`](operational/caller_profiles.json).
+The harness forwards only `turns` and `caller_phone`; the agent looks the
+profile up itself.
 
 ## What you submit
 

--- a/agent/__init__.py
+++ b/agent/__init__.py
@@ -1,0 +1,12 @@
+"""CBRE HITL call-intake agent.
+
+Single public entrypoint:
+
+    from agent.classify import classify
+    classify(turns: list[dict], caller_phone: str | None) -> dict
+
+The returned dict matches `evaluation/prediction.py::Prediction`. Downstream
+issues replace the stub in `agent/classify.py` with the real LangGraph
+pipeline (extract → retrieve → classify → validator → log).
+"""
+__version__ = "0.1.0"

--- a/agent/classify.py
+++ b/agent/classify.py
@@ -1,0 +1,55 @@
+"""Single public entrypoint for the agent.
+
+This is the stub scaffolding for issue #1: it returns a schema-valid
+`Prediction` dict so the eval harness runs end-to-end. Real classification,
+retrieval, risk scoring, HITL gating, and vendor selection land in later
+issues. The goal here is wire compatibility, not score.
+
+Contract reference: `evaluation/prediction.py::Prediction` + `TrainerLog`.
+"""
+from __future__ import annotations
+
+from typing import Any, Optional
+
+
+def _flatten(turns: list[dict]) -> str:
+    return "\n".join(
+        f"[{t.get('speaker', '?').upper()}] {t.get('text', '')}".rstrip()
+        for t in turns
+    )
+
+
+def classify(turns: list[dict], caller_phone: Optional[str]) -> dict[str, Any]:
+    """Return a schema-valid Prediction dict.
+
+    Stub behavior: emit safe, conservative defaults that pass the schema check
+    in `evaluation/run_eval.py` and avoid the −5 false-911 penalty. Downstream
+    issues replace this with the real LangGraph pipeline.
+    """
+    base = {
+        "category": "OTHER",
+        "subcategory": "other",
+        "risk_level": "MEDIUM",
+        "needs_human_review": True,
+        "needs_clarification": False,
+        "building_name": None,
+        "address": None,
+        "floor": None,
+        "dispatched_vendor_id": None,
+        "dispatched_emergency_services": False,
+        "call_summary": (
+            "Stub prediction from agent scaffold (issue #1). "
+            "Call routed to human reviewer pending full pipeline implementation."
+        ),
+    }
+
+    full_transcript = _flatten(turns)
+    return {
+        **base,
+        "trainer_log": {
+            "full_transcript": full_transcript,
+            "ai_prediction": dict(base),
+            "human_override": None,
+            "final_decision": dict(base),
+        },
+    }

--- a/agent/data/buildings.py
+++ b/agent/data/buildings.py
@@ -1,0 +1,185 @@
+"""Building registry over `operational/buildings.json`.
+
+Behaviour summary:
+- `get_by_id` is exact-match on `building_id`.
+- `get_by_name` does a normalized lookup (case + whitespace insensitive)
+  followed by a substring match — so a transcript "Pacific Ridge"
+  resolves to the canonical "Pacific Ridge Medical Plaza".
+- `validate_floor` is a three-state checker (`ok` / `out_of_range` /
+  `unknown`). It returns `unknown` whenever the building lacks
+  `floor_count` rather than rejecting — the buildings.json file is
+  intentionally sparse for warehouses / older properties (~8% of records).
+- `resolve_address_city` returns the canonical `(address, city)` tuple
+  preferring the building registry over a caller profile, per the brief's
+  "transcript wins on conflict; registry is canonical" rule.
+"""
+from __future__ import annotations
+
+import json
+import re
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Dict, List, Literal, Optional, Tuple
+
+_BUILDING_PATH = Path(__file__).resolve().parents[2] / "operational" / "buildings.json"
+
+FloorCheck = Literal["ok", "out_of_range", "unknown"]
+
+# Recognised floor strings beyond plain "Floor N" — pulled from the floor
+# value distributions in profiles + historicals (Ground Floor and Mezzanine
+# show up frequently; Basement / Rooftop appear in the historicals).
+_FLOOR_NUM_RX = re.compile(r"^\s*floor\s+(\d+)\s*$", re.IGNORECASE)
+_BASEMENT_RX = re.compile(r"^\s*(basement|b\s*\d+)\s*$", re.IGNORECASE)
+_ROOFTOP_RX = re.compile(r"^\s*(roof(top)?)\s*$", re.IGNORECASE)
+_GROUND_RX = re.compile(r"^\s*ground(\s+floor)?\s*$", re.IGNORECASE)
+
+
+@dataclass(frozen=True)
+class Building:
+    building_id: str
+    name: str
+    address: Optional[str]
+    city: Optional[str]
+    building_type: Optional[str]
+    floor_count: Optional[int]
+    has_basement: Optional[bool]
+    has_rooftop: Optional[bool]
+    special_floors: Tuple[str, ...] = field(default_factory=tuple)
+    suites_per_floor: Optional[int] = None
+
+
+_INDEX_BY_ID: Optional[Dict[str, Building]] = None
+_INDEX_BY_NAME: Optional[Dict[str, Building]] = None  # normalized name → Building
+
+
+def _normalize(s: str) -> str:
+    return re.sub(r"\s+", " ", s.strip().lower())
+
+
+def _build_indexes() -> Tuple[Dict[str, Building], Dict[str, Building]]:
+    raw = json.loads(_BUILDING_PATH.read_text())
+    by_id: Dict[str, Building] = {}
+    by_name: Dict[str, Building] = {}
+    for r in raw:
+        bid = r.get("building_id")
+        if not bid:
+            continue
+        b = Building(
+            building_id=bid,
+            name=r.get("name", ""),
+            address=r.get("address"),
+            city=r.get("city"),
+            building_type=r.get("building_type"),
+            floor_count=r.get("floor_count"),
+            has_basement=r.get("has_basement"),
+            has_rooftop=r.get("has_rooftop"),
+            special_floors=tuple(r.get("special_floors") or ()),
+            suites_per_floor=r.get("suites_per_floor"),
+        )
+        by_id[bid] = b
+        if b.name:
+            by_name[_normalize(b.name)] = b
+    return by_id, by_name
+
+
+def _indexes() -> Tuple[Dict[str, Building], Dict[str, Building]]:
+    global _INDEX_BY_ID, _INDEX_BY_NAME
+    if _INDEX_BY_ID is None or _INDEX_BY_NAME is None:
+        _INDEX_BY_ID, _INDEX_BY_NAME = _build_indexes()
+    return _INDEX_BY_ID, _INDEX_BY_NAME
+
+
+def get_by_id(building_id: Optional[str]) -> Optional[Building]:
+    if not building_id:
+        return None
+    by_id, _ = _indexes()
+    return by_id.get(building_id)
+
+
+def get_by_name(name: Optional[str]) -> Optional[Building]:
+    """Resolve a free-text building name to the canonical record.
+
+    Match strategy: normalized exact → unique substring (caller said the
+    short-form "Pacific Ridge", catalog has "Pacific Ridge Medical Plaza").
+    Returns None when the candidate is ambiguous (multiple substring hits)
+    rather than guessing.
+    """
+    if not name:
+        return None
+    _, by_name = _indexes()
+    key = _normalize(name)
+    if key in by_name:
+        return by_name[key]
+    candidates: List[Building] = [
+        b for n, b in by_name.items() if key in n or n in key
+    ]
+    if len(candidates) == 1:
+        return candidates[0]
+    return None
+
+
+def validate_floor(building: Optional[Building], floor_str: Optional[str]) -> FloorCheck:
+    """Check whether `floor_str` is plausible for this building.
+
+    Returns:
+        - 'unknown' when the building is missing or has no `floor_count`
+          (we can't evaluate; downstream should treat this as soft-pass)
+        - 'ok' when the floor parses and falls in range / matches a
+          documented special floor / matches has_basement / has_rooftop
+        - 'out_of_range' when the floor parses to a number outside
+          [1, floor_count] OR references basement/rooftop/special on a
+          building documented to lack them
+    """
+    if building is None or building.floor_count is None:
+        return "unknown"
+    if not floor_str:
+        return "unknown"
+
+    s = floor_str.strip()
+
+    # Plain "Floor N"
+    m = _FLOOR_NUM_RX.match(s)
+    if m:
+        n = int(m.group(1))
+        return "ok" if 1 <= n <= building.floor_count else "out_of_range"
+
+    # "Ground Floor" — treat as floor 1 (always valid for a building that
+    # exists at all).
+    if _GROUND_RX.match(s):
+        return "ok"
+
+    # Basement variants — valid only if the building documents one.
+    if _BASEMENT_RX.match(s):
+        return "ok" if building.has_basement else "out_of_range"
+
+    # Rooftop variants
+    if _ROOFTOP_RX.match(s):
+        return "ok" if building.has_rooftop else "out_of_range"
+
+    # Special floors (Mezzanine, Loading Dock N, etc.) — case-insensitive
+    # match against the documented list.
+    if any(_normalize(s) == _normalize(sp) for sp in building.special_floors):
+        return "ok"
+
+    # Unparseable floor string + we have floor_count → can't confirm → unknown
+    # (caller said something we don't understand, not necessarily wrong).
+    return "unknown"
+
+
+def resolve_address_city(
+    building: Optional[Building] = None,
+    profile_address: Optional[str] = None,
+    profile_city: Optional[str] = None,
+) -> Tuple[Optional[str], Optional[str]]:
+    """Return (address, city) preferring the registry over the profile.
+
+    The brief: the building registry is the canonical source for address /
+    city; the caller profile is a last-known default. When both exist and
+    disagree, the registry wins.
+    """
+    if building is not None:
+        return (
+            building.address or profile_address,
+            building.city or profile_city,
+        )
+    return (profile_address, profile_city)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,22 @@
+# Runtime dependencies for the CBRE HITL call-intake agent.
+# Pinned for reproducibility; regenerated from a clean venv at submission
+# time per issue #31. Stub in issue #1 uses stdlib only — these pins are for
+# downstream issues that wire in LangGraph + the LLM/embedding stack.
+
+# Orchestration
+langgraph>=0.2.50,<0.4
+langgraph-checkpoint>=2.0.0,<3
+
+# LLM + structured output
+langchain-core>=0.3.0,<0.4
+langchain-openai>=0.2.0,<0.3
+pydantic>=2.7,<3
+
+# Retrieval / vector store
+langchain-chroma>=0.1.4,<0.3
+chromadb>=0.5.0,<1
+langchain-text-splitters>=0.3.0,<0.4
+
+# Utilities
+python-dotenv>=1.0,<2
+typing-extensions>=4.10,<5

--- a/tests/test_buildings.py
+++ b/tests/test_buildings.py
@@ -1,0 +1,173 @@
+"""Unit tests for `agent.data.buildings`.
+
+Anchored on real data: bld_001 (Westfield Commerce Center, 18 floors, has
+basement + rooftop) and bld_007 (Central Tower, missing floor_count) plus
+bld_018 (Gateway Industrial Complex, has Mezzanine + loading docks).
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from agent.data import buildings  # noqa: E402
+
+
+# --- get_by_id / get_by_name -------------------------------------------------
+
+
+def test_get_by_id_known():
+    b = buildings.get_by_id("bld_001")
+    assert b is not None
+    assert b.name == "Westfield Commerce Center"
+    assert b.address == "100 Wilshire Blvd"
+    assert b.city == "Los Angeles"
+    assert b.floor_count == 18
+    assert b.has_basement is True
+
+
+def test_get_by_id_unknown_returns_none():
+    assert buildings.get_by_id("bld_does_not_exist") is None
+    assert buildings.get_by_id(None) is None
+    assert buildings.get_by_id("") is None
+
+
+def test_get_by_name_exact():
+    b = buildings.get_by_name("Westfield Commerce Center")
+    assert b is not None and b.building_id == "bld_001"
+
+
+def test_get_by_name_case_insensitive():
+    b = buildings.get_by_name("WESTFIELD commerce center")
+    assert b is not None and b.building_id == "bld_001"
+
+
+def test_get_by_name_substring_match():
+    # Caller says the short form; catalog has the canonical longer name.
+    b = buildings.get_by_name("Westfield")
+    assert b is not None and b.building_id == "bld_001"
+
+
+def test_get_by_name_unknown_returns_none():
+    assert buildings.get_by_name("Nonexistent Plaza") is None
+    assert buildings.get_by_name(None) is None
+    assert buildings.get_by_name("") is None
+
+
+# --- validate_floor: the three required outcomes ----------------------------
+
+
+def test_validate_floor_ok_in_range():
+    b = buildings.get_by_id("bld_001")  # 18 floors
+    assert buildings.validate_floor(b, "Floor 5") == "ok"
+    assert buildings.validate_floor(b, "Floor 1") == "ok"
+    assert buildings.validate_floor(b, "Floor 18") == "ok"
+
+
+def test_validate_floor_out_of_range():
+    b = buildings.get_by_id("bld_001")  # 18 floors
+    assert buildings.validate_floor(b, "Floor 19") == "out_of_range"
+    assert buildings.validate_floor(b, "Floor 100") == "out_of_range"
+    assert buildings.validate_floor(b, "Floor 0") == "out_of_range"
+
+
+def test_validate_floor_unknown_when_floor_count_missing():
+    b = buildings.get_by_id("bld_007")  # Central Tower — no floor_count
+    assert b is not None and b.floor_count is None
+    assert buildings.validate_floor(b, "Floor 5") == "unknown"
+    assert buildings.validate_floor(b, "Floor 9999") == "unknown"
+
+
+def test_validate_floor_unknown_when_building_missing():
+    assert buildings.validate_floor(None, "Floor 5") == "unknown"
+
+
+def test_validate_floor_unknown_when_floor_str_missing():
+    b = buildings.get_by_id("bld_001")
+    assert buildings.validate_floor(b, None) == "unknown"
+    assert buildings.validate_floor(b, "") == "unknown"
+
+
+# --- validate_floor: special floors / basement / rooftop --------------------
+
+
+def test_validate_floor_ground_floor_is_ok():
+    b = buildings.get_by_id("bld_001")
+    assert buildings.validate_floor(b, "Ground Floor") == "ok"
+
+
+def test_validate_floor_basement_ok_when_building_has_one():
+    b = buildings.get_by_id("bld_001")  # has_basement=True
+    assert buildings.validate_floor(b, "Basement") == "ok"
+    assert buildings.validate_floor(b, "B1") == "ok"
+
+
+def test_validate_floor_rooftop_ok_when_building_has_one():
+    b = buildings.get_by_id("bld_001")  # has_rooftop=True
+    assert buildings.validate_floor(b, "Rooftop") == "ok"
+    assert buildings.validate_floor(b, "Roof") == "ok"
+
+
+def test_validate_floor_mezzanine_ok_for_special_floor_building():
+    b = buildings.get_by_id("bld_018")  # special_floors includes Mezzanine
+    assert b is not None and "Mezzanine" in b.special_floors
+    assert buildings.validate_floor(b, "Mezzanine") == "ok"
+    assert buildings.validate_floor(b, "Loading Dock 1") == "ok"
+
+
+def test_validate_floor_unparseable_returns_unknown():
+    # Caller said something we can't interpret. With floor_count present,
+    # we still can't *confirm* it's wrong → unknown (soft-pass).
+    b = buildings.get_by_id("bld_001")
+    assert buildings.validate_floor(b, "the upstairs bit") == "unknown"
+
+
+# --- resolve_address_city ---------------------------------------------------
+
+
+def test_resolve_prefers_registry_over_profile():
+    b = buildings.get_by_id("bld_001")
+    addr, city = buildings.resolve_address_city(
+        building=b,
+        profile_address="OUTDATED ADDRESS",
+        profile_city="OUTDATED CITY",
+    )
+    assert addr == "100 Wilshire Blvd"
+    assert city == "Los Angeles"
+
+
+def test_resolve_falls_back_to_profile_when_no_building():
+    addr, city = buildings.resolve_address_city(
+        building=None,
+        profile_address="500 Mission St",
+        profile_city="San Francisco",
+    )
+    assert addr == "500 Mission St"
+    assert city == "San Francisco"
+
+
+def test_resolve_returns_none_pair_when_nothing_known():
+    addr, city = buildings.resolve_address_city()
+    assert addr is None
+    assert city is None
+
+
+if __name__ == "__main__":
+    import inspect
+
+    tests = [(n, f) for n, f in inspect.getmembers(sys.modules[__name__])
+             if n.startswith("test_") and callable(f)]
+    failed = 0
+    for name, fn in tests:
+        try:
+            fn()
+            print(f"  PASS  {name}")
+        except AssertionError as e:
+            print(f"  FAIL  {name}: {e}")
+            failed += 1
+        except Exception as e:
+            print(f"  ERROR {name}: {type(e).__name__}: {e}")
+            failed += 1
+    print(f"\n{len(tests) - failed}/{len(tests)} passed")
+    sys.exit(1 if failed else 0)


### PR DESCRIPTION
Closes #5

## Summary
- Wraps `operational/buildings.json` (52 properties, ~8% missing `floor_count` for warehouse / older sites) with a typed query API:
  - `get_by_id(id)` — exact match.
  - `get_by_name(name)` — normalized exact, then unique-substring fallback. Returns `None` on ambiguous matches rather than guessing.
  - `validate_floor(building, floor_str)` — three-state checker `'ok' | 'out_of_range' | 'unknown'`.
  - `resolve_address_city(building, profile_address, profile_city)` — registry wins over profile.

## What landed
- `agent/data/buildings.py`
- `tests/test_buildings.py`
- `.gitignore`

## Validation
**19/19 unit tests pass.** Coverage explicitly hits all three `validate_floor` outcomes plus:
- All three `get_by_name` match modes (exact, case-insensitive, substring).
- Ground Floor, Basement/B1 (gated on `has_basement`), Rooftop/Roof (gated on `has_rooftop`), Mezzanine + Loading Docks (matched against `special_floors`).
- `resolve_address_city` precedence (registry-wins, profile-fallback, both-None).

## Test plan
- [ ] `python tests/test_buildings.py` reports 19/19 passing.
- [ ] `python -c 'from agent.data.buildings import get_by_id, validate_floor; b=get_by_id("bld_001"); print(validate_floor(b, "Floor 19"))'` prints `out_of_range`.

## Notes for reviewer
- **Trivial merge conflict** on `.gitignore` (identical content as `main`).
- **Soft-pass on unparseable floors:** when `floor_count` is present but the caller's floor string can't be parsed, returns `'unknown'` rather than `'out_of_range'`. Better to defer to the clarification node (#18) than to reject something the caller might be right about.
- **Ambiguous name matches return `None`:** if a caller says "Tower" and three buildings substring-match, returns `None` rather than guess. Forces the upstream to clarify or escalate.

## Backlog reference
Implements issue #5 in [`docs/PROJECT_BACKLOG.md`](docs/PROJECT_BACKLOG.md).
Consumed by issue #19 (location reconciliation).
