### PR TITLE
issue-9: integrate qa_audit_findings.json into RAG conflict resolution

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,30 @@
+# Copy this file to `.env` and fill in your secrets.
+# `.env` is gitignored; this template is committed so a fresh clone has
+# a checklist of every variable the agent reads.
+#
+# Loaded automatically by python-dotenv when agent.config is first imported.
+# All AGENT_* vars are optional — defaults in agent/config.py are tuned for
+# determinism and match what the grader expects.
+
+# ─── Required ──────────────────────────────────────────────────────────
+# Auth for OpenAI chat + embedding models. Get one at
+# https://platform.openai.com/api-keys.
+OPENAI_API_KEY=
+
+# ─── Optional ──────────────────────────────────────────────────────────
+# Chat model used for extraction, classification, risk scoring, summary.
+# Default: gpt-4o-mini (cheap; bump to gpt-4o for higher accuracy at cost).
+# AGENT_CHAT_MODEL=gpt-4o-mini
+
+# Sampling temperature. Keep at 0.0 — the brief grades determinism (#28).
+# AGENT_CHAT_TEMPERATURE=0.0
+
+# OpenAI seed parameter (used where the model supports it).
+# AGENT_CHAT_SEED=7
+
+# Embedding model for the historical-records RAG index (#7). Changing this
+# requires rebuilding the chroma store from scratch.
+# AGENT_EMBEDDING_MODEL=text-embedding-3-small
+
+# Cap on the query-rewrite retry loop in the extraction node.
+# AGENT_MAX_EXTRACTION_RETRIES=2

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,30 @@
+# Python
+__pycache__/
+*.py[cod]
+*$py.class
+*.egg-info/
+.pytest_cache/
+.mypy_cache/
+.ruff_cache/
+
+# Virtualenvs
+.venv/
+venv/
+env/
+
+# Environment / secrets
+.env
+.env.local
+
+# Editor / OS
+.vscode/
+.idea/
+.DS_Store
+*.swp
+
+# Local eval outputs (committed runs go under eval_runs/)
+predictions.json
+/tmp_*.json
+
+# Vector store build artifacts (issue #7 will configure)
+agent/rag/chroma_store/

--- a/README.md
+++ b/README.md
@@ -59,6 +59,29 @@ Each eval row also carries `caller_known_in_profiles: bool` — true when
 The harness forwards only `turns` and `caller_phone`; the agent looks the
 profile up itself.
 
+## Environment variables
+
+Required:
+
+| Variable | Purpose |
+|---|---|
+| `OPENAI_API_KEY` | Auth for OpenAI chat + embedding models |
+
+Optional (defaults are tuned for determinism):
+
+| Variable | Default | Purpose |
+|---|---|---|
+| `AGENT_CHAT_MODEL` | `gpt-4o-mini` | Chat model for extraction / classification / risk |
+| `AGENT_CHAT_TEMPERATURE` | `0.0` | Sampling temperature (keep 0 for reproducibility) |
+| `AGENT_CHAT_SEED` | `7` | OpenAI seed parameter when supported |
+| `AGENT_EMBEDDING_MODEL` | `text-embedding-3-small` | Embedding model for the historical-records RAG index |
+| `AGENT_MAX_EXTRACTION_RETRIES` | `2` | Cap on the query-rewrite retry loop |
+
+Either export these in your shell or drop them in a `.env` at the repo root —
+the agent loads `.env` automatically via `python-dotenv`. Missing required
+vars surface as a `RuntimeError` from `agent.config.get_settings()` naming
+the exact variable that's unset.
+
 ## What you submit
 
 1. **Source repo** — your agent code, dependencies, README with run instructions.

--- a/README.md
+++ b/README.md
@@ -33,24 +33,34 @@ final_project/
 python3 -m venv .venv && source .venv/bin/activate
 pip install -r requirements.txt
 
-# 2. Run the agent on the dev set (with labels — for self-evaluation)
+# 2. Build the RAG index over historical_records.json (one-time, ~1 min, ~$0.02)
+#    — produces a persistent chroma store at agent/rag/chroma_store/.
+#    Skip this if a store already exists; pass --force to rebuild.
+python -m agent.rag.build_index
+
+# 3. Run the agent on the dev set (with labels — for self-evaluation)
 python evaluation/run_eval.py \
     --agent agent.classify:classify \
     --eval evaluation/eval_transcripts_dev.json \
     --out predictions.json
 
-# 3. Score yourself
+# 4. Score yourself
 python evaluation/scoring.py \
     --eval evaluation/eval_transcripts_dev.json \
     --ground-truth evaluation/dev_labels.json \
     --predictions predictions.json
 
-# 4. Final test-set run (used for grading)
+# 5. Final test-set run (used for grading)
 python evaluation/run_eval.py \
     --agent agent.classify:classify \
     --eval evaluation/eval_transcripts_test.json \
     --out predictions.json
 ```
+
+The chroma store is gitignored — it's built on first run from
+[`operational/historical_records.json`](operational/historical_records.json)
+using the `text-embedding-3-small` model (configurable via `AGENT_EMBEDDING_MODEL`).
+Changing the embedding model requires a `--force` rebuild.
 
 The agent exposes a single callable, `agent.classify:classify(turns, caller_phone) -> dict`,
 returning the fields documented in [`evaluation/prediction.py`](evaluation/prediction.py).

--- a/README.md
+++ b/README.md
@@ -29,39 +29,35 @@ final_project/
 ## Quick start
 
 ```bash
-# 1. Set up a Python env (Python ≥ 3.9)
+# 1. Set up a Python env (Python ≥ 3.9) and install runtime deps
 python3 -m venv .venv && source .venv/bin/activate
-# Install whatever your agent needs (LangGraph, OpenAI, etc.).
+pip install -r requirements.txt
 
-# 2. Build your agent. It must expose a single callable:
-#       def classify(turns: list[dict], caller_phone: str | None) -> dict
-#    Returning the fields documented in evaluation/prediction.py.
-#
-#    Note: each eval row also carries caller_known_in_profiles: bool — true when
-#    caller_phone matches an entry in operational/caller_profiles.json. The
-#    harness only forwards `turns` and `caller_phone` to your callable; if you
-#    want to use the flag, look it up yourself from caller_profiles.json.
-
-# 3. Run on the dev set (with labels — for self-evaluation)
+# 2. Run the agent on the dev set (with labels — for self-evaluation)
 python evaluation/run_eval.py \
-    --agent your_module.your_agent:classify \
+    --agent agent.classify:classify \
     --eval evaluation/eval_transcripts_dev.json \
     --out predictions.json
 
-# 4. Score yourself
+# 3. Score yourself
 python evaluation/scoring.py \
     --eval evaluation/eval_transcripts_dev.json \
     --ground-truth evaluation/dev_labels.json \
     --predictions predictions.json
 
-# 5. When you're ready to submit, generate predictions on the test set:
+# 4. Final test-set run (used for grading)
 python evaluation/run_eval.py \
-    --agent your_module.your_agent:classify \
+    --agent agent.classify:classify \
     --eval evaluation/eval_transcripts_test.json \
     --out predictions.json
