### PR TITLE
issue-6: vendor catalog loader and qualification query API

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,30 @@
+# Python
+__pycache__/
+*.py[cod]
+*$py.class
+*.egg-info/
+.pytest_cache/
+.mypy_cache/
+.ruff_cache/
+
+# Virtualenvs
+.venv/
+venv/
+env/
+
+# Environment / secrets
+.env
+.env.local
+
+# Editor / OS
+.vscode/
+.idea/
+.DS_Store
+*.swp
+
+# Local eval outputs (committed runs go under eval_runs/)
+predictions.json
+/tmp_*.json
+
+# Vector store build artifacts (issue #7 will configure)
+agent/rag/chroma_store/

--- a/README.md
+++ b/README.md
@@ -29,39 +29,35 @@ final_project/
 ## Quick start
 
 ```bash
-# 1. Set up a Python env (Python ≥ 3.9)
+# 1. Set up a Python env (Python ≥ 3.9) and install runtime deps
 python3 -m venv .venv && source .venv/bin/activate
-# Install whatever your agent needs (LangGraph, OpenAI, etc.).
+pip install -r requirements.txt
 
-# 2. Build your agent. It must expose a single callable:
-#       def classify(turns: list[dict], caller_phone: str | None) -> dict
-#    Returning the fields documented in evaluation/prediction.py.
-#
-#    Note: each eval row also carries caller_known_in_profiles: bool — true when
-#    caller_phone matches an entry in operational/caller_profiles.json. The
-#    harness only forwards `turns` and `caller_phone` to your callable; if you
-#    want to use the flag, look it up yourself from caller_profiles.json.
-
-# 3. Run on the dev set (with labels — for self-evaluation)
+# 2. Run the agent on the dev set (with labels — for self-evaluation)
 python evaluation/run_eval.py \
-    --agent your_module.your_agent:classify \
+    --agent agent.classify:classify \
     --eval evaluation/eval_transcripts_dev.json \
     --out predictions.json
 
-# 4. Score yourself
+# 3. Score yourself
 python evaluation/scoring.py \
     --eval evaluation/eval_transcripts_dev.json \
     --ground-truth evaluation/dev_labels.json \
     --predictions predictions.json
 
-# 5. When you're ready to submit, generate predictions on the test set:
+# 4. Final test-set run (used for grading)
 python evaluation/run_eval.py \
-    --agent your_module.your_agent:classify \
+    --agent agent.classify:classify \
     --eval evaluation/eval_transcripts_test.json \
     --out predictions.json
-# Submit predictions.json + your repo. We grade with the same scoring.py
-# against held-out labels.
 ```
+
+The agent exposes a single callable, `agent.classify:classify(turns, caller_phone) -> dict`,
+returning the fields documented in [`evaluation/prediction.py`](evaluation/prediction.py).
+Each eval row also carries `caller_known_in_profiles: bool` — true when
+`caller_phone` matches [`operational/caller_profiles.json`](operational/caller_profiles.json).
+The harness forwards only `turns` and `caller_phone`; the agent looks the
+profile up itself.
 
 ## What you submit
 

--- a/agent/__init__.py
+++ b/agent/__init__.py
@@ -1,0 +1,12 @@
+"""CBRE HITL call-intake agent.
+
+Single public entrypoint:
+
+    from agent.classify import classify
+    classify(turns: list[dict], caller_phone: str | None) -> dict
+
+The returned dict matches `evaluation/prediction.py::Prediction`. Downstream
+issues replace the stub in `agent/classify.py` with the real LangGraph
+pipeline (extract → retrieve → classify → validator → log).
+"""
+__version__ = "0.1.0"

