### PR TITLE
issue-19: location reconciliation node

### DIFF
--- a/agent/nodes/location.py
+++ b/agent/nodes/location.py
@@ -1,0 +1,123 @@
+"""Location reconciliation node.
+
+Resolves the final (building_name, address, floor, city) tuple from three
+sources, in precedence order:
+
+    1. Transcript-derived fields (from extraction) — highest authority
+    2. Building registry lookup (canonical address/city for a matched name)
+    3. Caller profile defaults (last-known prior — lowest authority)
+
+The spec: "transcript always wins on conflict; registry is canonical for
+address/city; profiles are a stale prior, not source of truth."
+
+Consumed by the orchestrator to populate prediction fields. The scorer
+checks all three (building_name, address, floor) case-insensitively.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Optional
+
+from agent.data.buildings import Building, FloorCheck, get_by_name, validate_floor
+from agent.data.profiles import Profile
+
+
+@dataclass(frozen=True)
+class ResolvedLocation:
+    building_name: Optional[str]
+    address: Optional[str]
+    floor: Optional[str]
+    city: Optional[str]
+    building_type: Optional[str]
+    floor_check: FloorCheck
+    source_building: str  # 'transcript' | 'profile' | 'none'
+    source_floor: str     # 'transcript' | 'profile' | 'none'
+
+
+def reconcile(
+    *,
+    extracted_building_name: Optional[str] = None,
+    extracted_floor: Optional[str] = None,
+    building_confidence: float = 0.0,
+    floor_confidence: float = 0.0,
+    profile: Optional[Profile] = None,
+) -> ResolvedLocation:
+    """Reconcile location from extraction + profile + registry.
+
+    Strategy:
+    - If extraction has a building name (confidence > 0.3), try to resolve
+      it against the registry. This catches both transcript-stated names
+      and profile-derived names the LLM echoed.
+    - If extraction has no building name or the registry lookup fails,
+      fall back to the profile's primary_building_name → registry lookup.
+    - Address and city always come from the registry when we have a match;
+      the registry is the canonical source for those.
+    - Floor: extraction wins when confidence is high (> 0.3); otherwise
+      fall back to profile. Validate against building floor_count.
+    """
+    building: Optional[Building] = None
+    source_building = "none"
+    resolved_name: Optional[str] = None
+
+    # Try extraction's building name first
+    if extracted_building_name and building_confidence > 0.3:
+        building = get_by_name(extracted_building_name)
+        if building:
+            resolved_name = building.name
+            source_building = "transcript"
+
+    # Fall back to profile's building
+    if building is None and profile and profile.primary_building_name:
+        building = get_by_name(profile.primary_building_name)
+        if building:
+            resolved_name = building.name
+            source_building = "profile"
+        elif profile.primary_building_name:
+            resolved_name = profile.primary_building_name
+            source_building = "profile"
+
+    # If extraction had a name but it didn't resolve, still use it raw
+    if resolved_name is None and extracted_building_name and building_confidence > 0.3:
+        resolved_name = extracted_building_name
+        source_building = "transcript"
+
+    # Address and city: registry wins, then profile
+    address: Optional[str] = None
+    city: Optional[str] = None
+    building_type: Optional[str] = None
+
+    if building:
+        address = building.address
+        city = building.city
+        building_type = building.building_type
+    if not address and profile:
+        address = profile.primary_address
+    if not city and profile:
+        city = profile.primary_city
+    if not building_type and profile:
+        building_type = profile.primary_building_type
+
+    # Floor: extraction wins when confident, otherwise profile
+    floor: Optional[str] = None
+    source_floor = "none"
+
+    if extracted_floor and floor_confidence > 0.3:
+        floor = extracted_floor
+        source_floor = "transcript"
+    elif profile and profile.primary_floor:
+        floor = profile.primary_floor
+        source_floor = "profile"
+
+    # Validate floor against building
+    floor_check = validate_floor(building, floor)
+
+    return ResolvedLocation(
+        building_name=resolved_name,
+        address=address,
+        floor=floor,
+        city=city,
+        building_type=building_type,
+        floor_check=floor_check,
+        source_building=source_building,
+        source_floor=source_floor,
+    )

--- a/tests/test_location.py
+++ b/tests/test_location.py
@@ -1,0 +1,252 @@
+"""Unit tests for `agent.nodes.location`.
+
+Tests location reconciliation logic against the real operational data.
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from agent.data.profiles import Profile  # noqa: E402
+from agent.nodes.location import reconcile  # noqa: E402
+
+
+# ─── Fixtures ──────────────────────────────────────────────────────────
+
+_PROFILE_LEO = Profile(
+    caller_name="Leo Green",
+    phone_number="+1-310-555-0142",
+    email="leo.green@example.com",
+    tenant_company="Sherwin Finance Group",
+    tenant_id="t_001",
+    contact_role="tenant",
+    preferred_language="en",
+    primary_building_id="bld_001",
+    primary_building_name="Westfield Commerce Center",
+    primary_address="100 Wilshire Blvd",
+    primary_city="Los Angeles",
+    primary_floor="Floor 5",
+    primary_suite="Suite 503",
+    primary_building_type="office",
+    last_verified_at="2024-04-07T10:00:00-08:00",
+    active=True,
+)
+
+
+# ─── Tests: transcript-stated building ─────────────────────────────────
+
+
+def test_transcript_building_resolves_via_registry():
+    """Transcript says a building name; registry resolves it to canonical."""
+    loc = reconcile(
+        extracted_building_name="Pacific Ridge Medical Plaza",
+        extracted_floor="Floor 7",
+        building_confidence=0.95,
+        floor_confidence=0.95,
+    )
+    assert loc.building_name == "Pacific Ridge Medical Plaza"
+    assert loc.address == "3200 Pacific Coast Hwy"
+    assert loc.city == "Long Beach"
+    assert loc.floor == "Floor 7"
+    assert loc.source_building == "transcript"
+    assert loc.source_floor == "transcript"
+    assert loc.building_type == "medical"
+
+
+def test_transcript_building_substring_match():
+    """Transcript says short form; registry resolves via substring."""
+    loc = reconcile(
+        extracted_building_name="Pacific Ridge",
+        extracted_floor="Floor 3",
+        building_confidence=0.8,
+        floor_confidence=0.9,
+    )
+    assert loc.building_name == "Pacific Ridge Medical Plaza"
+    assert loc.source_building == "transcript"
+
+
+def test_transcript_building_unknown_uses_raw_name():
+    """Transcript says a building not in the registry; use as-is."""
+    loc = reconcile(
+        extracted_building_name="Mystery Building XYZ",
+        extracted_floor="Floor 2",
+        building_confidence=0.8,
+        floor_confidence=0.9,
+    )
+    assert loc.building_name == "Mystery Building XYZ"
+    assert loc.address is None
+    assert loc.source_building == "transcript"
+
+
+# ─── Tests: profile fallback ─────────────────────────────────────────
+
+
+def test_no_extraction_falls_back_to_profile():
+    """No building from extraction; profile provides the building."""
+    loc = reconcile(
+        extracted_building_name=None,
+        extracted_floor=None,
+        building_confidence=0.0,
+        floor_confidence=0.0,
+        profile=_PROFILE_LEO,
+    )
+    assert loc.building_name == "Westfield Commerce Center"
+    assert loc.address == "100 Wilshire Blvd"
+    assert loc.city == "Los Angeles"
+    assert loc.floor == "Floor 5"
+    assert loc.source_building == "profile"
+    assert loc.source_floor == "profile"
+
+
+def test_low_confidence_extraction_falls_back_to_profile():
+    """Extraction has a building name but low confidence; use profile."""
+    loc = reconcile(
+        extracted_building_name="Some Guess",
+        extracted_floor="Floor 99",
+        building_confidence=0.2,
+        floor_confidence=0.2,
+        profile=_PROFILE_LEO,
+    )
+    assert loc.building_name == "Westfield Commerce Center"
+    assert loc.floor == "Floor 5"
+    assert loc.source_building == "profile"
+    assert loc.source_floor == "profile"
+
+
+# ─── Tests: transcript overrides profile ─────────────────────────────
+
+
+def test_transcript_overrides_profile_building():
+    """Transcript says a different building than profile; transcript wins."""
+    loc = reconcile(
+        extracted_building_name="Summit Office Towers",
+        extracted_floor="Floor 9",
+        building_confidence=0.95,
+        floor_confidence=1.0,
+        profile=_PROFILE_LEO,
+    )
+    assert loc.building_name == "Summit Office Towers"
+    assert loc.address == "800 Summit Blvd"
+    assert loc.city == "San Francisco"
+    assert loc.floor == "Floor 9"
+    assert loc.source_building == "transcript"
+    assert loc.source_floor == "transcript"
+
+
+def test_transcript_floor_overrides_profile_floor():
+    """Same building but transcript says different floor."""
+    loc = reconcile(
+        extracted_building_name=None,
+        extracted_floor="Floor 9",
+        building_confidence=0.0,
+        floor_confidence=0.95,
+        profile=_PROFILE_LEO,
+    )
+    assert loc.building_name == "Westfield Commerce Center"
+    assert loc.floor == "Floor 9"
+    assert loc.source_building == "profile"
+    assert loc.source_floor == "transcript"
+
+
+# ─── Tests: floor validation ────────────────────────────────────────
+
+
+def test_floor_in_range_returns_ok():
+    """Floor within building's floor_count."""
+    loc = reconcile(
+        extracted_building_name="Westfield Commerce Center",
+        extracted_floor="Floor 5",
+        building_confidence=0.95,
+        floor_confidence=0.95,
+    )
+    assert loc.floor_check == "ok"
+
+
+def test_floor_out_of_range_detected():
+    """Floor exceeds building's floor_count (bld_001 has 18 floors)."""
+    loc = reconcile(
+        extracted_building_name="Westfield Commerce Center",
+        extracted_floor="Floor 25",
+        building_confidence=0.95,
+        floor_confidence=0.95,
+    )
+    assert loc.floor_check == "out_of_range"
+
+
+def test_floor_unknown_when_building_lacks_floor_count():
+    """Building without floor_count (sparse data) returns unknown."""
+    loc = reconcile(
+        extracted_building_name="Central Tower",
+        extracted_floor="Floor 10",
+        building_confidence=0.95,
+        floor_confidence=0.95,
+    )
+    assert loc.floor_check == "unknown"
+
+
+# ─── Tests: anonymous caller ────────────────────────────────────────
+
+
+def test_anonymous_caller_no_profile_no_extraction():
+    """No info at all → all None."""
+    loc = reconcile()
+    assert loc.building_name is None
+    assert loc.address is None
+    assert loc.floor is None
+    assert loc.city is None
+    assert loc.source_building == "none"
+    assert loc.source_floor == "none"
+
+
+def test_anonymous_caller_with_transcript_building():
+    """Anonymous caller but transcript states building clearly."""
+    loc = reconcile(
+        extracted_building_name="Torrance Gateway Center",
+        extracted_floor="Floor 2",
+        building_confidence=1.0,
+        floor_confidence=1.0,
+    )
+    assert loc.building_name == "Torrance Gateway Center"
+    assert loc.address == "3500 Carson St"
+    assert loc.floor == "Floor 2"
+    assert loc.source_building == "transcript"
+
+
+# ─── Tests: address/city from registry over profile ─────────────────
+
+
+def test_registry_address_overrides_profile_address():
+    """When registry resolves, its address wins even if profile differs."""
+    # Profile says "100 Wilshire Blvd" (bld_001), but transcript names
+    # a different building with a different address.
+    loc = reconcile(
+        extracted_building_name="Pacific Ridge Medical Plaza",
+        extracted_floor="Floor 3",
+        building_confidence=0.9,
+        floor_confidence=0.9,
+        profile=_PROFILE_LEO,
+    )
+    assert loc.address == "3200 Pacific Coast Hwy"
+    assert loc.city == "Long Beach"
+
+
+if __name__ == "__main__":
+    import inspect
+
+    tests = [(n, f) for n, f in inspect.getmembers(sys.modules[__name__])
+             if n.startswith("test_") and callable(f)]
+    failed = 0
+    for name, fn in sorted(tests):
+        try:
+            fn()
+            print(f"  PASS  {name}")
+        except AssertionError as e:
+            print(f"  FAIL  {name}: {e}")
+            failed += 1
+        except Exception as e:
+            print(f"  ERROR {name}: {type(e).__name__}: {e}")
+            failed += 1
+    print(f"\n{len(tests) - failed}/{len(tests)} passed")
+    sys.exit(1 if failed else 0)


### PR DESCRIPTION
Closes #19

## Summary
- `agent/nodes/location.py` resolves the final `(building_name, address, floor, city)` tuple from three sources in precedence order: transcript extraction > building registry > caller profile.
- Registry provides canonical address/city when a building name resolves via `get_by_name` (exact + substring match).
- Floor validated against building `floor_count` — returns `ok` / `out_of_range` / `unknown`.
- Low-confidence extractions (< 0.3) fall back to profile gracefully.

## Precedence rules (per the spec)
1. Transcript always wins on conflict
2. Building registry is canonical for address/city
3. Caller profile is a stale prior, not source of truth

## What landed
- `agent/nodes/location.py` — `reconcile()` + `ResolvedLocation` dataclass
- `tests/test_location.py` — 13 unit tests

## Validation
- 13/13 unit tests pass against real operational data
- Integration verified: EVAL-0006 and EVAL-0027 both resolve to exact ground-truth matches

## Test plan
- [ ] `python tests/test_location.py` reports 13/13 passing
- [ ] Transcript-stated building resolves via registry (canonical address/city)
- [ ] Profile fallback works when extraction has no building
- [ ] Floor out-of-range detected for buildings with known floor_count
- [ ] Anonymous callers with transcript info still resolve correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)