-# Submit predictions.json + your repo. We grade with the same scoring.py
-# against held-out labels.
 ```
+
+The agent exposes a single callable, `agent.classify:classify(turns, caller_phone) -> dict`,
+returning the fields documented in [`evaluation/prediction.py`](evaluation/prediction.py).
+Each eval row also carries `caller_known_in_profiles: bool` — true when
+`caller_phone` matches [`operational/caller_profiles.json`](operational/caller_profiles.json).
+The harness forwards only `turns` and `caller_phone`; the agent looks the
+profile up itself.
 
 ## What you submit
 

--- a/agent/__init__.py
+++ b/agent/__init__.py
@@ -1,0 +1,12 @@
+"""CBRE HITL call-intake agent.
+
+Single public entrypoint:
+
+    from agent.classify import classify
+    classify(turns: list[dict], caller_phone: str | None) -> dict
+
+The returned dict matches `evaluation/prediction.py::Prediction`. Downstream
+issues replace the stub in `agent/classify.py` with the real LangGraph
+pipeline (extract → retrieve → classify → validator → log).
+"""
+__version__ = "0.1.0"

--- a/agent/classify.py
+++ b/agent/classify.py
@@ -1,0 +1,55 @@
+"""Single public entrypoint for the agent.
+
+This is the stub scaffolding for issue #1: it returns a schema-valid
+`Prediction` dict so the eval harness runs end-to-end. Real classification,
+retrieval, risk scoring, HITL gating, and vendor selection land in later
+issues. The goal here is wire compatibility, not score.
+
+Contract reference: `evaluation/prediction.py::Prediction` + `TrainerLog`.
+"""
+from __future__ import annotations
+
+from typing import Any, Optional
+
+
+def _flatten(turns: list[dict]) -> str:
+    return "\n".join(
+        f"[{t.get('speaker', '?').upper()}] {t.get('text', '')}".rstrip()
+        for t in turns
+    )
+
+
+def classify(turns: list[dict], caller_phone: Optional[str]) -> dict[str, Any]:
+    """Return a schema-valid Prediction dict.
+
+    Stub behavior: emit safe, conservative defaults that pass the schema check
+    in `evaluation/run_eval.py` and avoid the −5 false-911 penalty. Downstream
+    issues replace this with the real LangGraph pipeline.
+    """
+    base = {
+        "category": "OTHER",
+        "subcategory": "other",
+        "risk_level": "MEDIUM",
+        "needs_human_review": True,
+        "needs_clarification": False,
+        "building_name": None,
+        "address": None,
+        "floor": None,
+        "dispatched_vendor_id": None,
+        "dispatched_emergency_services": False,
+        "call_summary": (
+            "Stub prediction from agent scaffold (issue #1). "
+            "Call routed to human reviewer pending full pipeline implementation."
+        ),
+    }
+
+    full_transcript = _flatten(turns)
+    return {
+        **base,
+        "trainer_log": {
+            "full_transcript": full_transcript,
+            "ai_prediction": dict(base),
+            "human_override": None,
+            "final_decision": dict(base),
+        },
+    }

--- a/agent/config.py
+++ b/agent/config.py
@@ -1,0 +1,78 @@
+"""Central runtime configuration for the agent.
+
+All tunable knobs (model name, embedding model, temperature, retry caps)
+live here. Each is overridable via an environment variable; defaults are
+picked to favor determinism (`temperature=0`, fixed `seed`) per the
+submission contract.
+
+Secrets are validated lazily — importing this module is side-effect-free
+beyond a `.env` load. The first call to `get_settings()` (or an explicit
+`Settings.validate_or_raise()`) raises a `RuntimeError` naming the exact
+missing environment variable. Pass `validate=False` to bypass when wiring up
+LLM-free code paths (e.g. data-loader unit tests, the stub in agent/classify).
+"""
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+from typing import Optional, Tuple
+
+try:
+    from dotenv import load_dotenv
+
+    load_dotenv()
+except ImportError:
+    pass
+
+
+REQUIRED_ENV_VARS: Tuple[str, ...] = ("OPENAI_API_KEY",)
+
+
+@dataclass(frozen=True)
+class Settings:
+    chat_model: str
+    chat_temperature: float
+    chat_seed: Optional[int]
+    embedding_model: str
+    max_extraction_retries: int
+    openai_api_key: Optional[str]
+
+    def validate_or_raise(self) -> None:
+        missing = [v for v in REQUIRED_ENV_VARS if not os.environ.get(v)]
+        if missing:
+            raise RuntimeError(
+                "Missing required environment variable(s): "
+                f"{', '.join(missing)}. Set them in your shell or in a .env "
+                "file at the repo root."
+            )
+
+
+def _env_float(name: str, default: float) -> float:
+    raw = os.environ.get(name)
+    return float(raw) if raw not in (None, "") else default
+
+
+def _env_int_opt(name: str, default: int) -> int:
+    raw = os.environ.get(name)
+    return int(raw) if raw not in (None, "") else default
+
+
+def get_settings(*, validate: bool = True) -> Settings:
+    """Build a `Settings` from the current environment.
+
+    Set `validate=False` only for code paths that genuinely don't need the
+    LLM (data loaders, schema tests, the issue-#1 stub).
+    """
+    settings = Settings(
+        chat_model=os.environ.get("AGENT_CHAT_MODEL", "gpt-4o-mini"),
+        chat_temperature=_env_float("AGENT_CHAT_TEMPERATURE", 0.0),
+        chat_seed=_env_int_opt("AGENT_CHAT_SEED", 7),
+        embedding_model=os.environ.get(
+            "AGENT_EMBEDDING_MODEL", "text-embedding-3-small"
+        ),
+        max_extraction_retries=_env_int_opt("AGENT_MAX_EXTRACTION_RETRIES", 2),
+        openai_api_key=os.environ.get("OPENAI_API_KEY"),
+    )
+    if validate:
+        settings.validate_or_raise()
+    return settings

--- a/agent/data/audit.py
+++ b/agent/data/audit.py
@@ -1,0 +1,126 @@
+"""Loader for `evaluation/qa_audit_findings.json`.
+
+Audit findings are post-hoc QA reviews over ~10% of the historical CMMS
+corpus. Each entry references one ticket_id and may carry up to three
+flags:
+
+- `was_over_escalated`: intake_risk_level was too high vs final_risk_level.
+- `was_reclassified`: intake_subcategory was wrong; final_subcategory differs.
+- `floor_was_wrong_at_intake`: intake captured the wrong floor; the
+  audited `actual_floor` is the correct one.
+
+A finding may exist with *no* flags set — that means the auditor reviewed
+the ticket and confirmed the intake decision. `has_any_flag` is the
+canonical signal for "this ticket had a real problem the QA team caught."
+
+This module is consumed by:
+- `agent/rag/build_index.py` — to stamp audit metadata into chroma at
+  index-build time, so the classifier can prefer corrected labels over
+  flawed intake labels.
+- `agent/rag/retriever.py` — `RetrievedRecord.corrected_*` properties
+  derive from these flags.
+
+Empirically (988 findings):
+- 188 / 988 over-escalated
+- 279 / 988 reclassified
+- 391 / 988 floor wrong at intake
+-  20 / 988 with multiple flags
+- 150 / 988 audited and found OK (no flags set)
+"""
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Dict, Optional, Set
+
+_AUDIT_PATH: Path = (
+    Path(__file__).resolve().parents[2] / "evaluation" / "qa_audit_findings.json"
+)
+
+
+@dataclass(frozen=True)
+class AuditFinding:
+    ticket_id: str
+    audit_id: str
+    was_over_escalated: bool
+    was_reclassified: bool
+    floor_was_wrong_at_intake: bool
+    over_escalation_reason: Optional[str] = None
+    reclassification_note: Optional[str] = None
+    actual_floor: Optional[str] = None
+    notes: Optional[str] = None
+    audited_by: Optional[str] = None
+    audited_at: Optional[str] = None
+
+    @property
+    def has_any_flag(self) -> bool:
+        """True iff at least one of the three flags is set.
+
+        An audit entry can exist with no flags — that's "auditor reviewed
+        this ticket and confirmed the intake decision." Those tickets are
+        NOT what the classifier should treat as suspect.
+        """
+        return (
+            self.was_over_escalated
+            or self.was_reclassified
+            or self.floor_was_wrong_at_intake
+        )
+
+
+_INDEX_CACHE: Optional[Dict[str, AuditFinding]] = None
+
+
+def _build_index() -> Dict[str, AuditFinding]:
+    raw = json.loads(_AUDIT_PATH.read_text())
+    out: Dict[str, AuditFinding] = {}
+    for r in raw:
+        tid = r.get("ticket_id")
+        if not tid:
+            continue
+        out[tid] = AuditFinding(
+            ticket_id=tid,
+            audit_id=r.get("audit_id", ""),
+            was_over_escalated=bool(r.get("was_over_escalated")),
+            was_reclassified=bool(r.get("was_reclassified")),
+            floor_was_wrong_at_intake=bool(r.get("floor_was_wrong_at_intake")),
+            over_escalation_reason=r.get("over_escalation_reason"),
+            reclassification_note=r.get("reclassification_note"),
+            actual_floor=r.get("actual_floor"),
+            notes=r.get("notes"),
+            audited_by=r.get("audited_by"),
+            audited_at=r.get("audited_at"),
+        )
+    return out
+
+
+def _index() -> Dict[str, AuditFinding]:
+    global _INDEX_CACHE
+    if _INDEX_CACHE is None:
+        _INDEX_CACHE = _build_index()
+    return _INDEX_CACHE
+
+
+def lookup(ticket_id: Optional[str]) -> Optional[AuditFinding]:
+    """Return the audit finding for `ticket_id`, or None if not audited."""
+    if not ticket_id:
+        return None
+    return _index().get(ticket_id)
+
+
+def flagged_ticket_ids() -> Set[str]:
+    """Set of ticket_ids with at least one audit flag set.
+
+    Excludes audited-and-clean tickets (~150 of 988 in the current data).
+    """
+    return {tid for tid, f in _index().items() if f.has_any_flag}
+
+
+def all_audited_ticket_ids() -> Set[str]:
+    """Set of every ticket_id with an audit entry, flagged or not."""
+    return set(_index().keys())
+
+
+def _reset_cache_for_tests() -> None:
+    global _INDEX_CACHE
+    _INDEX_CACHE = None

--- a/agent/rag/__init__.py
+++ b/agent/rag/__init__.py
@@ -1,0 +1,39 @@
+"""RAG layer over `operational/historical_records.json`.
+
+Layout:
+- `build_index.py` — CLI to embed + persist the 10K-record corpus.
+- `retriever.py` — (issue #8) retrieval API on top of the persisted store.
+
+Constants here are the single source of truth for builder + retriever:
+they must agree on the on-disk store path, the chroma collection name,
+and the embedding model. Changing the embedding model requires a full
+rebuild.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+# Where the persisted chroma store lives. Gitignored — built on first run
+# (or on demand via `python -m agent.rag.build_index --force`).
+STORE_DIR: Path = Path(__file__).resolve().parent / "chroma_store"
+
+# Single chroma collection per build; keep in lockstep with the retriever.
+COLLECTION_NAME: str = "historical_records"
+
+# Schema of every chroma metadata row. Listed here so the builder, the
+# retriever, and any analysis script all agree. `was_audit_flagged` is a
+# placeholder: it lands as `False` in this issue and gets joined against
+# `evaluation/qa_audit_findings.json` in issue #9.
+METADATA_KEYS: tuple[str, ...] = (
+    "ticket_id",
+    "intake_category",
+    "intake_subcategory",
+    "intake_risk_level",
+    "final_category",
+    "final_subcategory",
+    "final_risk_level",
+    "assigned_vendor_id",
+    "building_type",
+    "city",
+    "was_audit_flagged",
+)

--- a/agent/rag/__init__.py
+++ b/agent/rag/__init__.py
@@ -21,9 +21,15 @@ STORE_DIR: Path = Path(__file__).resolve().parent / "chroma_store"
 COLLECTION_NAME: str = "historical_records"
 
 # Schema of every chroma metadata row. Listed here so the builder, the
-# retriever, and any analysis script all agree. `was_audit_flagged` is a
-# placeholder: it lands as `False` in this issue and gets joined against
-# `evaluation/qa_audit_findings.json` in issue #9.
+# retriever, and any analysis script all agree.
+#
+# Audit fields are populated at build time via a join against
+# `evaluation/qa_audit_findings.json` (issue #9):
+# - `was_audit_flagged` is True iff the ticket has at least one specific
+#   audit flag set; not just "the auditor reviewed this ticket".
+# - The three sub-flags are denormalized so the classifier can ask
+#   "which axis was the intake wrong about" and the retriever can expose
+#   `corrected_*` properties (final_* on flagged records, intake_* otherwise).
 METADATA_KEYS: tuple[str, ...] = (
     "ticket_id",
     "intake_category",
@@ -36,4 +42,7 @@ METADATA_KEYS: tuple[str, ...] = (
     "building_type",
     "city",
     "was_audit_flagged",
+    "audit_over_escalated",
+    "audit_reclassified",
+    "audit_floor_wrong",
 )

--- a/agent/rag/build_index.py
+++ b/agent/rag/build_index.py
@@ -1,0 +1,255 @@
+"""Build the RAG vector index over `operational/historical_records.json`.
+
+Run:
+    python -m agent.rag.build_index               # build if no store yet
+    python -m agent.rag.build_index --force       # rebuild from scratch
+    python -m agent.rag.build_index --limit 100   # subset (smoke test)
+
+What this builds
+----------------
+A persisted chromadb collection at `agent/rag/chroma_store/`. Each ticket
+becomes one document. The document text is a structured concatenation of
+the verbatim caller transcript and the intake / dispatch / resolution
+notes — caller transcript first because it's the richest signal per the
+brief. Metadata covers the join keys downstream nodes need: intake +
+final category / subcategory / risk_level, the assigned vendor, building
+type, city, and a `was_audit_flagged` placeholder that issue #9 fills.
+
+Embedding model defaults to `text-embedding-3-small` via `agent.config`.
+Changing the model requires a rebuild — the on-disk store has no concept
+of which embedder produced its vectors.
+
+Cost / time
+-----------
+Average ticket text is ~400 chars (~100 tokens). The full 10K corpus is
+~1M tokens; at text-embedding-3-small pricing that's ≈ $0.02. Wall time
+on a typical laptop laptop: 1–3 minutes (well under the AC's 10 min cap).
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import shutil
+import sys
+import time
+from pathlib import Path
+from typing import Any, Iterable, List, Optional, Sequence
+
+# chromadb's posthog telemetry is incompatible with Python 3.14 and emits
+# noisy "capture() takes 1 positional argument" warnings. Opt out before
+# any chromadb code path runs and silence the leftover error logger that
+# fires even when telemetry is disabled.
+os.environ.setdefault("ANONYMIZED_TELEMETRY", "False")
+import logging  # noqa: E402
+logging.getLogger("chromadb.telemetry.product.posthog").setLevel(logging.CRITICAL)
+
+from langchain_core.documents import Document  # noqa: E402
+
+from agent import config  # noqa: E402
+from agent.rag import COLLECTION_NAME, METADATA_KEYS, STORE_DIR  # noqa: E402
+
+
+HISTORICAL_PATH: Path = (
+    Path(__file__).resolve().parents[2] / "operational" / "historical_records.json"
+)
+
+# Hard cap on per-document text length. text-embedding-3-small accepts
+# ~8K tokens (~32K chars). Real-world tickets average ~400 chars and
+# top out at ~540, so this is a safety belt rather than a routine path.
+MAX_DOC_CHARS: int = 24_000
+
+# Embedding batch size sent to OpenAI. Chroma + langchain handle batching,
+# but we set this explicitly for predictable throughput at 10K scale.
+EMBEDDING_BATCH_SIZE: int = 256
+
+
+# ─── Pure builders (no I/O, no network — easily unit-testable) ─────────
+
+
+def _format_document_text(record: dict) -> str:
+    """Produce one embeddable text block per ticket.
+
+    Order matters for retrieval quality: the caller's verbatim quote
+    leads, then operator shorthand, then dispatch + resolution. Empty
+    sections are dropped so they don't dilute the embedding.
+    """
+    parts: List[str] = []
+    if record.get("call_recording_transcript"):
+        parts.append(f"CALLER TRANSCRIPT:\n{record['call_recording_transcript']}")
+    if record.get("intake_notes"):
+        parts.append(f"INTAKE NOTES: {record['intake_notes']}")
+    if record.get("dispatch_notes"):
+        parts.append(f"DISPATCH NOTES: {record['dispatch_notes']}")
+    if record.get("resolution_notes"):
+        parts.append(f"RESOLUTION NOTES: {record['resolution_notes']}")
+    text = "\n\n".join(parts)
+    if len(text) > MAX_DOC_CHARS:
+        text = text[:MAX_DOC_CHARS]
+    return text
+
+
+def _format_metadata(record: dict) -> dict:
+    """Extract the metadata fields downstream nodes filter and rank by.
+
+    Chroma metadata values must be primitives (str / int / float / bool);
+    `None`s are dropped because some chromadb versions choke on them in
+    where-clauses.
+    """
+    md: dict[str, Any] = {
+        "ticket_id": record.get("ticket_id"),
+        "intake_category": record.get("intake_category"),
+        "intake_subcategory": record.get("intake_subcategory"),
+        "intake_risk_level": record.get("intake_risk_level"),
+        "final_category": record.get("final_category"),
+        "final_subcategory": record.get("final_subcategory"),
+        "final_risk_level": record.get("final_risk_level"),
+        "assigned_vendor_id": record.get("assigned_vendor_id"),
+        "building_type": record.get("building_type"),
+        "city": record.get("city"),
+        # Placeholder; issue #9 joins evaluation/qa_audit_findings.json
+        # to populate this on a per-ticket basis.
+        "was_audit_flagged": False,
+    }
+    return {k: v for k, v in md.items() if v is not None}
+
+
+def _to_documents(records: Iterable[dict]) -> List[Document]:
+    out: List[Document] = []
+    for r in records:
+        text = _format_document_text(r)
+        if not text.strip():
+            continue
+        out.append(Document(page_content=text, metadata=_format_metadata(r)))
+    return out
+
+
+def _load_records(limit: Optional[int] = None) -> List[dict]:
+    raw = json.loads(HISTORICAL_PATH.read_text())
+    if limit is not None:
+        raw = raw[:limit]
+    return raw
+
+
+# ─── Build orchestration ───────────────────────────────────────────────
+
+
+def build(
+    *,
+    force: bool = False,
+    limit: Optional[int] = None,
+    verbose: bool = True,
+    embeddings: Any = None,
+    store_dir: Optional[Path] = None,
+) -> int:
+    """Build (or refresh) the chroma store. Returns the document count.
+
+    Returns -1 when an existing store is left intact (no `--force`).
+
+    `embeddings` and `store_dir` are injection points for tests — pass a
+    `FakeEmbeddings` instance and a `tmp_path` to validate end-to-end
+    without hitting OpenAI.
+    """
+    from langchain_chroma import Chroma  # heavy imports kept off module load
+
+    target_dir = Path(store_dir) if store_dir else STORE_DIR
+
+    if target_dir.exists() and any(target_dir.iterdir()):
+        if not force:
+            if verbose:
+                print(
+                    f"[rag] store exists at {target_dir} — skipping "
+                    "(use --force to rebuild)"
+                )
+            return -1
+        if verbose:
+            print(f"[rag] --force: removing existing store at {target_dir}")
+        shutil.rmtree(target_dir)
+        # chromadb keeps an in-process SharedSystemClient cache keyed on
+        # persist path; without clearing it, a subsequent open of the same
+        # path inside the same Python process tries to write through stale
+        # SQLite handles and trips "attempt to write a readonly database".
+        try:
+            from chromadb.api.client import SharedSystemClient
+            SharedSystemClient.clear_system_cache()
+        except Exception:
+            pass
+
+    if embeddings is None:
+        from langchain_openai import OpenAIEmbeddings
+
+        settings = config.get_settings()
+        if verbose:
+            print(f"[rag] embedding model: {settings.embedding_model}")
+        embeddings = OpenAIEmbeddings(
+            model=settings.embedding_model,
+            chunk_size=EMBEDDING_BATCH_SIZE,
+        )
+    elif verbose:
+        print("[rag] using injected embeddings (test mode)")
+
+    if verbose:
+        print(f"[rag] loading historicals from {HISTORICAL_PATH.name}...")
+    records = _load_records(limit=limit)
+    docs = _to_documents(records)
+    if verbose:
+        print(f"[rag] {len(docs)} documents to embed (from {len(records)} records)")
+
+    target_dir.mkdir(parents=True, exist_ok=True)
+
+    t0 = time.time()
+    Chroma.from_documents(
+        documents=docs,
+        embedding=embeddings,
+        persist_directory=str(target_dir),
+        collection_name=COLLECTION_NAME,
+    )
+    elapsed = time.time() - t0
+
+    if verbose:
+        rate = len(docs) / elapsed if elapsed > 0 else 0
+        print(
+            f"[rag] embedded + persisted {len(docs)} docs in {elapsed:.1f}s "
+            f"({rate:.0f} docs/s)"
+        )
+        print(f"[rag] store: {target_dir}")
+    return len(docs)
+
+
+def main(argv: Optional[Sequence[str]] = None) -> int:
+    ap = argparse.ArgumentParser(
+        description="Build the RAG vector index over operational/historical_records.json"
+    )
+    ap.add_argument(
+        "--force",
+        action="store_true",
+        help="rebuild even if a store already exists at agent/rag/chroma_store/",
+    )
+    ap.add_argument(
+        "--limit",
+        type=int,
+        default=None,
+        help="cap on records (smoke tests / debugging)",
+    )
+    ap.add_argument(
+        "--quiet",
+        action="store_true",
+        help="suppress progress logging",
+    )
+    args = ap.parse_args(argv)
+    n = build(force=args.force, limit=args.limit, verbose=not args.quiet)
+    return 0 if n >= 0 else 0  # both paths are clean exits
+
+
+if __name__ == "__main__":
+    sys.exit(main())
+
+
+# Re-export schema for tests / external scripts.
+__all__ = (
+    "build",
+    "main",
+    "MAX_DOC_CHARS",
+    "METADATA_KEYS",
+    "HISTORICAL_PATH",
+)

--- a/agent/rag/build_index.py
+++ b/agent/rag/build_index.py
@@ -47,6 +47,7 @@ logging.getLogger("chromadb.telemetry.product.posthog").setLevel(logging.CRITICA
 from langchain_core.documents import Document  # noqa: E402
 
 from agent import config  # noqa: E402
+from agent.data import audit  # noqa: E402
 from agent.rag import COLLECTION_NAME, METADATA_KEYS, STORE_DIR  # noqa: E402
 
 
@@ -92,10 +93,18 @@ def _format_document_text(record: dict) -> str:
 def _format_metadata(record: dict) -> dict:
     """Extract the metadata fields downstream nodes filter and rank by.
 
+    Joins `evaluation/qa_audit_findings.json` (issue #9) to stamp the
+    audit booleans into each row. Records without a finding default to
+    every audit flag = False; records with a finding but no specific
+    flags set (auditor reviewed and confirmed intake) likewise stay False
+    on `was_audit_flagged` — that key tracks "real problem the auditor
+    caught", not "this ticket was reviewed".
+
     Chroma metadata values must be primitives (str / int / float / bool);
     `None`s are dropped because some chromadb versions choke on them in
     where-clauses.
     """
+    finding = audit.lookup(record.get("ticket_id"))
     md: dict[str, Any] = {
         "ticket_id": record.get("ticket_id"),
         "intake_category": record.get("intake_category"),
@@ -107,9 +116,10 @@ def _format_metadata(record: dict) -> dict:
         "assigned_vendor_id": record.get("assigned_vendor_id"),
         "building_type": record.get("building_type"),
         "city": record.get("city"),
-        # Placeholder; issue #9 joins evaluation/qa_audit_findings.json
-        # to populate this on a per-ticket basis.
-        "was_audit_flagged": False,
+        "was_audit_flagged": bool(finding and finding.has_any_flag),
+        "audit_over_escalated": bool(finding and finding.was_over_escalated),
+        "audit_reclassified": bool(finding and finding.was_reclassified),
+        "audit_floor_wrong": bool(finding and finding.floor_was_wrong_at_intake),
     }
     return {k: v for k, v in md.items() if v is not None}
 

--- a/agent/rag/retriever.py
+++ b/agent/rag/retriever.py
@@ -46,7 +46,8 @@ from agent.rag import COLLECTION_NAME, STORE_DIR  # noqa: E402
 DEFAULT_K = 5
 # The set of metadata keys callers can safely pass through `filters` —
 # matches the schema written by the builder. Anything outside this list
-# would silently match nothing in the chroma store.
+# would silently match nothing in the chroma store. A unit test asserts
+# this stays in lockstep with `agent.rag.METADATA_KEYS`.
 FILTERABLE_KEYS = (
     "ticket_id",
     "intake_category",
@@ -59,6 +60,9 @@ FILTERABLE_KEYS = (
     "building_type",
     "city",
     "was_audit_flagged",
+    "audit_over_escalated",
+    "audit_reclassified",
+    "audit_floor_wrong",
 )
 
 
@@ -73,10 +77,17 @@ class RetrievedRecord:
     `distance` is chroma's L2 distance between the query embedding and
     this document's embedding (lower = more similar; 0.0 = identical).
     None when the underlying call didn't surface a score.
+
+    The `corrected_*` properties are the AC's "relabel" path for
+    audit-flagged records: when the QA team reclassified or de-escalated
+    a ticket, classifier prompts should learn from the corrected label,
+    not the flawed intake label.
     """
     text: str
     metadata: Mapping[str, Any]
     distance: Optional[float] = None
+
+    # ─── Raw metadata accessors ────────────────────────────────────────
 
     @property
     def ticket_id(self) -> Optional[str]:
@@ -91,12 +102,65 @@ class RetrievedRecord:
         return self.metadata.get("intake_subcategory")
 
     @property
+    def intake_risk_level(self) -> Optional[str]:
+        return self.metadata.get("intake_risk_level")
+
+    @property
+    def final_category(self) -> Optional[str]:
+        return self.metadata.get("final_category")
+
+    @property
     def final_subcategory(self) -> Optional[str]:
         return self.metadata.get("final_subcategory")
 
     @property
+    def final_risk_level(self) -> Optional[str]:
+        return self.metadata.get("final_risk_level")
+
+    @property
     def assigned_vendor_id(self) -> Optional[str]:
         return self.metadata.get("assigned_vendor_id")
+
+    @property
+    def is_audit_flagged(self) -> bool:
+        return bool(self.metadata.get("was_audit_flagged"))
+
+    @property
+    def was_reclassified(self) -> bool:
+        return bool(self.metadata.get("audit_reclassified"))
+
+    @property
+    def was_over_escalated(self) -> bool:
+        return bool(self.metadata.get("audit_over_escalated"))
+
+    # ─── Corrected accessors — the audit-aware view ────────────────────
+
+    @property
+    def corrected_category(self) -> Optional[str]:
+        """`final_category` when the auditor reclassified, else `intake_category`."""
+        if self.was_reclassified and self.metadata.get("final_category"):
+            return self.metadata.get("final_category")
+        return self.metadata.get("intake_category")
+
+    @property
+    def corrected_subcategory(self) -> Optional[str]:
+        """`final_subcategory` when the auditor reclassified, else `intake_subcategory`.
+
+        This is the *primary* label the classifier should learn from on
+        retrieved records — using `intake_subcategory` directly perpetuates
+        the original miss on flagged tickets (e.g. "roof_leak" intake that
+        was actually a `structural` life-safety call).
+        """
+        if self.was_reclassified and self.metadata.get("final_subcategory"):
+            return self.metadata.get("final_subcategory")
+        return self.metadata.get("intake_subcategory")
+
+    @property
+    def corrected_risk_level(self) -> Optional[str]:
+        """`final_risk_level` when the auditor flagged over-escalation, else intake."""
+        if self.was_over_escalated and self.metadata.get("final_risk_level"):
+            return self.metadata.get("final_risk_level")
+        return self.metadata.get("intake_risk_level")
 
 
 _STORE: Any = None
@@ -218,3 +282,60 @@ def _reset_caches_for_tests() -> None:
     """Drop the cached Chroma client so tests can swap stores mid-process."""
     global _STORE
     _STORE = None
+
+
+def detect_label_conflict(
+    records: List["RetrievedRecord"],
+    *,
+    use_corrected: bool = True,
+) -> Optional[dict]:
+    """Surface conflicting subcategory labels across a retrieved set.
+
+    The brief: "When a retrieved set contains conflicting labels for
+    similar calls, the agent surfaces the conflict (test/log) rather
+    than silently picking the most frequent." This is the surfacer.
+
+    Returns None when records agree (or fewer than 2 meaningful labels
+    exist). When they disagree, returns a dict the classifier or the
+    clarification node can log / act on:
+
+        {
+          "conflict": True,
+          "labels": {"pipe_leak": 3, "drainage_backup": 2},
+          "consensus": "pipe_leak",   # the modal label
+          "consensus_share": 0.6,     # 3/5
+          "n_records": 5,
+          "use_corrected": True,
+        }
+
+    Set `use_corrected=False` to inspect the raw intake labels (useful
+    for diagnostics — "what did intake think?" — but not what the
+    classifier should consume).
+    """
+    from collections import Counter
+
+    if not records:
+        return None
+
+    if use_corrected:
+        labels = [r.corrected_subcategory for r in records]
+    else:
+        labels = [r.intake_subcategory for r in records]
+    labels = [l for l in labels if l]
+
+    if len(labels) < 2:
+        return None
+
+    counts = Counter(labels)
+    if len(counts) <= 1:
+        return None  # all agree
+
+    consensus, top_count = counts.most_common(1)[0]
+    return {
+        "conflict": True,
+        "labels": dict(counts),
+        "consensus": consensus,
+        "consensus_share": top_count / len(labels),
+        "n_records": len(labels),
+        "use_corrected": use_corrected,
+    }

--- a/agent/rag/retriever.py
+++ b/agent/rag/retriever.py
@@ -1,0 +1,220 @@
+"""Retrieval API on top of the persisted RAG index.
+
+Public surface is `retrieve(query, k, filters)` returning a list of
+`RetrievedRecord`s. Callers (the classifier in #11, the conflict-resolver
+in #9, etc.) get a typed, embedding-agnostic façade over the chroma store
+that issue #7 builds — they don't have to know about `Chroma`,
+`OpenAIEmbeddings`, or chromadb's `where` syntax.
+
+Filters are pre-applied at the index level (chromadb's metadata filter,
+not a post-hoc Python filter on top of vector results) so a `k=5` request
+returns 5 *qualifying* hits rather than 5 hits filtered down to fewer.
+
+Usage:
+
+    from agent.rag.retriever import retrieve
+
+    # Simple: no filter, default k=5
+    hits = retrieve("water leaking from ceiling")
+
+    # With a single-field metadata filter (chroma equality shorthand):
+    hits = retrieve("door card reader broken", filters={"city": "Long Beach"})
+
+    # With a multi-field filter (must use chroma's $and operator):
+    hits = retrieve(
+        "no heat",
+        k=8,
+        filters={"$and": [{"building_type": "office"}, {"city": "Los Angeles"}]},
+    )
+"""
+from __future__ import annotations
+
+import logging
+import os
+from dataclasses import dataclass
+from typing import Any, List, Mapping, Optional
+
+# Same telemetry-noise suppression as build_index.py — chromadb's posthog
+# hook breaks under Python 3.14 and we opt out before any chroma import.
+os.environ.setdefault("ANONYMIZED_TELEMETRY", "False")
+logging.getLogger("chromadb.telemetry.product.posthog").setLevel(logging.CRITICAL)
+
+from agent import config  # noqa: E402
+from agent.rag import COLLECTION_NAME, STORE_DIR  # noqa: E402
+
+
+DEFAULT_K = 5
+# The set of metadata keys callers can safely pass through `filters` —
+# matches the schema written by the builder. Anything outside this list
+# would silently match nothing in the chroma store.
+FILTERABLE_KEYS = (
+    "ticket_id",
+    "intake_category",
+    "intake_subcategory",
+    "intake_risk_level",
+    "final_category",
+    "final_subcategory",
+    "final_risk_level",
+    "assigned_vendor_id",
+    "building_type",
+    "city",
+    "was_audit_flagged",
+)
+
+
+@dataclass(frozen=True)
+class RetrievedRecord:
+    """One hit returned by `retrieve()`.
+
+    `text` is the full embeddable document body the builder produced — the
+    structured concatenation of caller transcript + intake / dispatch /
+    resolution notes. `metadata` holds every field listed in
+    `agent.rag.METADATA_KEYS` that was non-None for this ticket.
+    `distance` is chroma's L2 distance between the query embedding and
+    this document's embedding (lower = more similar; 0.0 = identical).
+    None when the underlying call didn't surface a score.
+    """
+    text: str
+    metadata: Mapping[str, Any]
+    distance: Optional[float] = None
+
+    @property
+    def ticket_id(self) -> Optional[str]:
+        return self.metadata.get("ticket_id")
+
+    @property
+    def intake_category(self) -> Optional[str]:
+        return self.metadata.get("intake_category")
+
+    @property
+    def intake_subcategory(self) -> Optional[str]:
+        return self.metadata.get("intake_subcategory")
+
+    @property
+    def final_subcategory(self) -> Optional[str]:
+        return self.metadata.get("final_subcategory")
+
+    @property
+    def assigned_vendor_id(self) -> Optional[str]:
+        return self.metadata.get("assigned_vendor_id")
+
+
+_STORE: Any = None
+
+
+def _get_store(*, embeddings: Any = None, store_dir: Any = None) -> Any:
+    """Return the persisted Chroma store, building the embedder lazily.
+
+    `embeddings` and `store_dir` are injection points for tests — the
+    production path constructs `OpenAIEmbeddings` from `agent.config` and
+    points at `STORE_DIR`. Callers should usually let those defaults stand.
+    """
+    global _STORE
+    target_dir = store_dir if store_dir is not None else STORE_DIR
+
+    if _STORE is not None and embeddings is None and store_dir is None:
+        return _STORE
+
+    from pathlib import Path
+    target_path = Path(str(target_dir))
+    if not target_path.exists() or not any(target_path.iterdir()):
+        raise RuntimeError(
+            f"RAG store not found at {target_path}. Run "
+            "`python -m agent.rag.build_index` to populate it."
+        )
+
+    from langchain_chroma import Chroma
+
+    if embeddings is None:
+        from langchain_openai import OpenAIEmbeddings
+
+        s = config.get_settings()
+        embeddings = OpenAIEmbeddings(model=s.embedding_model)
+
+    store = Chroma(
+        persist_directory=str(target_path),
+        collection_name=COLLECTION_NAME,
+        embedding_function=embeddings,
+    )
+
+    # Cache only the production-path store; test invocations with explicit
+    # injection params get a fresh instance every call.
+    if embeddings is None and store_dir is None:
+        _STORE = store
+    return store
+
+
+def _normalize_filters(filters: Optional[Mapping[str, Any]]) -> Optional[dict]:
+    """Pass-through chroma `where` clauses unchanged; light validation.
+
+    Chroma accepts equality shorthand (`{"city": "LA"}`) and operator
+    forms (`{"city": {"$eq": "LA"}}`, `{"$and": [...]}`). We accept both.
+    Single-field shorthand against a non-known key emits a debug log so
+    typos surface during development without rejecting the call.
+    """
+    if not filters:
+        return None
+    if "$and" in filters or "$or" in filters or "$not" in filters:
+        return dict(filters)
+    for k in filters:
+        if k not in FILTERABLE_KEYS and not k.startswith("$"):
+            logging.getLogger(__name__).debug(
+                "filter on metadata key %r is outside FILTERABLE_KEYS; "
+                "results may be empty",
+                k,
+            )
+    return dict(filters)
+
+
+def retrieve(
+    query: str,
+    *,
+    k: int = DEFAULT_K,
+    filters: Optional[Mapping[str, Any]] = None,
+    embeddings: Any = None,
+    store_dir: Any = None,
+) -> List[RetrievedRecord]:
+    """Vector-search the historical-records corpus.
+
+    Args:
+        query: free-text query string. Embedded by the same model that
+            built the index (text-embedding-3-small by default).
+        k: max number of hits to return (default 5; classification may
+            want 8–10 for richer disambiguation).
+        filters: optional metadata pre-filter applied at index level.
+            Pass a chromadb `where`-style dict; see module docstring for
+            shape examples.
+        embeddings, store_dir: test-only injection points. Production
+            callers should omit both.
+
+    Returns:
+        Up to `k` `RetrievedRecord`s ordered by ascending distance
+        (most similar first). Empty list if no docs match.
+
+    Raises:
+        ValueError: on empty query or non-positive k.
+        RuntimeError: when the chroma store hasn't been built.
+    """
+    if not query or not query.strip():
+        raise ValueError("query must be a non-empty string")
+    if k <= 0:
+        raise ValueError(f"k must be positive, got {k}")
+
+    store = _get_store(embeddings=embeddings, store_dir=store_dir)
+    where = _normalize_filters(filters)
+
+    pairs = store.similarity_search_with_score(query=query, k=k, filter=where)
+    return [
+        RetrievedRecord(
+            text=doc.page_content,
+            metadata=dict(doc.metadata or {}),
+            distance=float(score) if score is not None else None,
+        )
+        for doc, score in pairs
+    ]
+
+
+def _reset_caches_for_tests() -> None:
+    """Drop the cached Chroma client so tests can swap stores mid-process."""
+    global _STORE
+    _STORE = None

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,22 @@
+# Runtime dependencies for the CBRE HITL call-intake agent.
+# Pinned for reproducibility; regenerated from a clean venv at submission
+# time per issue #31. Stub in issue #1 uses stdlib only — these pins are for
+# downstream issues that wire in LangGraph + the LLM/embedding stack.
+
+# Orchestration
+langgraph>=0.2.50,<0.4
+langgraph-checkpoint>=2.0.0,<3
+
+# LLM + structured output
+langchain-core>=0.3.0,<0.4
+langchain-openai>=0.2.0,<0.3
+pydantic>=2.7,<3
+
+# Retrieval / vector store
+langchain-chroma>=0.1.4,<0.3
+chromadb>=0.5.0,<1
+langchain-text-splitters>=0.3.0,<0.4
+
+# Utilities
+python-dotenv>=1.0,<2
+typing-extensions>=4.10,<5

--- a/tests/test_audit.py
+++ b/tests/test_audit.py
@@ -1,0 +1,99 @@
+"""Unit tests for `agent.data.audit`.
+
+Anchored on real findings:
+- TKT-2023-02756: was_reclassified=True (intake roof_leak → structural).
+- 988 total findings, 838 with at least one flag set, 150 audited-clean.
+
+If `evaluation/qa_audit_findings.json` is regenerated and the pinned
+ticket_ids move, swap them out.
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from agent.data import audit  # noqa: E402
+
+
+KNOWN_RECLASSIFIED_TID = "TKT-2023-02756"  # intake roof_leak → final structural
+NEVER_AUDITED_TID = "TKT-9999-99999"        # not in the audit file
+
+
+def test_lookup_known_reclassified():
+    f = audit.lookup(KNOWN_RECLASSIFIED_TID)
+    assert f is not None
+    assert f.was_reclassified is True
+    assert f.has_any_flag is True
+    assert "roof_leak" in (f.reclassification_note or "")
+
+
+def test_lookup_never_audited_returns_none():
+    assert audit.lookup(NEVER_AUDITED_TID) is None
+    assert audit.lookup(None) is None
+    assert audit.lookup("") is None
+
+
+def test_has_any_flag_true_when_any_set():
+    f = audit.lookup(KNOWN_RECLASSIFIED_TID)
+    assert f.has_any_flag is True
+
+
+def test_has_any_flag_false_for_audited_clean_record():
+    # Find a real audited-clean record from the dataset.
+    clean = [
+        f for f in audit._index().values()
+        if not f.has_any_flag
+    ]
+    assert len(clean) >= 1, "expected some audited-clean records"
+    sample = clean[0]
+    assert sample.was_over_escalated is False
+    assert sample.was_reclassified is False
+    assert sample.floor_was_wrong_at_intake is False
+    assert sample.has_any_flag is False
+
+
+def test_flagged_ticket_ids_excludes_audited_clean():
+    flagged = audit.flagged_ticket_ids()
+    all_audited = audit.all_audited_ticket_ids()
+    assert flagged.issubset(all_audited)
+    assert len(flagged) < len(all_audited), (
+        "expected some audited tickets to be clean (no flags)"
+    )
+    # Sanity: counts roughly match what the survey showed (988 total, ~838 flagged).
+    assert 800 < len(flagged) < 950
+    assert len(all_audited) == 988
+
+
+def test_flagged_set_includes_known_reclassified():
+    assert KNOWN_RECLASSIFIED_TID in audit.flagged_ticket_ids()
+
+
+def test_audit_findings_only_reference_real_tickets():
+    """Audit ticket_ids must all exist in operational/historical_records.json."""
+    import json
+    hist = json.loads(open("operational/historical_records.json").read())
+    hist_ids = {h["ticket_id"] for h in hist}
+    audit_ids = audit.all_audited_ticket_ids()
+    missing = audit_ids - hist_ids
+    assert not missing, f"audit references non-existent tickets: {sorted(missing)[:5]}"
+
+
+if __name__ == "__main__":
+    import inspect
+    tests = [(n, f) for n, f in inspect.getmembers(sys.modules[__name__])
+             if n.startswith("test_") and callable(f)]
+    failed = 0
+    for name, fn in tests:
+        try:
+            fn()
+            print(f"  PASS  {name}")
+        except AssertionError as e:
+            print(f"  FAIL  {name}: {e}")
+            failed += 1
+        except Exception as e:
+            print(f"  ERROR {name}: {type(e).__name__}: {e}")
+            failed += 1
+    print(f"\n{len(tests) - failed}/{len(tests)} passed")
+    sys.exit(1 if failed else 0)

--- a/tests/test_rag_build.py
+++ b/tests/test_rag_build.py
@@ -109,10 +109,25 @@ def test_metadata_carries_every_required_key():
         assert key in md, f"missing required metadata key {key!r}"
 
 
-def test_metadata_was_audit_flagged_is_false_placeholder():
-    # Issue #9 fills this in; #7's responsibility is just to allocate the field.
+def test_metadata_audit_fields_default_false_for_unaudited_record():
+    # The synthetic ticket_id "tkt_test_001" isn't in qa_audit_findings.json,
+    # so the audit lookup returns None and every audit boolean stays False.
     md = _format_metadata(_make_record())
     assert md["was_audit_flagged"] is False
+    assert md["audit_over_escalated"] is False
+    assert md["audit_reclassified"] is False
+    assert md["audit_floor_wrong"] is False
+
+
+def test_metadata_audit_fields_populated_for_known_flagged_ticket():
+    # TKT-2023-02756 was reclassified (intake roof_leak → final structural).
+    md = _format_metadata(_make_record(ticket_id="TKT-2023-02756"))
+    assert md["was_audit_flagged"] is True
+    assert md["audit_reclassified"] is True
+    # over-escalated and floor-wrong flags depend on the actual finding —
+    # we don't assert their exact values, just that they're proper booleans.
+    assert isinstance(md["audit_over_escalated"], bool)
+    assert isinstance(md["audit_floor_wrong"], bool)
 
 
 def test_metadata_drops_none_values_to_avoid_chroma_type_errors():

--- a/tests/test_rag_build.py
+++ b/tests/test_rag_build.py
@@ -1,0 +1,289 @@
+"""Unit + integration tests for `agent.rag.build_index`.
+
+Two layers:
+
+1. **Pure-function tests** — exercise the chunker / metadata projector
+   against synthetic records. No I/O, no embeddings, no API.
+
+2. **End-to-end build with FakeEmbeddings** — runs the real `build()`
+   against a `tmp_path` store and a deterministic embedding stub. Proves
+   the chroma persistence wiring works without spending a cent on
+   OpenAI calls. The full real build is validated manually as part of
+   the issue-#7 acceptance run (see PR notes).
+"""
+from __future__ import annotations
+
+import json
+import os
+import sys
+from pathlib import Path
+from typing import List
+
+# Suppress chromadb telemetry warnings under Python 3.14 (see build_index.py).
+os.environ.setdefault("ANONYMIZED_TELEMETRY", "False")
+import logging  # noqa: E402
+logging.getLogger("chromadb.telemetry.product.posthog").setLevel(logging.CRITICAL)
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from agent.rag import COLLECTION_NAME, METADATA_KEYS  # noqa: E402
+from agent.rag.build_index import (  # noqa: E402
+    MAX_DOC_CHARS,
+    _format_document_text,
+    _format_metadata,
+    _to_documents,
+    build,
+)
+
+
+# ─── Fixtures ──────────────────────────────────────────────────────────
+
+
+def _make_record(**overrides) -> dict:
+    base = {
+        "ticket_id": "tkt_test_001",
+        "call_recording_transcript": "Caller says the breakroom sink is leaking.",
+        "intake_notes": "kitchen sink leak floor 9",
+        "dispatch_notes": "vendor en route, ETA 30m",
+        "resolution_notes": "p-trap replaced, cleared blockage",
+        "intake_category": "PLUMBING",
+        "intake_subcategory": "pipe_leak",
+        "intake_risk_level": "MEDIUM",
+        "final_category": "PLUMBING",
+        "final_subcategory": "pipe_leak",
+        "final_risk_level": "MEDIUM",
+        "assigned_vendor_id": "v_001",
+        "building_type": "office",
+        "city": "Los Angeles",
+    }
+    base.update(overrides)
+    return base
+
+
+# ─── _format_document_text ─────────────────────────────────────────────
+
+
+def test_document_text_leads_with_caller_transcript():
+    text = _format_document_text(_make_record())
+    assert text.startswith("CALLER TRANSCRIPT:")
+    # Order: caller → intake → dispatch → resolution
+    pos_caller = text.find("CALLER TRANSCRIPT:")
+    pos_intake = text.find("INTAKE NOTES:")
+    pos_dispatch = text.find("DISPATCH NOTES:")
+    pos_resolution = text.find("RESOLUTION NOTES:")
+    assert pos_caller < pos_intake < pos_dispatch < pos_resolution
+
+
+def test_document_text_drops_empty_sections():
+    r = _make_record(dispatch_notes="", resolution_notes=None)
+    text = _format_document_text(r)
+    assert "DISPATCH NOTES:" not in text
+    assert "RESOLUTION NOTES:" not in text
+    # Caller + intake still present
+    assert "CALLER TRANSCRIPT:" in text and "INTAKE NOTES:" in text
+
+
+def test_document_text_truncates_oversized_records():
+    # Build a synthetic giant transcript well past MAX_DOC_CHARS.
+    huge = "x" * (MAX_DOC_CHARS + 5_000)
+    text = _format_document_text(_make_record(call_recording_transcript=huge))
+    assert len(text) == MAX_DOC_CHARS
+
+
+def test_document_text_empty_when_all_sections_blank():
+    r = _make_record(
+        call_recording_transcript="",
+        intake_notes="",
+        dispatch_notes="",
+        resolution_notes="",
+    )
+    assert _format_document_text(r) == ""
+
+
+# ─── _format_metadata ──────────────────────────────────────────────────
+
+
+def test_metadata_carries_every_required_key():
+    md = _format_metadata(_make_record())
+    for key in METADATA_KEYS:
+        assert key in md, f"missing required metadata key {key!r}"
+
+
+def test_metadata_was_audit_flagged_is_false_placeholder():
+    # Issue #9 fills this in; #7's responsibility is just to allocate the field.
+    md = _format_metadata(_make_record())
+    assert md["was_audit_flagged"] is False
+
+
+def test_metadata_drops_none_values_to_avoid_chroma_type_errors():
+    r = _make_record(assigned_vendor_id=None, city=None)
+    md = _format_metadata(r)
+    assert "assigned_vendor_id" not in md
+    assert "city" not in md
+    # Required keys that are present remain.
+    assert md["ticket_id"] == "tkt_test_001"
+
+
+def test_metadata_values_are_chroma_compatible_primitives():
+    md = _format_metadata(_make_record())
+    for k, v in md.items():
+        assert isinstance(v, (str, int, float, bool)), (
+            f"metadata value for {k!r} is {type(v).__name__}, "
+            "chroma only accepts primitives"
+        )
+
+
+# ─── _to_documents ─────────────────────────────────────────────────────
+
+
+def test_to_documents_skips_records_with_no_text():
+    records = [
+        _make_record(ticket_id="tkt_001"),
+        _make_record(
+            ticket_id="tkt_002",
+            call_recording_transcript="",
+            intake_notes="",
+            dispatch_notes="",
+            resolution_notes="",
+        ),
+        _make_record(ticket_id="tkt_003"),
+    ]
+    docs = _to_documents(records)
+    assert len(docs) == 2
+    assert {d.metadata["ticket_id"] for d in docs} == {"tkt_001", "tkt_003"}
+
+
+def test_to_documents_preserves_record_order():
+    records = [_make_record(ticket_id=f"tkt_{i:03d}") for i in range(5)]
+    docs = _to_documents(records)
+    assert [d.metadata["ticket_id"] for d in docs] == [
+        "tkt_000", "tkt_001", "tkt_002", "tkt_003", "tkt_004"
+    ]
+
+
+# ─── End-to-end build with FakeEmbeddings ──────────────────────────────
+
+
+class _FakeEmbeddings:
+    """Deterministic, zero-cost embedder for E2E tests.
+
+    Returns a fixed-length vector derived from a stable hash of the text
+    so semantic similarity is meaningless but identical inputs produce
+    identical vectors (good enough for shape / persistence assertions).
+    """
+
+    def __init__(self, dim: int = 64):
+        self.dim = dim
+
+    def _embed(self, text: str) -> List[float]:
+        import hashlib
+        h = hashlib.sha256(text.encode("utf-8")).digest()
+        # Stretch the 32-byte hash to `dim` floats in [-1, 1].
+        out: List[float] = []
+        i = 0
+        while len(out) < self.dim:
+            out.append((h[i % 32] / 127.5) - 1.0)
+            i += 1
+        return out
+
+    def embed_documents(self, texts: List[str]) -> List[List[float]]:
+        return [self._embed(t) for t in texts]
+
+    def embed_query(self, text: str) -> List[float]:
+        return self._embed(text)
+
+
+def test_e2e_build_creates_persistent_store_with_fake_embeddings(tmp_path):
+    """Build over the first 25 records, persist to tmp_path, reopen, sanity check."""
+    target = tmp_path / "chroma_store"
+    n = build(
+        force=True,
+        limit=25,
+        verbose=False,
+        embeddings=_FakeEmbeddings(),
+        store_dir=target,
+    )
+    assert n == 25
+    assert target.exists() and any(target.iterdir())
+
+    # Reopen the persisted store and confirm the doc count + metadata schema.
+    from langchain_chroma import Chroma
+
+    store = Chroma(
+        persist_directory=str(target),
+        collection_name=COLLECTION_NAME,
+        embedding_function=_FakeEmbeddings(),
+    )
+    persisted = store.get()
+    assert len(persisted["ids"]) == 25
+    # Pick a metadata row at random and assert every required key is there.
+    sample_md = persisted["metadatas"][0]
+    for key in METADATA_KEYS:
+        # was_audit_flagged is bool False — present even when filtered.
+        # Other keys may be dropped if None in source, but our test fixtures
+        # never have None for the canonical fields, so they should all stick.
+        assert key in sample_md, f"missing {key} in persisted metadata"
+
+
+def test_e2e_build_skips_when_store_exists_without_force(tmp_path):
+    target = tmp_path / "chroma_store"
+    # First build populates.
+    build(force=True, limit=5, verbose=False,
+          embeddings=_FakeEmbeddings(), store_dir=target)
+    assert target.exists()
+
+    # Second build without --force should no-op and return -1 (the negative
+    # return value is the stable contract — log message is incidental).
+    n = build(force=False, limit=5, verbose=False,
+              embeddings=_FakeEmbeddings(), store_dir=target)
+    assert n == -1
+
+
+def test_e2e_force_rebuild_replaces_store(tmp_path):
+    target = tmp_path / "chroma_store"
+    # First build with 5 records.
+    build(force=True, limit=5, verbose=False,
+          embeddings=_FakeEmbeddings(), store_dir=target)
+    # Force rebuild with 10 records.
+    n = build(force=True, limit=10, verbose=False,
+              embeddings=_FakeEmbeddings(), store_dir=target)
+    assert n == 10
+
+    from langchain_chroma import Chroma
+
+    store = Chroma(
+        persist_directory=str(target),
+        collection_name=COLLECTION_NAME,
+        embedding_function=_FakeEmbeddings(),
+    )
+    assert len(store.get()["ids"]) == 10  # not 15 — old store was wiped
+
+
+# ─── Inline runner so the file works with or without pytest ────────────
+
+
+if __name__ == "__main__":
+    import inspect, tempfile
+
+    tests = [
+        (n, f) for n, f in inspect.getmembers(sys.modules[__name__])
+        if n.startswith("test_") and callable(f)
+    ]
+    failed = 0
+    for name, fn in tests:
+        sig = inspect.signature(fn)
+        kwargs = {}
+        if "tmp_path" in sig.parameters:
+            # Each tmp_path is a fresh directory so tests stay isolated.
+            kwargs["tmp_path"] = Path(tempfile.mkdtemp(prefix=f"{name}_"))
+        try:
+            fn(**kwargs)
+            print(f"  PASS  {name}")
+        except AssertionError as e:
+            print(f"  FAIL  {name}: {e}")
+            failed += 1
+        except Exception as e:
+            print(f"  ERROR {name}: {type(e).__name__}: {e}")
+            failed += 1
+    print(f"\n{len(tests) - failed}/{len(tests)} passed")
+    sys.exit(1 if failed else 0)

--- a/tests/test_rag_retriever.py
+++ b/tests/test_rag_retriever.py
@@ -34,8 +34,14 @@ from agent.rag.retriever import (  # noqa: E402
     RetrievedRecord,
     _normalize_filters,
     _reset_caches_for_tests,
+    detect_label_conflict,
     retrieve,
 )
+
+
+def _record(**md) -> RetrievedRecord:
+    """Construct a RetrievedRecord with controlled metadata."""
+    return RetrievedRecord(text="(synthetic)", metadata=md, distance=0.0)
 
 
 # ─── Deterministic embedder identical to the one used in test_rag_build ──
@@ -229,6 +235,127 @@ def test_retrieved_record_convenience_accessors(tmp_path):
     assert h.intake_subcategory == h.metadata.get("intake_subcategory")
     assert h.final_subcategory == h.metadata.get("final_subcategory")
     assert h.assigned_vendor_id == h.metadata.get("assigned_vendor_id")
+
+
+# ─── corrected_* properties (audit-aware relabel) ──────────────────────────
+
+
+def test_corrected_subcategory_unflagged_returns_intake():
+    r = _record(
+        intake_category="PLUMBING", intake_subcategory="pipe_leak",
+        final_category="PLUMBING", final_subcategory="pipe_leak",
+        intake_risk_level="MEDIUM", final_risk_level="MEDIUM",
+        was_audit_flagged=False, audit_reclassified=False,
+        audit_over_escalated=False, audit_floor_wrong=False,
+    )
+    assert r.corrected_subcategory == "pipe_leak"
+    assert r.corrected_category == "PLUMBING"
+    assert r.corrected_risk_level == "MEDIUM"
+
+
+def test_corrected_subcategory_reclassified_returns_final():
+    # The TKT-2023-02756 case: intake roof_leak was actually structural.
+    r = _record(
+        intake_category="PLUMBING", intake_subcategory="roof_leak",
+        final_category="LIFE_SAFETY", final_subcategory="structural",
+        intake_risk_level="MEDIUM", final_risk_level="HIGH",
+        was_audit_flagged=True, audit_reclassified=True,
+        audit_over_escalated=False, audit_floor_wrong=False,
+    )
+    # Subcategory + category get the corrected (final) values.
+    assert r.corrected_subcategory == "structural"
+    assert r.corrected_category == "LIFE_SAFETY"
+    # Risk level NOT corrected — the over-escalated flag isn't set; the
+    # auditor agreed with MEDIUM as the right risk band.
+    assert r.corrected_risk_level == "MEDIUM"
+
+
+def test_corrected_risk_level_over_escalated_returns_final():
+    # Intake was HIGH but auditor confirmed it should have been LOW.
+    r = _record(
+        intake_subcategory="restroom_fixture", final_subcategory="restroom_fixture",
+        intake_risk_level="HIGH", final_risk_level="LOW",
+        was_audit_flagged=True, audit_over_escalated=True,
+        audit_reclassified=False, audit_floor_wrong=False,
+    )
+    assert r.corrected_risk_level == "LOW"
+    # Subcategory wasn't reclassified, so it stays.
+    assert r.corrected_subcategory == "restroom_fixture"
+
+
+def test_corrected_falls_back_to_intake_when_final_missing():
+    # Defensive: if a flagged record has no final_* (shouldn't happen in
+    # practice), the corrected_* properties should not return None silently.
+    r = _record(
+        intake_subcategory="pipe_leak",
+        was_audit_flagged=True, audit_reclassified=True,
+    )
+    assert r.corrected_subcategory == "pipe_leak"
+
+
+def test_audit_flag_accessors_default_false():
+    r = _record(intake_subcategory="pipe_leak")
+    assert r.is_audit_flagged is False
+    assert r.was_reclassified is False
+    assert r.was_over_escalated is False
+
+
+# ─── detect_label_conflict ────────────────────────────────────────────────
+
+
+def test_detect_label_conflict_returns_none_on_unanimous():
+    records = [
+        _record(intake_subcategory="pipe_leak"),
+        _record(intake_subcategory="pipe_leak"),
+        _record(intake_subcategory="pipe_leak"),
+    ]
+    assert detect_label_conflict(records) is None
+
+
+def test_detect_label_conflict_returns_none_on_empty():
+    assert detect_label_conflict([]) is None
+
+
+def test_detect_label_conflict_returns_none_with_single_record():
+    assert detect_label_conflict([_record(intake_subcategory="pipe_leak")]) is None
+
+
+def test_detect_label_conflict_surfaces_split():
+    records = [
+        _record(intake_subcategory="pipe_leak"),
+        _record(intake_subcategory="pipe_leak"),
+        _record(intake_subcategory="pipe_leak"),
+        _record(intake_subcategory="drainage_backup"),
+        _record(intake_subcategory="drainage_backup"),
+    ]
+    out = detect_label_conflict(records)
+    assert out is not None
+    assert out["conflict"] is True
+    assert out["consensus"] == "pipe_leak"
+    assert out["consensus_share"] == 0.6
+    assert out["labels"] == {"pipe_leak": 3, "drainage_backup": 2}
+    assert out["n_records"] == 5
+    assert out["use_corrected"] is True
+
+
+def test_detect_label_conflict_uses_corrected_by_default():
+    # Two records: one unflagged (intake_subcategory == final), one with
+    # was_reclassified pointing to a different final_subcategory. With
+    # use_corrected=True the records *agree* on the corrected label
+    # (same final_subcategory); use_corrected=False sees them disagree.
+    records = [
+        _record(intake_subcategory="structural", final_subcategory="structural",
+                was_audit_flagged=False, audit_reclassified=False),
+        _record(intake_subcategory="roof_leak", final_subcategory="structural",
+                was_audit_flagged=True, audit_reclassified=True),
+    ]
+    # use_corrected=True: both → "structural" → no conflict
+    assert detect_label_conflict(records, use_corrected=True) is None
+    # use_corrected=False: roof_leak vs structural → conflict
+    raw = detect_label_conflict(records, use_corrected=False)
+    assert raw is not None
+    assert raw["use_corrected"] is False
+    assert set(raw["labels"]) == {"roof_leak", "structural"}
 
 
 # ─── Inline runner ─────────────────────────────────────────────────────────

--- a/tests/test_rag_retriever.py
+++ b/tests/test_rag_retriever.py
@@ -1,0 +1,260 @@
+"""Tests for `agent.rag.retriever`.
+
+Strategy: build a tiny chroma store at `tmp_path` with `_FakeEmbeddings`
+and the first ~50 historical records, then exercise `retrieve()` against
+it. FakeEmbeddings means semantic quality of results is meaningless — we
+assert structural properties (k bound, filter pass-through, schema of the
+returned `RetrievedRecord`s, error handling). Real semantic retrieval is
+validated end-to-end in the issue-#7 acceptance run.
+
+The "3 representative queries" smoke test from the AC is implemented as
+three filter scenarios (no filter / single-field / compound), since the
+queries themselves can't usefully differ when the embedder is a hash
+function.
+"""
+from __future__ import annotations
+
+import hashlib
+import os
+import sys
+from pathlib import Path
+from typing import List
+
+os.environ.setdefault("ANONYMIZED_TELEMETRY", "False")
+import logging  # noqa: E402
+logging.getLogger("chromadb.telemetry.product.posthog").setLevel(logging.CRITICAL)
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from agent.rag import COLLECTION_NAME  # noqa: E402
+from agent.rag.build_index import build  # noqa: E402
+from agent.rag.retriever import (  # noqa: E402
+    DEFAULT_K,
+    FILTERABLE_KEYS,
+    RetrievedRecord,
+    _normalize_filters,
+    _reset_caches_for_tests,
+    retrieve,
+)
+
+
+# ─── Deterministic embedder identical to the one used in test_rag_build ──
+
+
+class _FakeEmbeddings:
+    def __init__(self, dim: int = 64):
+        self.dim = dim
+
+    def _embed(self, text: str) -> List[float]:
+        h = hashlib.sha256(text.encode("utf-8")).digest()
+        out: List[float] = []
+        i = 0
+        while len(out) < self.dim:
+            out.append((h[i % 32] / 127.5) - 1.0)
+            i += 1
+        return out
+
+    def embed_documents(self, texts: List[str]) -> List[List[float]]:
+        return [self._embed(t) for t in texts]
+
+    def embed_query(self, text: str) -> List[float]:
+        return self._embed(text)
+
+
+# ─── Pure helpers ──────────────────────────────────────────────────────────
+
+
+def test_normalize_filters_passes_through_simple_equality():
+    assert _normalize_filters({"city": "Los Angeles"}) == {"city": "Los Angeles"}
+
+
+def test_normalize_filters_passes_through_operator_forms():
+    f = {"$and": [{"city": "LA"}, {"building_type": "office"}]}
+    assert _normalize_filters(f) == f
+
+
+def test_normalize_filters_returns_none_for_empty_input():
+    assert _normalize_filters(None) is None
+    assert _normalize_filters({}) is None
+
+
+def test_filterable_keys_match_metadata_schema():
+    # Drift guard: if METADATA_KEYS in agent/rag/__init__.py grows or
+    # shrinks, FILTERABLE_KEYS should track. was_audit_flagged is the
+    # only "currently False everywhere" key but it's still filterable.
+    from agent.rag import METADATA_KEYS
+    assert set(FILTERABLE_KEYS) == set(METADATA_KEYS)
+
+
+# ─── Validation ────────────────────────────────────────────────────────────
+
+
+def test_retrieve_rejects_empty_query(tmp_path):
+    target = tmp_path / "store"
+    build(force=True, limit=5, verbose=False,
+          embeddings=_FakeEmbeddings(), store_dir=target)
+    _reset_caches_for_tests()
+    try:
+        retrieve("", embeddings=_FakeEmbeddings(), store_dir=target)
+        raise AssertionError("expected ValueError on empty query")
+    except ValueError as e:
+        assert "non-empty" in str(e)
+
+
+def test_retrieve_rejects_non_positive_k(tmp_path):
+    target = tmp_path / "store"
+    build(force=True, limit=5, verbose=False,
+          embeddings=_FakeEmbeddings(), store_dir=target)
+    _reset_caches_for_tests()
+    try:
+        retrieve("anything", k=0, embeddings=_FakeEmbeddings(), store_dir=target)
+        raise AssertionError("expected ValueError on k=0")
+    except ValueError as e:
+        assert "k must be positive" in str(e)
+
+
+def test_retrieve_raises_when_store_not_built(tmp_path):
+    target = tmp_path / "nonexistent_store"
+    _reset_caches_for_tests()
+    try:
+        retrieve("anything", embeddings=_FakeEmbeddings(), store_dir=target)
+        raise AssertionError("expected RuntimeError on missing store")
+    except RuntimeError as e:
+        assert "build_index" in str(e)
+
+
+# ─── Core retrieval — the three representative scenarios ───────────────────
+
+
+def _setup_store(tmp_path):
+    target = tmp_path / "store"
+    build(force=True, limit=50, verbose=False,
+          embeddings=_FakeEmbeddings(), store_dir=target)
+    _reset_caches_for_tests()
+    return target
+
+
+def test_retrieve_no_filter_returns_k_records(tmp_path):
+    target = _setup_store(tmp_path)
+    hits = retrieve("water leak", k=5, embeddings=_FakeEmbeddings(), store_dir=target)
+    assert len(hits) == 5
+    for h in hits:
+        assert isinstance(h, RetrievedRecord)
+        assert h.text  # non-empty
+        assert h.metadata
+        assert h.distance is not None
+
+
+def test_retrieve_default_k_is_DEFAULT_K(tmp_path):
+    target = _setup_store(tmp_path)
+    hits = retrieve("anything", embeddings=_FakeEmbeddings(), store_dir=target)
+    assert len(hits) == DEFAULT_K
+
+
+def test_retrieve_with_city_filter_only_returns_matching(tmp_path):
+    target = _setup_store(tmp_path)
+    # Pick a city that's actually present in the first 50 records.
+    import json
+    raw = json.loads(open("operational/historical_records.json").read())[:50]
+    cities_present = {r["city"] for r in raw if r.get("city")}
+    target_city = next(iter(cities_present))
+
+    hits = retrieve(
+        "any query",
+        k=10,
+        filters={"city": target_city},
+        embeddings=_FakeEmbeddings(),
+        store_dir=target,
+    )
+    # Every hit must satisfy the filter.
+    assert len(hits) > 0
+    for h in hits:
+        assert h.metadata.get("city") == target_city
+
+
+def test_retrieve_with_compound_filter(tmp_path):
+    target = _setup_store(tmp_path)
+    # Build a compound filter we know matches at least one record.
+    import json, collections
+    raw = json.loads(open("operational/historical_records.json").read())[:50]
+    pairs = collections.Counter((r.get("building_type"), r.get("city")) for r in raw)
+    (bt, ct), n = pairs.most_common(1)[0]
+    assert n > 0
+
+    hits = retrieve(
+        "any query",
+        k=10,
+        filters={"$and": [{"building_type": bt}, {"city": ct}]},
+        embeddings=_FakeEmbeddings(),
+        store_dir=target,
+    )
+    for h in hits:
+        assert h.metadata.get("building_type") == bt
+        assert h.metadata.get("city") == ct
+
+
+def test_retrieve_returns_empty_when_filter_matches_nothing(tmp_path):
+    target = _setup_store(tmp_path)
+    hits = retrieve(
+        "any query",
+        filters={"city": "Atlantis"},
+        embeddings=_FakeEmbeddings(),
+        store_dir=target,
+    )
+    assert hits == []
+
+
+def test_retrieve_results_ordered_by_ascending_distance(tmp_path):
+    target = _setup_store(tmp_path)
+    hits = retrieve(
+        "any query",
+        k=10,
+        embeddings=_FakeEmbeddings(),
+        store_dir=target,
+    )
+    distances = [h.distance for h in hits]
+    assert distances == sorted(distances), (
+        f"results should be sorted nearest-first; got {distances}"
+    )
+
+
+def test_retrieved_record_convenience_accessors(tmp_path):
+    target = _setup_store(tmp_path)
+    hits = retrieve("any query", k=1,
+                    embeddings=_FakeEmbeddings(), store_dir=target)
+    h = hits[0]
+    # Convenience properties should mirror the underlying metadata dict.
+    assert h.ticket_id == h.metadata.get("ticket_id")
+    assert h.intake_category == h.metadata.get("intake_category")
+    assert h.intake_subcategory == h.metadata.get("intake_subcategory")
+    assert h.final_subcategory == h.metadata.get("final_subcategory")
+    assert h.assigned_vendor_id == h.metadata.get("assigned_vendor_id")
+
+
+# ─── Inline runner ─────────────────────────────────────────────────────────
+
+
+if __name__ == "__main__":
+    import inspect, tempfile
+
+    tests = [
+        (n, f) for n, f in inspect.getmembers(sys.modules[__name__])
+        if n.startswith("test_") and callable(f)
+    ]
+    failed = 0
+    for name, fn in tests:
+        sig = inspect.signature(fn)
+        kwargs = {}
+        if "tmp_path" in sig.parameters:
+            kwargs["tmp_path"] = Path(tempfile.mkdtemp(prefix=f"{name}_"))
+        try:
+            fn(**kwargs)
+            print(f"  PASS  {name}")
+        except AssertionError as e:
+            print(f"  FAIL  {name}: {e}")
+            failed += 1
+        except Exception as e:
+            print(f"  ERROR {name}: {type(e).__name__}: {e}")
+            failed += 1
+    print(f"\n{len(tests) - failed}/{len(tests)} passed")
+    sys.exit(1 if failed else 0)


### PR DESCRIPTION
Closes #9

## Summary

Audit findings (`evaluation/qa_audit_findings.json`, ~10% of the 10K corpus) flag tickets where intake got something wrong. Three flag types: `was_over_escalated` (intake risk too high), `was_reclassified` (subcategory miss), `floor_was_wrong_at_intake` (location miss). Without this integration the classifier prompt would learn from the bad intake labels every time retrieval surfaced a flagged record — actively degrading subcategory accuracy.

## Design choice on the AC's "deprioritize OR relabel" fork

I went with **relabel**. The deprioritize path would make flagged records less reachable, throwing away their high-signal caller language. Relabel preserves the record while exposing the QA-corrected labels via `corrected_*` properties on `RetrievedRecord`. The classifier prompt naturally consumes `subcategory` from retrieved records; surfacing `corrected_subcategory` (final on flagged, intake otherwise) fixes the problem without changing classifier code.

Real example from the data — `TKT-2023-02756`:

| | Intake | Final / Corrected |
|---|---|---|
| category | `PLUMBING` | **`LIFE_SAFETY`** |
| subcategory | `roof_leak` | **`structural`** |
| risk_level | `MEDIUM` | `MEDIUM` *(not corrected — `was_over_escalated` is False)* |

Without this PR, retrieval would have silently fed "roof_leak / PLUMBING / MEDIUM" to the classifier prompt. With it, the classifier learns the corrected `structural / LIFE_SAFETY` labels. Per-axis correction (subcategory only changes when `was_reclassified`; risk only when `was_over_escalated`) matches the audit data's actual structure.

## What landed

- **`agent/data/audit.py`** — typed loader for `qa_audit_findings.json`. `AuditFinding` dataclass with `has_any_flag` property (True iff any of the three specific flags is set; distinguishes "real problem caught" from "auditor reviewed and confirmed intake" — ~150/988 audits are reviewed-and-clean).
- **`agent/rag/__init__.py`** — `METADATA_KEYS` extended with `audit_over_escalated`, `audit_reclassified`, `audit_floor_wrong`. `was_audit_flagged` is True iff at least one specific flag is set.
- **`agent/rag/build_index.py`** — `_format_metadata` now joins `agent.data.audit` at build time. Records without a finding default every audit boolean to False.
- **`agent/rag/retriever.py`**:
  - `FILTERABLE_KEYS` extended in lockstep (the existing drift-guard test asserts `set` equality with `METADATA_KEYS`).
  - `RetrievedRecord` gains `is_audit_flagged`, `was_reclassified`, `was_over_escalated`, plus richer raw accessors and the `corrected_category` / `corrected_subcategory` / `corrected_risk_level` audit-aware view.
  - New free function `detect_label_conflict(records, use_corrected=True)` surfaces split subcategory labels across a retrieved set per the brief's "surface the conflict rather than silently picking the most frequent". Returns `None` on consensus or empty/single-record inputs.

## Validation evidence

| Layer | Tests | Result |
|---|---|---|
| Audit loader | 7 unit tests | 7/7 ✓ |
| Build (audit join) | 14 tests (+2 new) | 14/14 ✓ |
| Retriever (corrected_*, conflict) | 24 tests (+10 new) | 24/24 ✓ |
| **Real 10K rebuild** | wall time | 67.9s — same as #7 (~$0.02 again) |
| **Audit metadata counts at scale** | exact match to survey | 838 / 279 / 188 / 391 ✓ |
| **`corrected_subcategory` on real flagged ticket** | `TKT-2023-02756` | `intake=roof_leak → corrected=structural` ✓ |
| **`corrected_*` on unflagged records** | spot-check (3 records) | always equals `intake_*` (backwards-compat) ✓ |
| **Conflict detection on real query** | "toilet overflowing" k=5 | unanimous `restroom_fixture`, no false-positive conflict ✓ |

## Test plan

- [ ] `python tests/test_audit.py` reports 7/7 passing.
- [ ] `python tests/test_rag_build.py` reports 14/14 passing (includes the two new audit-flow tests).
- [ ] `python tests/test_rag_retriever.py` reports 24/24 passing (includes 10 new corrected_* / conflict tests).
- [ ] After pulling: `python -m agent.rag.build_index --force` once to refresh the chroma store with audit metadata. Verify `was_audit_flagged=True` count is around 838 via `retrieve("any", k=1000, filters={"was_audit_flagged": True})`.

## Notes for reviewer

- **Branch base is `issue-8`** — this PR depends on the retriever from #8. Merge order: `#1 → #3 → #7 → #8 → #9`.
- **Schema-migration story:** this commit changes chroma metadata. Anyone with an older store needs `python -m agent.rag.build_index --force` once after pulling. The metadata fields stamp in at build time — there's no runtime hot-reload path. Could add an in-place metadata update via chromadb's `update_metadata` later if rebuild cost becomes painful (it's $0.02 / 65s today, so not worth the complexity).
- **`was_audit_flagged: True` requires at least one *specific* flag set** — not just "the auditor reviewed this ticket". Otherwise we'd treat ~150 audited-clean records as suspect and the relabel logic would needlessly fire.
- **`detect_label_conflict` defaults to corrected labels** since the classifier should reason about consensus on the *correct* labels. The `use_corrected=False` toggle is for diagnostics ("what did intake think?"), not the production path.

## Backlog reference

Implements issue #9 in [`docs/PROJECT_BACKLOG.md`](docs/PROJECT_BACKLOG.md). Direct downstream consumer: #11 (classifier prompt builds on `corrected_subcategory` + `detect_label_conflict`).