--- a/agent/classify.py
+++ b/agent/classify.py
@@ -1,0 +1,55 @@
+"""Single public entrypoint for the agent.
+
+This is the stub scaffolding for issue #1: it returns a schema-valid
+`Prediction` dict so the eval harness runs end-to-end. Real classification,
+retrieval, risk scoring, HITL gating, and vendor selection land in later
+issues. The goal here is wire compatibility, not score.
+
+Contract reference: `evaluation/prediction.py::Prediction` + `TrainerLog`.
+"""
+from __future__ import annotations
+
+from typing import Any, Optional
+
+
+def _flatten(turns: list[dict]) -> str:
+    return "\n".join(
+        f"[{t.get('speaker', '?').upper()}] {t.get('text', '')}".rstrip()
+        for t in turns
+    )
+
+
+def classify(turns: list[dict], caller_phone: Optional[str]) -> dict[str, Any]:
+    """Return a schema-valid Prediction dict.
+
+    Stub behavior: emit safe, conservative defaults that pass the schema check
+    in `evaluation/run_eval.py` and avoid the −5 false-911 penalty. Downstream
+    issues replace this with the real LangGraph pipeline.
+    """
+    base = {
+        "category": "OTHER",
+        "subcategory": "other",
+        "risk_level": "MEDIUM",
+        "needs_human_review": True,
+        "needs_clarification": False,
+        "building_name": None,
+        "address": None,
+        "floor": None,
+        "dispatched_vendor_id": None,
+        "dispatched_emergency_services": False,
+        "call_summary": (
+            "Stub prediction from agent scaffold (issue #1). "
+            "Call routed to human reviewer pending full pipeline implementation."
+        ),
+    }
+
+    full_transcript = _flatten(turns)
+    return {
+        **base,
+        "trainer_log": {
+            "full_transcript": full_transcript,
+            "ai_prediction": dict(base),
+            "human_override": None,
+            "final_decision": dict(base),
+        },
+    }

