### PR TITLE
issue-20: subcategory → vendor_type derived mapping

### DIFF
--- a/agent/data/derived/subcategory_to_vendor_type.json
+++ b/agent/data/derived/subcategory_to_vendor_type.json
@@ -1,0 +1,110 @@
+{
+  "access_control": [
+    "access_control"
+  ],
+  "active_threat": [
+    "security"
+  ],
+  "air_quality": [
+    "hvac"
+  ],
+  "appliance_kitchen": [
+    "appliance_tech"
+  ],
+  "auto_door": [
+    "access_control"
+  ],
+  "carpet_floor": [
+    "janitorial"
+  ],
+  "controls_bms": [
+    "hvac"
+  ],
+  "door_mechanical": [
+    "facilities"
+  ],
+  "drainage_backup": [
+    "plumber"
+  ],
+  "entrapment": [
+    "elevator_service"
+  ],
+  "fire_smoke": [
+    "fire_life_safety"
+  ],
+  "gas_chemical": [
+    "fire_life_safety"
+  ],
+  "glass_damage": [
+    "glazier"
+  ],
+  "infestation": [
+    "pest_control"
+  ],
+  "landscaping": [
+    "grounds"
+  ],
+  "lighting": [
+    "facilities"
+  ],
+  "low_voltage_data": [
+    "low_voltage_tech"
+  ],
+  "malfunction": [
+    "elevator_service"
+  ],
+  "minor_issue": [
+    "elevator_service"
+  ],
+  "no_cooling": [
+    "hvac"
+  ],
+  "no_heating": [
+    "hvac"
+  ],
+  "panel_hazard": [
+    "electrician"
+  ],
+  "parking_lighting": [
+    "electrician"
+  ],
+  "pavement_damage": [
+    "exterior_maintenance"
+  ],
+  "pipe_leak": [
+    "plumber"
+  ],
+  "power_outage": [
+    "electrician"
+  ],
+  "refrigerant": [
+    "hvac"
+  ],
+  "restroom_fixture": [
+    "plumber"
+  ],
+  "restroom_supplies": [
+    "janitorial"
+  ],
+  "roof_leak": [
+    "roofer"
+  ],
+  "signage_fencing": [
+    "exterior_maintenance"
+  ],
+  "slip_trip": [
+    "janitorial"
+  ],
+  "structural": [
+    "fire_life_safety"
+  ],
+  "suspicious_person": [
+    "security"
+  ],
+  "unauthorized_access": [
+    "security"
+  ],
+  "waste_odor": [
+    "janitorial"
+  ]
+}

