### PR TITLE
feat: location reconciliation node (issue #19)

### DIFF
--- a/agent/nodes/location.py
+++ b/agent/nodes/location.py
@@ -5,10 +5,19 @@ sources, in precedence order:
 
     1. Transcript-derived fields (from extraction) — highest authority
     2. Building registry lookup (canonical address/city for a matched name)
-    3. Caller profile defaults (last-known prior — lowest authority)
+    3. Caller profile defaults — **only when the profile is active and not
+       stale**. An inactive (`active=False`) or stale profile
+       (`last_verified_at` older than `profiles.DEFAULT_STALE_DAYS`) is a
+       prior we do not trust; precedence falls through to the
+       anonymous-caller fallback (None) instead.
 
 The spec: "transcript always wins on conflict; registry is canonical for
 address/city; profiles are a stale prior, not source of truth."
+
+Floor sanity: a floor that resolves outside the building's `floor_count`
+is **not silently corrected**. The reported floor is kept verbatim and
+`needs_clarification` is set so the orchestrator asks the caller rather
+than guessing (e.g. "Floor 25 in an 18-floor building").
 
 Consumed by the orchestrator to populate prediction fields. The scorer
 checks all three (building_name, address, floor) case-insensitively.
@@ -16,8 +25,10 @@ checks all three (building_name, address, floor) case-insensitively.
 from __future__ import annotations
 
 from dataclasses import dataclass
+from datetime import datetime
 from typing import Optional
 
+from agent.data import profiles
 from agent.data.buildings import Building, FloorCheck, get_by_name, validate_floor
 from agent.data.profiles import Profile
 
@@ -32,6 +43,30 @@ class ResolvedLocation:
     floor_check: FloorCheck
     source_building: str  # 'transcript' | 'profile' | 'none'
     source_floor: str     # 'transcript' | 'profile' | 'none'
+    # True when the resolved floor is out of range for the building — the
+    # orchestrator must raise a clarification rather than dispatch on a
+    # floor we know is impossible. Defaulted so existing constructors
+    # (e.g. the orchestrator's exception fallback) stay valid.
+    needs_clarification: bool = False
+
+
+def _usable_profile(
+    profile: Optional[Profile], now: Optional[datetime]
+) -> Optional[Profile]:
+    """Return the profile only if it is active and not stale, else None.
+
+    Precedence per issue #19: caller profile is consulted *only* when
+    active and not stale; otherwise we fall through to the anonymous
+    fallback rather than trust a profile we can't date or that the
+    tenant has deactivated.
+    """
+    if profile is None:
+        return None
+    if not profile.active:
+        return None
+    if profiles.is_stale(profile, now=now):
+        return None
+    return profile
 
 
 def reconcile(
@@ -41,20 +76,30 @@ def reconcile(
     building_confidence: float = 0.0,
     floor_confidence: float = 0.0,
     profile: Optional[Profile] = None,
+    now: Optional[datetime] = None,
 ) -> ResolvedLocation:
     """Reconcile location from extraction + profile + registry.
 
     Strategy:
+    - The profile is first gated through `_usable_profile`: an inactive
+      or stale profile is dropped (treated as no profile at all).
     - If extraction has a building name (confidence > 0.3), try to resolve
       it against the registry. This catches both transcript-stated names
       and profile-derived names the LLM echoed.
     - If extraction has no building name or the registry lookup fails,
-      fall back to the profile's primary_building_name → registry lookup.
+      fall back to the (usable) profile's primary_building_name → registry.
     - Address and city always come from the registry when we have a match;
       the registry is the canonical source for those.
     - Floor: extraction wins when confidence is high (> 0.3); otherwise
-      fall back to profile. Validate against building floor_count.
+      fall back to the usable profile. Validate against floor_count; an
+      out-of-range floor sets `needs_clarification` (kept, not corrected).
+
+    Args:
+        now: reference time for the profile-staleness check. Defaults to
+            wall-clock now (production); tests pin it for determinism.
     """
+    profile = _usable_profile(profile, now)
+
     building: Optional[Building] = None
     source_building = "none"
     resolved_name: Optional[str] = None
@@ -108,8 +153,10 @@ def reconcile(
         floor = profile.primary_floor
         source_floor = "profile"
 
-    # Validate floor against building
+    # Validate floor against building. An out-of-range floor is kept
+    # verbatim (never silently corrected) but flags clarification.
     floor_check = validate_floor(building, floor)
+    needs_clarification = floor_check == "out_of_range"
 
     return ResolvedLocation(
         building_name=resolved_name,
@@ -120,4 +167,5 @@ def reconcile(
         floor_check=floor_check,
         source_building=source_building,
         source_floor=source_floor,
+        needs_clarification=needs_clarification,
     )

--- a/agent/nodes/location.py
+++ b/agent/nodes/location.py
@@ -1,0 +1,123 @@
+"""Location reconciliation node.
+
+Resolves the final (building_name, address, floor, city) tuple from three
+sources, in precedence order:
+
+    1. Transcript-derived fields (from extraction) — highest authority
+    2. Building registry lookup (canonical address/city for a matched name)
+    3. Caller profile defaults (last-known prior — lowest authority)
+
+The spec: "transcript always wins on conflict; registry is canonical for
+address/city; profiles are a stale prior, not source of truth."
+
+Consumed by the orchestrator to populate prediction fields. The scorer
+checks all three (building_name, address, floor) case-insensitively.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Optional
+
+from agent.data.buildings import Building, FloorCheck, get_by_name, validate_floor
+from agent.data.profiles import Profile
+
+
+@dataclass(frozen=True)
+class ResolvedLocation:
+    building_name: Optional[str]
+    address: Optional[str]
+    floor: Optional[str]
+    city: Optional[str]
+    building_type: Optional[str]
+    floor_check: FloorCheck
+    source_building: str  # 'transcript' | 'profile' | 'none'
+    source_floor: str     # 'transcript' | 'profile' | 'none'
+
+
+def reconcile(
+    *,
+    extracted_building_name: Optional[str] = None,
+    extracted_floor: Optional[str] = None,
+    building_confidence: float = 0.0,
+    floor_confidence: float = 0.0,
+    profile: Optional[Profile] = None,
+) -> ResolvedLocation:
+    """Reconcile location from extraction + profile + registry.
+
+    Strategy:
+    - If extraction has a building name (confidence > 0.3), try to resolve
+      it against the registry. This catches both transcript-stated names
+      and profile-derived names the LLM echoed.
+    - If extraction has no building name or the registry lookup fails,
+      fall back to the profile's primary_building_name → registry lookup.
+    - Address and city always come from the registry when we have a match;
+      the registry is the canonical source for those.
+    - Floor: extraction wins when confidence is high (> 0.3); otherwise
+      fall back to profile. Validate against building floor_count.
+    """
+    building: Optional[Building] = None
+    source_building = "none"
+    resolved_name: Optional[str] = None
+
+    # Try extraction's building name first
+    if extracted_building_name and building_confidence > 0.3:
+        building = get_by_name(extracted_building_name)
+        if building:
+            resolved_name = building.name
+            source_building = "transcript"
+
+    # Fall back to profile's building
+    if building is None and profile and profile.primary_building_name:
+        building = get_by_name(profile.primary_building_name)
+        if building:
+            resolved_name = building.name
+            source_building = "profile"
+        elif profile.primary_building_name:
+            resolved_name = profile.primary_building_name
+            source_building = "profile"
+
+    # If extraction had a name but it didn't resolve, still use it raw
+    if resolved_name is None and extracted_building_name and building_confidence > 0.3:
+        resolved_name = extracted_building_name
+        source_building = "transcript"
+
+    # Address and city: registry wins, then profile
+    address: Optional[str] = None
+    city: Optional[str] = None
+    building_type: Optional[str] = None
+
+    if building:
+        address = building.address
+        city = building.city
+        building_type = building.building_type
+    if not address and profile:
+        address = profile.primary_address
+    if not city and profile:
+        city = profile.primary_city
+    if not building_type and profile:
+        building_type = profile.primary_building_type
+
+    # Floor: extraction wins when confident, otherwise profile
+    floor: Optional[str] = None
+    source_floor = "none"
+
+    if extracted_floor and floor_confidence > 0.3:
+        floor = extracted_floor
+        source_floor = "transcript"
+    elif profile and profile.primary_floor:
+        floor = profile.primary_floor
+        source_floor = "profile"
+
+    # Validate floor against building
+    floor_check = validate_floor(building, floor)
+
+    return ResolvedLocation(
+        building_name=resolved_name,
+        address=address,
+        floor=floor,
+        city=city,
+        building_type=building_type,
+        floor_check=floor_check,
+        source_building=source_building,
+        source_floor=source_floor,
+    )

--- a/tests/test_location.py
+++ b/tests/test_location.py
@@ -1,0 +1,252 @@
+"""Unit tests for `agent.nodes.location`.
+
+Tests location reconciliation logic against the real operational data.
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from agent.data.profiles import Profile  # noqa: E402
+from agent.nodes.location import reconcile  # noqa: E402
+
+
+# ─── Fixtures ──────────────────────────────────────────────────────────
+
+_PROFILE_LEO = Profile(
+    caller_name="Leo Green",
+    phone_number="+1-310-555-0142",
+    email="leo.green@example.com",
+    tenant_company="Sherwin Finance Group",
+    tenant_id="t_001",
+    contact_role="tenant",
+    preferred_language="en",
+    primary_building_id="bld_001",
+    primary_building_name="Westfield Commerce Center",
+    primary_address="100 Wilshire Blvd",
+    primary_city="Los Angeles",
+    primary_floor="Floor 5",
+    primary_suite="Suite 503",
+    primary_building_type="office",
+    last_verified_at="2024-04-07T10:00:00-08:00",
+    active=True,
+)
+
+
+# ─── Tests: transcript-stated building ─────────────────────────────────
+
+
+def test_transcript_building_resolves_via_registry():
+    """Transcript says a building name; registry resolves it to canonical."""
+    loc = reconcile(
+        extracted_building_name="Pacific Ridge Medical Plaza",
+        extracted_floor="Floor 7",
+        building_confidence=0.95,
+        floor_confidence=0.95,
+    )
+    assert loc.building_name == "Pacific Ridge Medical Plaza"
+    assert loc.address == "3200 Pacific Coast Hwy"
+    assert loc.city == "Long Beach"
+    assert loc.floor == "Floor 7"
+    assert loc.source_building == "transcript"
+    assert loc.source_floor == "transcript"
+    assert loc.building_type == "medical"
+
+
+def test_transcript_building_substring_match():
+    """Transcript says short form; registry resolves via substring."""
+    loc = reconcile(
+        extracted_building_name="Pacific Ridge",
+        extracted_floor="Floor 3",
+        building_confidence=0.8,
+        floor_confidence=0.9,
+    )
+    assert loc.building_name == "Pacific Ridge Medical Plaza"
+    assert loc.source_building == "transcript"
+
+
+def test_transcript_building_unknown_uses_raw_name():
+    """Transcript says a building not in the registry; use as-is."""
+    loc = reconcile(
+        extracted_building_name="Mystery Building XYZ",
+        extracted_floor="Floor 2",
+        building_confidence=0.8,
+        floor_confidence=0.9,
+    )
+    assert loc.building_name == "Mystery Building XYZ"
+    assert loc.address is None
+    assert loc.source_building == "transcript"
+
+
+# ─── Tests: profile fallback ─────────────────────────────────────────
+
+
+def test_no_extraction_falls_back_to_profile():
+    """No building from extraction; profile provides the building."""
+    loc = reconcile(
+        extracted_building_name=None,
+        extracted_floor=None,
+        building_confidence=0.0,
+        floor_confidence=0.0,
+        profile=_PROFILE_LEO,
+    )
+    assert loc.building_name == "Westfield Commerce Center"
+    assert loc.address == "100 Wilshire Blvd"
+    assert loc.city == "Los Angeles"
+    assert loc.floor == "Floor 5"
+    assert loc.source_building == "profile"
+    assert loc.source_floor == "profile"
+
+
+def test_low_confidence_extraction_falls_back_to_profile():
+    """Extraction has a building name but low confidence; use profile."""
+    loc = reconcile(
+        extracted_building_name="Some Guess",
+        extracted_floor="Floor 99",
+        building_confidence=0.2,
+        floor_confidence=0.2,
+        profile=_PROFILE_LEO,
+    )
+    assert loc.building_name == "Westfield Commerce Center"
+    assert loc.floor == "Floor 5"
+    assert loc.source_building == "profile"
+    assert loc.source_floor == "profile"
+
+
+# ─── Tests: transcript overrides profile ─────────────────────────────
+
+
+def test_transcript_overrides_profile_building():
+    """Transcript says a different building than profile; transcript wins."""
+    loc = reconcile(
+        extracted_building_name="Summit Office Towers",
+        extracted_floor="Floor 9",
+        building_confidence=0.95,
+        floor_confidence=1.0,
+        profile=_PROFILE_LEO,
+    )
+    assert loc.building_name == "Summit Office Towers"
+    assert loc.address == "800 Summit Blvd"
+    assert loc.city == "San Francisco"
+    assert loc.floor == "Floor 9"
+    assert loc.source_building == "transcript"
+    assert loc.source_floor == "transcript"
+
+
+def test_transcript_floor_overrides_profile_floor():
+    """Same building but transcript says different floor."""
+    loc = reconcile(
+        extracted_building_name=None,
+        extracted_floor="Floor 9",
+        building_confidence=0.0,
+        floor_confidence=0.95,
+        profile=_PROFILE_LEO,
+    )
+    assert loc.building_name == "Westfield Commerce Center"
+    assert loc.floor == "Floor 9"
+    assert loc.source_building == "profile"
+    assert loc.source_floor == "transcript"
+
+
+# ─── Tests: floor validation ────────────────────────────────────────
+
+
+def test_floor_in_range_returns_ok():
+    """Floor within building's floor_count."""
+    loc = reconcile(
+        extracted_building_name="Westfield Commerce Center",
+        extracted_floor="Floor 5",
+        building_confidence=0.95,
+        floor_confidence=0.95,
+    )
+    assert loc.floor_check == "ok"
+
+
+def test_floor_out_of_range_detected():
+    """Floor exceeds building's floor_count (bld_001 has 18 floors)."""
+    loc = reconcile(
+        extracted_building_name="Westfield Commerce Center",
+        extracted_floor="Floor 25",
+        building_confidence=0.95,
+        floor_confidence=0.95,
+    )
+    assert loc.floor_check == "out_of_range"
+
+
+def test_floor_unknown_when_building_lacks_floor_count():
+    """Building without floor_count (sparse data) returns unknown."""
+    loc = reconcile(
+        extracted_building_name="Central Tower",
+        extracted_floor="Floor 10",
+        building_confidence=0.95,
+        floor_confidence=0.95,
+    )
+    assert loc.floor_check == "unknown"
+
+
+# ─── Tests: anonymous caller ────────────────────────────────────────
+
+
+def test_anonymous_caller_no_profile_no_extraction():
+    """No info at all → all None."""
+    loc = reconcile()
+    assert loc.building_name is None
+    assert loc.address is None
+    assert loc.floor is None
+    assert loc.city is None
+    assert loc.source_building == "none"
+    assert loc.source_floor == "none"
+
+
+def test_anonymous_caller_with_transcript_building():
+    """Anonymous caller but transcript states building clearly."""
+    loc = reconcile(
+        extracted_building_name="Torrance Gateway Center",
+        extracted_floor="Floor 2",
+        building_confidence=1.0,
+        floor_confidence=1.0,
+    )
+    assert loc.building_name == "Torrance Gateway Center"
+    assert loc.address == "3500 Carson St"
+    assert loc.floor == "Floor 2"
+    assert loc.source_building == "transcript"
+
+
+# ─── Tests: address/city from registry over profile ─────────────────
+
+
+def test_registry_address_overrides_profile_address():
+    """When registry resolves, its address wins even if profile differs."""
+    # Profile says "100 Wilshire Blvd" (bld_001), but transcript names
+    # a different building with a different address.
+    loc = reconcile(
+        extracted_building_name="Pacific Ridge Medical Plaza",
+        extracted_floor="Floor 3",
+        building_confidence=0.9,
+        floor_confidence=0.9,
+        profile=_PROFILE_LEO,
+    )
+    assert loc.address == "3200 Pacific Coast Hwy"
+    assert loc.city == "Long Beach"
+
+
+if __name__ == "__main__":
+    import inspect
+
+    tests = [(n, f) for n, f in inspect.getmembers(sys.modules[__name__])
+             if n.startswith("test_") and callable(f)]
+    failed = 0
+    for name, fn in sorted(tests):
+        try:
+            fn()
+            print(f"  PASS  {name}")
+        except AssertionError as e:
+            print(f"  FAIL  {name}: {e}")
+            failed += 1
+        except Exception as e:
+            print(f"  ERROR {name}: {type(e).__name__}: {e}")
+            failed += 1
+    print(f"\n{len(tests) - failed}/{len(tests)} passed")
+    sys.exit(1 if failed else 0)

--- a/tests/test_location.py
+++ b/tests/test_location.py
@@ -1,10 +1,16 @@
 """Unit tests for `agent.nodes.location`.
 
-Tests location reconciliation logic against the real operational data.
+Tests location reconciliation logic against the real operational data,
+including the profile active/stale gate and the out-of-range-floor
+clarification path (issue #19 ACs).
+
+`_NOW` pins the reference time so the staleness check is deterministic
+(issue #28) and the suite doesn't rot as wall-clock advances.
 """
 from __future__ import annotations
 
 import sys
+from datetime import datetime, timezone
 from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
@@ -14,6 +20,9 @@ from agent.nodes.location import reconcile  # noqa: E402
 
 
 # ─── Fixtures ──────────────────────────────────────────────────────────
+
+# Pinned reference "now" for deterministic staleness checks.
+_NOW = datetime(2025, 3, 5, tzinfo=timezone.utc)
 
 _PROFILE_LEO = Profile(
     caller_name="Leo Green",
@@ -30,9 +39,17 @@ _PROFILE_LEO = Profile(
     primary_floor="Floor 5",
     primary_suite="Suite 503",
     primary_building_type="office",
-    last_verified_at="2024-04-07T10:00:00-08:00",
+    last_verified_at="2025-01-15T10:00:00-08:00",  # ~49 days before _NOW → fresh
     active=True,
 )
+
+# Same profile, but verified years ago → stale relative to _NOW.
+_PROFILE_LEO_STALE = Profile(
+    **{**_PROFILE_LEO.__dict__, "last_verified_at": "2022-10-04T10:00:00-08:00"}
+)
+
+# Same profile, deactivated by the tenant.
+_PROFILE_LEO_INACTIVE = Profile(**{**_PROFILE_LEO.__dict__, "active": False})
 
 
 # ─── Tests: transcript-stated building ─────────────────────────────────
@@ -80,17 +97,18 @@ def test_transcript_building_unknown_uses_raw_name():
     assert loc.source_building == "transcript"
 
 
-# ─── Tests: profile fallback ─────────────────────────────────────────
+# ─── Tests: profile fallback (active + not stale) ────────────────────
 
 
 def test_no_extraction_falls_back_to_profile():
-    """No building from extraction; profile provides the building."""
+    """No building from extraction; a usable profile provides the building."""
     loc = reconcile(
         extracted_building_name=None,
         extracted_floor=None,
         building_confidence=0.0,
         floor_confidence=0.0,
         profile=_PROFILE_LEO,
+        now=_NOW,
     )
     assert loc.building_name == "Westfield Commerce Center"
     assert loc.address == "100 Wilshire Blvd"
@@ -108,11 +126,62 @@ def test_low_confidence_extraction_falls_back_to_profile():
         building_confidence=0.2,
         floor_confidence=0.2,
         profile=_PROFILE_LEO,
+        now=_NOW,
     )
     assert loc.building_name == "Westfield Commerce Center"
     assert loc.floor == "Floor 5"
     assert loc.source_building == "profile"
     assert loc.source_floor == "profile"
+
+
+# ─── Tests: profile active/stale gate (issue #19 AC) ─────────────────
+
+
+def test_inactive_profile_is_ignored():
+    """A deactivated profile is not trusted; precedence falls through to
+    the anonymous fallback (None)."""
+    loc = reconcile(
+        extracted_building_name=None,
+        extracted_floor=None,
+        profile=_PROFILE_LEO_INACTIVE,
+        now=_NOW,
+    )
+    assert loc.building_name is None
+    assert loc.floor is None
+    assert loc.source_building == "none"
+    assert loc.source_floor == "none"
+
+
+def test_stale_profile_is_ignored():
+    """A profile last verified years ago is stale → not used as a source."""
+    loc = reconcile(
+        extracted_building_name=None,
+        extracted_floor=None,
+        profile=_PROFILE_LEO_STALE,
+        now=_NOW,
+    )
+    assert loc.building_name is None
+    assert loc.address is None
+    assert loc.floor is None
+    assert loc.source_building == "none"
+    assert loc.source_floor == "none"
+
+
+def test_stale_profile_does_not_block_transcript():
+    """Even with a stale profile, an explicit transcript building still
+    resolves normally (transcript is independent of the profile gate)."""
+    loc = reconcile(
+        extracted_building_name="Pacific Ridge Medical Plaza",
+        extracted_floor="Floor 3",
+        building_confidence=0.95,
+        floor_confidence=0.95,
+        profile=_PROFILE_LEO_STALE,
+        now=_NOW,
+    )
+    assert loc.building_name == "Pacific Ridge Medical Plaza"
+    assert loc.source_building == "transcript"
+    # Address must come from the registry, NOT the stale profile.
+    assert loc.address == "3200 Pacific Coast Hwy"
 
 
 # ─── Tests: transcript overrides profile ─────────────────────────────
@@ -126,6 +195,7 @@ def test_transcript_overrides_profile_building():
         building_confidence=0.95,
         floor_confidence=1.0,
         profile=_PROFILE_LEO,
+        now=_NOW,
     )
     assert loc.building_name == "Summit Office Towers"
     assert loc.address == "800 Summit Blvd"
@@ -143,6 +213,7 @@ def test_transcript_floor_overrides_profile_floor():
         building_confidence=0.0,
         floor_confidence=0.95,
         profile=_PROFILE_LEO,
+        now=_NOW,
     )
     assert loc.building_name == "Westfield Commerce Center"
     assert loc.floor == "Floor 9"
@@ -150,10 +221,10 @@ def test_transcript_floor_overrides_profile_floor():
     assert loc.source_floor == "transcript"
 
 
-# ─── Tests: floor validation ────────────────────────────────────────
+# ─── Tests: floor validation + clarification ─────────────────────────
 
 
-def test_floor_in_range_returns_ok():
+def test_floor_in_range_returns_ok_no_clarification():
     """Floor within building's floor_count."""
     loc = reconcile(
         extracted_building_name="Westfield Commerce Center",
@@ -162,10 +233,13 @@ def test_floor_in_range_returns_ok():
         floor_confidence=0.95,
     )
     assert loc.floor_check == "ok"
+    assert loc.needs_clarification is False
 
 
-def test_floor_out_of_range_detected():
-    """Floor exceeds building's floor_count (bld_001 has 18 floors)."""
+def test_floor_out_of_range_sets_needs_clarification():
+    """Floor exceeds building's floor_count (bld_001 has 18 floors):
+    the floor is kept verbatim (not silently corrected) and
+    needs_clarification is raised."""
     loc = reconcile(
         extracted_building_name="Westfield Commerce Center",
         extracted_floor="Floor 25",
@@ -173,10 +247,13 @@ def test_floor_out_of_range_detected():
         floor_confidence=0.95,
     )
     assert loc.floor_check == "out_of_range"
+    assert loc.needs_clarification is True
+    assert loc.floor == "Floor 25"  # kept, NOT corrected
 
 
 def test_floor_unknown_when_building_lacks_floor_count():
-    """Building without floor_count (sparse data) returns unknown."""
+    """Building without floor_count (sparse data) returns unknown — and
+    unknown is not a clarification trigger (we can't prove it's wrong)."""
     loc = reconcile(
         extracted_building_name="Central Tower",
         extracted_floor="Floor 10",
@@ -184,6 +261,7 @@ def test_floor_unknown_when_building_lacks_floor_count():
         floor_confidence=0.95,
     )
     assert loc.floor_check == "unknown"
+    assert loc.needs_clarification is False
 
 
 # ─── Tests: anonymous caller ────────────────────────────────────────
@@ -198,6 +276,7 @@ def test_anonymous_caller_no_profile_no_extraction():
     assert loc.city is None
     assert loc.source_building == "none"
     assert loc.source_floor == "none"
+    assert loc.needs_clarification is False
 
 
 def test_anonymous_caller_with_transcript_building():
@@ -219,14 +298,13 @@ def test_anonymous_caller_with_transcript_building():
 
 def test_registry_address_overrides_profile_address():
     """When registry resolves, its address wins even if profile differs."""
-    # Profile says "100 Wilshire Blvd" (bld_001), but transcript names
-    # a different building with a different address.
     loc = reconcile(
         extracted_building_name="Pacific Ridge Medical Plaza",
         extracted_floor="Floor 3",
         building_confidence=0.9,
         floor_confidence=0.9,
         profile=_PROFILE_LEO,
+        now=_NOW,
     )
     assert loc.address == "3200 Pacific Coast Hwy"
     assert loc.city == "Long Beach"


### PR DESCRIPTION
## Summary
- Implements `agent/nodes/location.py` — reconciles building name, address, floor, and city from transcript extraction vs. caller profile
- Precedence: transcript (when confident) > building registry > caller profile
- Uses `agent/data/buildings.py` for registry lookups and floor validation

## Test plan
- [x] Unit tests in `tests/test_location.py` covering registry match, floor validation, confidence thresholds, profile fallback
- [x] All tests passing locally

Closes #19

🤖 Generated with [Claude Code](https://claude.com/claude-code)