--- a/agent/data/vendors.py
+++ b/agent/data/vendors.py
@@ -1,0 +1,183 @@
+"""Vendor catalog over `operational/vendors.json` plus a qualification API.
+
+`qualify(subcategory, city, building_type, is_emergency, after_hours)`
+returns the candidate set — vendors that *could* take this job — *before*
+any ranking or availability-cache filtering. Issue #21 picks one vendor out
+of this set; this module just narrows the field.
+
+Filter rules:
+
+- **specialty / vendor_type** — strict match first: a vendor qualifies if
+  its `specialties` list contains the subcategory string. Loose fallback:
+  the vendor's `vendor_type` appears in the subcategory→vendor-type map
+  loaded from `agent/data/derived/subcategory_to_vendor_type.json` once
+  issue #20 ships. Until then, the loose mapping is empty and only the
+  strict specialty match applies — that's already strong because the
+  dataset's `specialties` field contains subcategory-level strings (e.g.
+  `"pipe_leak"`).
+
+- **city** — exact match against `coverage_cities`. Soft-pass when the
+  vendor's coverage list is empty/missing — we don't know, so we don't
+  exclude.
+
+- **building_type** — exact match against `building_types_certified`.
+  Soft-pass when the cert list is empty/missing.
+
+- **available_24_7** — only enforced when `is_emergency AND after_hours`.
+  During business hours or on routine calls, every vendor is in scope
+  regardless of the 24/7 flag.
+
+This module deliberately ignores `status_at_last_check` /
+`last_status_confirmed_at` — those drive the tie-breaker and stale-
+availability handling in issue #21, not eligibility.
+"""
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Dict, List, Mapping, Optional, Tuple
+
+_VENDOR_PATH = Path(__file__).resolve().parents[2] / "operational" / "vendors.json"
+_DERIVED_PATH = (
+    Path(__file__).resolve().parents[1] / "data" / "derived" / "subcategory_to_vendor_type.json"
+)
+
+
+@dataclass(frozen=True)
+class Vendor:
+    vendor_id: str
+    name: str
+    vendor_type: str
+    specialties: Tuple[str, ...] = field(default_factory=tuple)
+    coverage_cities: Tuple[str, ...] = field(default_factory=tuple)
+    building_types_certified: Tuple[str, ...] = field(default_factory=tuple)
+    certifications: Tuple[str, ...] = field(default_factory=tuple)
+    response_sla_minutes: Optional[int] = None
+    emergency_response_sla_minutes: Optional[int] = None
+    available_24_7: bool = False
+    cost_tier: Optional[str] = None
+    rating: Optional[float] = None
+    phone: Optional[str] = None
+    status_at_last_check: Optional[str] = None  # 'available' | 'at_capacity' | 'offline' | None
+    last_status_confirmed_at: Optional[str] = None
+
+
+_ALL_CACHE: Optional[List[Vendor]] = None
+_BY_ID_CACHE: Optional[Dict[str, Vendor]] = None
+_SUBCAT_MAPPING_CACHE: Optional[Mapping[str, Tuple[str, ...]]] = None
+
+
+def _load_all() -> List[Vendor]:
+    raw = json.loads(_VENDOR_PATH.read_text())
+    out: List[Vendor] = []
+    for r in raw:
+        out.append(
+            Vendor(
+                vendor_id=r["vendor_id"],
+                name=r.get("name", ""),
+                vendor_type=r.get("vendor_type", ""),
+                specialties=tuple(r.get("specialties") or ()),
+                coverage_cities=tuple(r.get("coverage_cities") or ()),
+                building_types_certified=tuple(r.get("building_types_certified") or ()),
+                certifications=tuple(r.get("certifications") or ()),
+                response_sla_minutes=r.get("response_sla_minutes"),
+                emergency_response_sla_minutes=r.get("emergency_response_sla_minutes"),
+                available_24_7=bool(r.get("available_24_7")),
+                cost_tier=r.get("cost_tier"),
+                rating=r.get("rating"),
+                phone=r.get("phone"),
+                status_at_last_check=r.get("status_at_last_check"),
+                last_status_confirmed_at=r.get("last_status_confirmed_at"),
+            )
+        )
+    return out
+
+
+def _all_vendors() -> List[Vendor]:
+    global _ALL_CACHE
+    if _ALL_CACHE is None:
+        _ALL_CACHE = _load_all()
+    return _ALL_CACHE
+
+
+def _by_id() -> Dict[str, Vendor]:
+    global _BY_ID_CACHE
+    if _BY_ID_CACHE is None:
+        _BY_ID_CACHE = {v.vendor_id: v for v in _all_vendors()}
+    return _BY_ID_CACHE
+
+
+def _subcat_to_vendor_types() -> Mapping[str, Tuple[str, ...]]:
+    """Loose subcategory→vendor_type mapping, populated by issue #20.
+
+    Returns an empty mapping until that derived artifact lands; the strict
+    `specialties` filter still does the heavy lifting in the meantime.
+    """
+    global _SUBCAT_MAPPING_CACHE
+    if _SUBCAT_MAPPING_CACHE is not None:
+        return _SUBCAT_MAPPING_CACHE
+    if _DERIVED_PATH.exists():
+        raw = json.loads(_DERIVED_PATH.read_text())
+        _SUBCAT_MAPPING_CACHE = {k: tuple(v) for k, v in raw.items()}
+    else:
+        _SUBCAT_MAPPING_CACHE = {}
+    return _SUBCAT_MAPPING_CACHE
+
+
+def get_by_id(vendor_id: Optional[str]) -> Optional[Vendor]:
+    if not vendor_id:
+        return None
+    return _by_id().get(vendor_id)
+
+
+def all_vendors() -> List[Vendor]:
+    return list(_all_vendors())
+
+
+def _matches_subcategory(v: Vendor, subcategory: str) -> bool:
+    if subcategory in v.specialties:
+        return True
+    types_for_subcat = _subcat_to_vendor_types().get(subcategory)
+    if types_for_subcat and v.vendor_type in types_for_subcat:
+        return True
+    return False
+
+
+def qualify(
+    subcategory: Optional[str] = None,
+    city: Optional[str] = None,
+    building_type: Optional[str] = None,
+    is_emergency: bool = False,
+    after_hours: bool = False,
+) -> List[Vendor]:
+    """Return vendors that satisfy every applicable hard constraint.
+
+    Empty list = nobody qualifies → caller (issue #21) should escalate
+    rather than dispatch.
+    """
+    out: List[Vendor] = []
+    enforce_247 = is_emergency and after_hours
+    for v in _all_vendors():
+        if subcategory and not _matches_subcategory(v, subcategory):
+            continue
+        if city and v.coverage_cities and city not in v.coverage_cities:
+            continue
+        if (
+            building_type
+            and v.building_types_certified
+            and building_type not in v.building_types_certified
+        ):
+            continue
+        if enforce_247 and not v.available_24_7:
+            continue
+        out.append(v)
+    return out
+
+
+def _reset_caches_for_tests() -> None:
+    """Drop the in-process caches so tests can swap data files mid-run."""
+    global _ALL_CACHE, _BY_ID_CACHE, _SUBCAT_MAPPING_CACHE
+    _ALL_CACHE = None
+    _BY_ID_CACHE = None
+    _SUBCAT_MAPPING_CACHE = None

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,22 @@
+# Runtime dependencies for the CBRE HITL call-intake agent.
+# Pinned for reproducibility; regenerated from a clean venv at submission
+# time per issue #31. Stub in issue #1 uses stdlib only — these pins are for
+# downstream issues that wire in LangGraph + the LLM/embedding stack.
+
+# Orchestration
+langgraph>=0.2.50,<0.4
+langgraph-checkpoint>=2.0.0,<3
+
+# LLM + structured output
+langchain-core>=0.3.0,<0.4
+langchain-openai>=0.2.0,<0.3
+pydantic>=2.7,<3
+
+# Retrieval / vector store
+langchain-chroma>=0.1.4,<0.3
+chromadb>=0.5.0,<1
+langchain-text-splitters>=0.3.0,<0.4
+
+# Utilities
+python-dotenv>=1.0,<2
+typing-extensions>=4.10,<5