--- a/scripts/derive_vendor_map.py
+++ b/scripts/derive_vendor_map.py
@@ -1,0 +1,91 @@
+"""Derive the subcategory → vendor_type mapping from historical records.
+
+Each subcategory in the corpus maps to exactly one vendor_type at 100%
+frequency (no ambiguity). This script reads the 10K historicals, computes
+the mapping, and writes it to `agent/data/derived/subcategory_to_vendor_type.json`.
+
+The output format is `{subcategory: [vendor_type, ...]}` — a list to be
+forward-compatible with future subcategories that might need multiple
+vendor types. In practice every entry today is a single-element list.
+
+Run:
+    python scripts/derive_vendor_map.py
+    python scripts/derive_vendor_map.py --print-summary
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from collections import Counter, defaultdict
+from pathlib import Path
+from typing import Dict, List
+
+HISTORICAL_PATH = Path(__file__).resolve().parents[1] / "operational" / "historical_records.json"
+OUTPUT_PATH = Path(__file__).resolve().parents[1] / "agent" / "data" / "derived" / "subcategory_to_vendor_type.json"
+
+
+def derive(records: List[dict]) -> Dict[str, List[str]]:
+    """Compute subcategory → vendor_type(s) from historical assignments.
+
+    Uses `final_subcategory` and `assigned_vendor_type` — the on-site
+    authoritative fields, not intake.
+    """
+    subcat_to_vtypes: Dict[str, Counter] = defaultdict(Counter)
+    for r in records:
+        sub = r.get("final_subcategory")
+        vtype = r.get("assigned_vendor_type")
+        if sub and vtype:
+            subcat_to_vtypes[sub][vtype] += 1
+
+    result: Dict[str, List[str]] = {}
+    for sub in sorted(subcat_to_vtypes.keys()):
+        counts = subcat_to_vtypes[sub]
+        total = sum(counts.values())
+        # Include any vendor_type that handles >= 5% of this subcategory's tickets
+        qualifying = [vt for vt, c in counts.most_common() if c / total >= 0.05]
+        result[sub] = qualifying
+
+    return result
+
+
+def print_summary(mapping: Dict[str, List[str]], records: List[dict]) -> None:
+    subcat_to_vtypes: Dict[str, Counter] = defaultdict(Counter)
+    for r in records:
+        sub = r.get("final_subcategory")
+        vtype = r.get("assigned_vendor_type")
+        if sub and vtype:
+            subcat_to_vtypes[sub][vtype] += 1
+
+    print(f"{'Subcategory':<25} {'Vendor Type(s)':<30} {'N':>5}  {'%':>5}")
+    print("-" * 70)
+    for sub in sorted(mapping.keys()):
+        types = mapping[sub]
+        total = sum(subcat_to_vtypes[sub].values())
+        primary_count = subcat_to_vtypes[sub][types[0]]
+        pct = primary_count / total * 100
+        print(f"{sub:<25} {', '.join(types):<30} {total:>5}  {pct:>5.1f}%")
+    print(f"\n{len(mapping)} subcategories mapped.")
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description="Derive subcategory → vendor_type mapping")
+    ap.add_argument("--print-summary", action="store_true")
+    args = ap.parse_args()
+
+    records = json.loads(HISTORICAL_PATH.read_text())
+    mapping = derive(records)
+
+    OUTPUT_PATH.parent.mkdir(parents=True, exist_ok=True)
+    OUTPUT_PATH.write_text(json.dumps(mapping, indent=2, sort_keys=True) + "\n")
+    print(f"Wrote {len(mapping)} entries → {OUTPUT_PATH}")
+
+    if args.print_summary:
+        print()
+        print_summary(mapping, records)
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_vendor_map.py
+++ b/tests/test_vendor_map.py
@@ -1,0 +1,104 @@
+"""Tests for the derived subcategory → vendor_type mapping.
+
+Validates the committed JSON artifact and its integration with
+`agent.data.vendors.qualify()`.
+"""
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from agent.data import taxonomy  # noqa: E402
+from agent.data.vendors import qualify, _reset_caches_for_tests  # noqa: E402
+
+_MAP_PATH = Path(__file__).resolve().parents[1] / "agent" / "data" / "derived" / "subcategory_to_vendor_type.json"
+
+
+def test_map_file_exists():
+    assert _MAP_PATH.exists(), f"Derived map not found at {_MAP_PATH}"
+
+
+def test_map_covers_all_taxonomy_subcategories():
+    """Every subcategory in the canonical taxonomy has a vendor_type mapping."""
+    mapping = json.loads(_MAP_PATH.read_text())
+    all_subs = set(taxonomy.all_subcategories())
+    mapped_subs = set(mapping.keys())
+    missing = all_subs - mapped_subs
+    assert not missing, f"Subcategories missing from vendor map: {missing}"
+
+
+def test_map_values_are_nonempty_lists():
+    mapping = json.loads(_MAP_PATH.read_text())
+    for sub, types in mapping.items():
+        assert isinstance(types, list), f"{sub}: expected list, got {type(types)}"
+        assert len(types) >= 1, f"{sub}: vendor_type list is empty"
+
+
+def test_map_vendor_types_exist_in_catalog():
+    """Every vendor_type in the map has at least one vendor in the catalog."""
+    from agent.data.vendors import all_vendors
+    mapping = json.loads(_MAP_PATH.read_text())
+    catalog_types = {v.vendor_type for v in all_vendors()}
+    for sub, types in mapping.items():
+        for vt in types:
+            assert vt in catalog_types, (
+                f"{sub} maps to vendor_type={vt!r} which has no vendors in the catalog"
+            )
+
+
+def test_qualify_uses_loose_mapping_for_subcategory():
+    """qualify() returns vendors via the vendor_type mapping, not just specialties."""
+    _reset_caches_for_tests()
+    # pipe_leak → plumber vendor_type
+    results = qualify(subcategory="pipe_leak")
+    assert len(results) > 0
+    assert all(v.vendor_type == "plumber" for v in results)
+
+
+def test_qualify_fire_smoke_returns_fire_life_safety():
+    _reset_caches_for_tests()
+    results = qualify(subcategory="fire_smoke")
+    assert len(results) > 0
+    assert all(v.vendor_type == "fire_life_safety" for v in results)
+
+
+def test_qualify_lighting_returns_facilities():
+    _reset_caches_for_tests()
+    results = qualify(subcategory="lighting")
+    assert len(results) > 0
+    assert all(v.vendor_type == "facilities" for v in results)
+
+
+def test_known_mappings_spot_check():
+    """Spot-check a few well-known mappings."""
+    mapping = json.loads(_MAP_PATH.read_text())
+    assert mapping["pipe_leak"] == ["plumber"]
+    assert mapping["fire_smoke"] == ["fire_life_safety"]
+    assert mapping["malfunction"] == ["elevator_service"]
+    assert mapping["air_quality"] == ["hvac"]
+    assert mapping["waste_odor"] == ["janitorial"]
+    assert mapping["active_threat"] == ["security"]
+    assert mapping["roof_leak"] == ["roofer"]
+
+
+if __name__ == "__main__":
+    import inspect
+
+    tests = [(n, f) for n, f in inspect.getmembers(sys.modules[__name__])
+             if n.startswith("test_") and callable(f)]
+    failed = 0
+    for name, fn in sorted(tests):
+        try:
+            fn()
+            print(f"  PASS  {name}")
+        except AssertionError as e:
+            print(f"  FAIL  {name}: {e}")
+            failed += 1
+        except Exception as e:
+            print(f"  ERROR {name}: {type(e).__name__}: {e}")
+            failed += 1
+    print(f"\n{len(tests) - failed}/{len(tests)} passed")
+    sys.exit(1 if failed else 0)


### PR DESCRIPTION
Closes #20

## Summary
- Derives a 1:1 mapping from each of the 36 subcategories to its vendor_type by analyzing `assigned_vendor_type` across 10K historical records.
- Every subcategory maps at 100% frequency to exactly one vendor_type — no ambiguity in the corpus.
- The committed JSON at `agent/data/derived/subcategory_to_vendor_type.json` is consumed by `agent.data.vendors.qualify()` as the loose-mapping fallback (the hook was already wired in issue #6).

## What landed
- `agent/data/derived/subcategory_to_vendor_type.json` — 36-entry mapping
- `scripts/derive_vendor_map.py` — derivation script (idempotent, < 1s)
- `tests/test_vendor_map.py` — 8 tests

## Key mappings (sample)
| Subcategory | Vendor Type |
|---|---|
| pipe_leak | plumber |
| fire_smoke | fire_life_safety |
| malfunction | elevator_service |
| air_quality | hvac |
| waste_odor | janitorial |
| active_threat | security |
| roof_leak | roofer |

## Validation
- 8/8 tests pass
- Drift guard: every taxonomy subcategory has a mapping entry
- Integration verified: `qualify(subcategory="pipe_leak")` now returns plumber vendors via the loose mapping

## Test plan
- [ ] `python tests/test_vendor_map.py` reports 8/8 passing
- [ ] `python scripts/derive_vendor_map.py --print-summary` prints the full table

🤖 Generated with [Claude Code](https://claude.com/claude-code)