--- a/tests/test_vendors.py
+++ b/tests/test_vendors.py
@@ -1,0 +1,237 @@
+"""Unit tests for `agent.data.vendors`.
+
+Anchored on real data:
+- v_001 Pacific Plumbing Services: plumber, specialties=[pipe_leak,
+  restroom_fixture, drainage_backup], 24/7, covers LA + 6 cities.
+- v_002 Metro Drain & Pipe: plumber, same specialties, NOT 24/7.
+- 32 vendors total, every record has populated coverage_cities and
+  building_types_certified — soft-pass paths get hit via synthetic
+  Vendor objects.
+"""
+from __future__ import annotations
+
+import sys
+from dataclasses import replace
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from agent.data import vendors  # noqa: E402
+from agent.data.vendors import Vendor  # noqa: E402
+
+
+# ─── basic loading ─────────────────────────────────────────────────────────
+
+
+def test_all_vendors_loads_full_catalog():
+    assert len(vendors.all_vendors()) == 32
+
+
+def test_get_by_id_known():
+    v = vendors.get_by_id("v_001")
+    assert v is not None
+    assert v.name == "Pacific Plumbing Services"
+    assert v.vendor_type == "plumber"
+    assert "pipe_leak" in v.specialties
+    assert v.available_24_7 is True
+
+
+def test_get_by_id_unknown_returns_none():
+    assert vendors.get_by_id("v_does_not_exist") is None
+    assert vendors.get_by_id(None) is None
+
+
+# ─── qualify: specialty filter ─────────────────────────────────────────────
+
+
+def test_qualify_specialty_strict_match_includes_plumbers_for_pipe_leak():
+    out = vendors.qualify(subcategory="pipe_leak")
+    ids = {v.vendor_id for v in out}
+    assert "v_001" in ids and "v_002" in ids
+    assert all("pipe_leak" in v.specialties for v in out)
+
+
+def test_qualify_unknown_subcategory_returns_empty():
+    # No vendor has "definitely_not_a_real_thing" in specialties, and the
+    # subcategory→vendor-type mapping is empty until issue #20 ships.
+    out = vendors.qualify(subcategory="definitely_not_a_real_thing")
+    assert out == []
+
+
+def test_qualify_no_subcategory_returns_all():
+    out = vendors.qualify()
+    assert len(out) == 32
+
+
+# ─── qualify: city filter ──────────────────────────────────────────────────
+
+
+def test_qualify_city_in_coverage_includes_vendor():
+    out = vendors.qualify(subcategory="pipe_leak", city="Los Angeles")
+    ids = {v.vendor_id for v in out}
+    assert "v_001" in ids
+
+
+def test_qualify_city_not_in_coverage_excludes_vendor():
+    # v_001 covers LA, Santa Monica, Burbank, Pasadena, North Hollywood,
+    # Torrance, Long Beach. New York is not covered.
+    out = vendors.qualify(subcategory="pipe_leak", city="New York")
+    ids = {v.vendor_id for v in out}
+    assert "v_001" not in ids
+
+
+def test_qualify_city_soft_passes_when_coverage_empty():
+    # Build a synthetic vendor with empty coverage_cities to exercise the
+    # soft-pass path (real dataset has no such vendor).
+    fake = Vendor(
+        vendor_id="v_test",
+        name="Universal Vendor",
+        vendor_type="plumber",
+        specialties=("pipe_leak",),
+        coverage_cities=(),  # empty → no city filter applied
+        building_types_certified=("office",),
+    )
+    # Stub the cache so qualify() sees only this vendor.
+    vendors._ALL_CACHE = [fake]
+    try:
+        out = vendors.qualify(subcategory="pipe_leak", city="Anywhere")
+        assert len(out) == 1 and out[0].vendor_id == "v_test"
+    finally:
+        vendors._reset_caches_for_tests()
+
+
+# ─── qualify: building_type filter ─────────────────────────────────────────
+
+
+def test_qualify_building_type_in_cert_includes_vendor():
+    # v_001 certified for office, retail_office, parking
+    out = vendors.qualify(subcategory="pipe_leak", building_type="office")
+    ids = {v.vendor_id for v in out}
+    assert "v_001" in ids
+
+
+def test_qualify_building_type_not_in_cert_excludes_vendor():
+    # v_001 is NOT certified for medical
+    out = vendors.qualify(subcategory="pipe_leak", building_type="medical")
+    ids = {v.vendor_id for v in out}
+    assert "v_001" not in ids
+
+
+def test_qualify_building_type_soft_passes_when_cert_empty():
+    fake = Vendor(
+        vendor_id="v_uncertified",
+        name="Universal Vendor",
+        vendor_type="plumber",
+        specialties=("pipe_leak",),
+        coverage_cities=("Los Angeles",),
+        building_types_certified=(),  # empty → no cert filter applied
+    )
+    vendors._ALL_CACHE = [fake]
+    try:
+        out = vendors.qualify(
+            subcategory="pipe_leak", city="Los Angeles", building_type="medical"
+        )
+        assert len(out) == 1
+    finally:
+        vendors._reset_caches_for_tests()
+
+
+# ─── qualify: 24/7 filter ──────────────────────────────────────────────────
+
+
+def test_qualify_24_7_filter_off_during_business_hours():
+    # v_002 is NOT 24/7 but qualifies during business hours
+    out = vendors.qualify(subcategory="pipe_leak", is_emergency=False, after_hours=False)
+    ids = {v.vendor_id for v in out}
+    assert "v_002" in ids
+
+
+def test_qualify_24_7_filter_off_for_non_emergency_after_hours():
+    # Non-emergency at 2am should still include non-24/7 vendors
+    out = vendors.qualify(subcategory="pipe_leak", is_emergency=False, after_hours=True)
+    ids = {v.vendor_id for v in out}
+    assert "v_002" in ids
+
+
+def test_qualify_24_7_filter_excludes_non_247_on_after_hours_emergency():
+    out = vendors.qualify(subcategory="pipe_leak", is_emergency=True, after_hours=True)
+    ids = {v.vendor_id for v in out}
+    # v_001 is 24/7, qualifies. v_002 is NOT 24/7, must be excluded.
+    assert "v_001" in ids
+    assert "v_002" not in ids
+    assert all(v.available_24_7 for v in out)
+
+
+def test_qualify_24_7_filter_inactive_for_emergency_business_hours():
+    # is_emergency=True but after_hours=False → filter does NOT apply
+    out = vendors.qualify(subcategory="pipe_leak", is_emergency=True, after_hours=False)
+    ids = {v.vendor_id for v in out}
+    assert "v_002" in ids
+
+
+# ─── qualify: combined filters + escalate path ─────────────────────────────
+
+
+def test_qualify_combined_filters_returns_intersection():
+    out = vendors.qualify(
+        subcategory="pipe_leak",
+        city="Long Beach",
+        building_type="office",
+        is_emergency=True,
+        after_hours=True,
+    )
+    # All returned vendors must satisfy every constraint.
+    for v in out:
+        assert "pipe_leak" in v.specialties
+        assert "Long Beach" in v.coverage_cities
+        assert "office" in v.building_types_certified
+        assert v.available_24_7
+
+
+def test_qualify_returns_empty_when_nothing_satisfies():
+    out = vendors.qualify(
+        subcategory="pipe_leak",
+        city="Boston",  # no plumber covers Boston in this dataset
+    )
+    assert out == []
+
+
+# ─── subcategory→vendor-type mapping (issue #20 hook) ──────────────────────
+
+
+def test_loose_mapping_empty_by_default():
+    # Until issue #20 lands, the mapping is empty.
+    assert vendors._subcat_to_vendor_types() == {}
+
+
+def test_loose_mapping_extends_specialty_filter(monkeypatch=None):
+    # Simulate the issue-#20 derived mapping by stubbing the cache.
+    vendors._SUBCAT_MAPPING_CACHE = {"weird_new_subcat": ("plumber",)}
+    try:
+        out = vendors.qualify(subcategory="weird_new_subcat")
+        # Every plumber should now qualify even though no one has the
+        # specialty string.
+        assert len(out) >= 4  # 4 plumbers in the dataset
+        assert all(v.vendor_type == "plumber" for v in out)
+    finally:
+        vendors._reset_caches_for_tests()
+
+
+if __name__ == "__main__":
+    import inspect
+
+    tests = [(n, f) for n, f in inspect.getmembers(sys.modules[__name__])
+             if n.startswith("test_") and callable(f)]
+    failed = 0
+    for name, fn in tests:
+        try:
+            fn()
+            print(f"  PASS  {name}")
+        except AssertionError as e:
+            print(f"  FAIL  {name}: {e}")
+            failed += 1
+        except Exception as e:
+            print(f"  ERROR {name}: {type(e).__name__}: {e}")
+            failed += 1
+    print(f"\n{len(tests) - failed}/{len(tests)} passed")
+    sys.exit(1 if failed else 0)


### PR DESCRIPTION
Closes #6

## Summary
- Wraps `operational/vendors.json` (32 vendors, 16 distinct vendor_types, 13 with 24/7 coverage) with a typed query API.
- `qualify(subcategory, city, building_type, is_emergency, after_hours) -> list[Vendor]` returns the candidate set **before** ranking. Issue #21 picks one vendor out of this set; this module just narrows the field.

## What landed
- `agent/data/vendors.py`
- `tests/test_vendors.py`
- `.gitignore`

## Filter rules
- **specialty** — strict match on `vendor.specialties` (which already contains subcategory-level strings like `"pipe_leak"`); loose fallback via a subcategory→vendor_type mapping that issue #20 will populate at `agent/data/derived/subcategory_to_vendor_type.json`. Until that artifact lands the loose mapping is empty and the strict filter does the work.
- **city** — exact match against `coverage_cities`; soft-pass when empty/missing.
- **building_type** — exact match against `building_types_certified`; soft-pass when empty/missing.
- **available_24_7** — enforced **only** on after-hours emergencies. Business hours or routine calls → every vendor remains in scope.

## Deliberately not enforced here
- `status_at_last_check` / `last_status_confirmed_at` drive the tie-breaker and stale-availability handling in #21, not eligibility. `qualify()` is "*could* this vendor take it?", not "*should* they?".

## Validation
**20/20 unit tests pass.** Coverage:
- All 4 filters in isolation, both included and excluded paths.
- All 4 combinations of `is_emergency × after_hours` for the 24/7 filter.
- Soft-pass paths exercised via synthetic `Vendor` instances (the real dataset has no empty coverage/cert rows).
- Combined-filter intersection.
- Empty-result escalation case (`subcategory="pipe_leak", city="Boston"` → no plumber covers Boston).
- Loose-mapping hook for #20 (verified empty by default; verified that injecting a mapping pulls in matching `vendor_type`s).

## Test plan
- [ ] `python tests/test_vendors.py` reports 20/20 passing.
- [ ] `python -c 'from agent.data.vendors import qualify; print([v.vendor_id for v in qualify(subcategory="pipe_leak", city="Long Beach")])'` prints a plumber list.
- [ ] After issue #20 ships its derived JSON, dropping it at `agent/data/derived/subcategory_to_vendor_type.json` extends results without code changes here.

## Notes for reviewer
- **Trivial merge conflict** on `.gitignore` (identical content as `main`).
- `_reset_caches_for_tests()` is exposed as test-only API; not for runtime callers.

## Backlog reference
Implements issue #6 in [`docs/PROJECT_BACKLOG.md`](docs/PROJECT_BACKLOG.md).
Consumed by issue #20 (subcategory→vendor-type mapping) and issue #21 (vendor tie-breaker, stale availability, unroutable escalation).