### PR TITLE
feat: trainer_log assembly node (issue #23)

### DIFF
--- a/agent/nodes/trainer_log.py
+++ b/agent/nodes/trainer_log.py
@@ -1,0 +1,81 @@
+"""Trainer log assembly node.
+
+Runs as the final node of the graph on every call. Produces the
+supervised-training signal: a frozen snapshot of the AI's pre-override
+prediction, any human override, and the final decision.
+
+Output schema (matches scoring.py expectations):
+    {
+        "full_transcript": str,
+        "ai_prediction": { ... },
+        "human_override": None | { field: new_value, ... },
+        "final_decision": { ... }
+    }
+"""
+from __future__ import annotations
+
+from typing import Any, Dict, List, Optional
+
+
+def assemble_trainer_log(
+    *,
+    full_transcript: str,
+    ai_prediction: Dict[str, Any],
+    human_override: Optional[Dict[str, Any]] = None,
+    final_decision: Optional[Dict[str, Any]] = None,
+) -> Dict[str, Any]:
+    """Assemble the trainer log dict.
+
+    Args:
+        full_transcript: the raw transcript text.
+        ai_prediction: frozen snapshot of pre-validator AI outputs —
+            category, subcategory, risk_level, vendor, confidence,
+            validator_reasons, retrieved_record_ids, etc.
+        human_override: None if no override happened; otherwise a dict
+            of {field_name: overridden_value} for fields the reviewer changed.
+        final_decision: post-override result that becomes the top-level
+            prediction. If None (no override), uses ai_prediction.
+
+    Returns:
+        Complete trainer_log dict with all four required keys.
+    """
+    decision = final_decision if final_decision is not None else ai_prediction
+
+    return {
+        "full_transcript": full_transcript,
+        "ai_prediction": ai_prediction,
+        "human_override": human_override,
+        "final_decision": decision,
+    }
+
+
+def build_ai_prediction(
+    *,
+    category: Optional[str] = None,
+    subcategory: Optional[str] = None,
+    risk_level: Optional[str] = None,
+    dispatched_vendor_id: Optional[str] = None,
+    dispatched_emergency_services: bool = False,
+    needs_human_review: bool = False,
+    needs_clarification: bool = False,
+    confidence_category: Optional[float] = None,
+    confidence_subcategory: Optional[float] = None,
+    validator_reasons: Optional[List[str]] = None,
+    risk_reasons: Optional[List[str]] = None,
+    retrieved_record_ids: Optional[List[str]] = None,
+) -> Dict[str, Any]:
+    """Build the ai_prediction snapshot from node outputs."""
+    return {
+        "category": category,
+        "subcategory": subcategory,
+        "risk_level": risk_level,
+        "dispatched_vendor_id": dispatched_vendor_id,
+        "dispatched_emergency_services": dispatched_emergency_services,
+        "needs_human_review": needs_human_review,
+        "needs_clarification": needs_clarification,
+        "confidence_category": confidence_category,
+        "confidence_subcategory": confidence_subcategory,
+        "validator_reasons": validator_reasons or [],
+        "risk_reasons": risk_reasons or [],
+        "retrieved_record_ids": retrieved_record_ids or [],
+    }

--- a/tests/test_trainer_log.py
+++ b/tests/test_trainer_log.py
@@ -1,0 +1,134 @@
+"""Tests for `agent.nodes.trainer_log`.
+
+Validates trainer log assembly, schema conformance, and edge cases.
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from agent.nodes.trainer_log import assemble_trainer_log, build_ai_prediction  # noqa: E402
+
+
+def test_basic_assembly_has_all_keys():
+    """Assembled log must contain all four required keys."""
+    ai = build_ai_prediction(
+        category="PLUMBING",
+        subcategory="pipe_leak",
+        risk_level="MEDIUM",
+        dispatched_vendor_id="v_002",
+    )
+    log = assemble_trainer_log(
+        full_transcript="Caller reports a pipe leak on floor 3.",
+        ai_prediction=ai,
+    )
+    assert "full_transcript" in log
+    assert "ai_prediction" in log
+    assert "human_override" in log
+    assert "final_decision" in log
+
+
+def test_no_override_final_equals_ai():
+    """When no override, final_decision == ai_prediction."""
+    ai = build_ai_prediction(
+        category="HVAC",
+        subcategory="no_cooling",
+        risk_level="LOW",
+    )
+    log = assemble_trainer_log(
+        full_transcript="AC not working.",
+        ai_prediction=ai,
+    )
+    assert log["human_override"] is None
+    assert log["final_decision"] == log["ai_prediction"]
+
+
+def test_override_captured():
+    """When human overrides, final_decision reflects the override."""
+    ai = build_ai_prediction(
+        category="SECURITY",
+        subcategory="suspicious_person",
+        risk_level="HIGH",
+        needs_human_review=True,
+    )
+    override = {"risk_level": "MEDIUM", "needs_human_review": False}
+    final = {**ai, **override}
+
+    log = assemble_trainer_log(
+        full_transcript="Someone loitering in parking lot.",
+        ai_prediction=ai,
+        human_override=override,
+        final_decision=final,
+    )
+    assert log["human_override"] == override
+    assert log["final_decision"]["risk_level"] == "MEDIUM"
+    assert log["ai_prediction"]["risk_level"] == "HIGH"
+
+
+def test_full_transcript_preserved():
+    """full_transcript must be the exact string passed in."""
+    transcript = "This is a long transcript with special chars: é, ñ, 日本語"
+    ai = build_ai_prediction(category="OTHER", subcategory="minor_issue", risk_level="LOW")
+    log = assemble_trainer_log(full_transcript=transcript, ai_prediction=ai)
+    assert log["full_transcript"] == transcript
+
+
+def test_ai_prediction_snapshot_fields():
+    """ai_prediction contains all expected fields."""
+    ai = build_ai_prediction(
+        category="FIRE_LIFE_SAFETY",
+        subcategory="fire_smoke",
+        risk_level="EMERGENCY",
+        dispatched_vendor_id="v_021",
+        dispatched_emergency_services=True,
+        needs_human_review=True,
+        confidence_category=0.95,
+        confidence_subcategory=0.92,
+        validator_reasons=["emergency_band:always_pause"],
+        risk_reasons=["base_risk=EMERGENCY"],
+        retrieved_record_ids=["REC-001", "REC-002"],
+    )
+    assert ai["category"] == "FIRE_LIFE_SAFETY"
+    assert ai["dispatched_emergency_services"] is True
+    assert ai["confidence_category"] == 0.95
+    assert len(ai["retrieved_record_ids"]) == 2
+    assert ai["validator_reasons"] == ["emergency_band:always_pause"]
+
+
+def test_scoring_conformance():
+    """Log passes the scoring.py check: isinstance(dict) with full_transcript and final_decision."""
+    ai = build_ai_prediction(category="PLUMBING", subcategory="pipe_leak", risk_level="LOW")
+    log = assemble_trainer_log(full_transcript="Test.", ai_prediction=ai)
+    assert isinstance(log, dict)
+    assert "full_transcript" in log
+    assert "final_decision" in log
+
+
+def test_empty_transcript_still_valid():
+    """Even with empty transcript, structure is preserved."""
+    ai = build_ai_prediction(category="OTHER", subcategory="minor_issue", risk_level="LOW")
+    log = assemble_trainer_log(full_transcript="", ai_prediction=ai)
+    assert log["full_transcript"] == ""
+    assert isinstance(log["final_decision"], dict)
+
+
+if __name__ == "__main__":
+    import inspect
+
+    tests = [(n, f) for n, f in inspect.getmembers(sys.modules[__name__])
+             if n.startswith("test_") and callable(f)]
+    failed = 0
+    for name, fn in sorted(tests):
+        try:
+            fn()
+            print(f"  PASS  {name}")
+        except AssertionError as e:
+            print(f"  FAIL  {name}: {e}")
+            failed += 1
+        except Exception as e:
+            print(f"  ERROR {name}: {type(e).__name__}: {e}")
+            failed += 1
+    print(f"\n{len(tests) - failed}/{len(tests)} passed")
+    sys.exit(1 if failed else 0)


### PR DESCRIPTION
## Summary
- Implements `agent/nodes/trainer_log.py` — final graph node producing the supervised-training signal
- `assemble_trainer_log()` produces the required 4-key dict: `full_transcript`, `ai_prediction`, `human_override`, `final_decision`
- `build_ai_prediction()` helper freezes the pre-override AI state snapshot
- When no human override, `final_decision` defaults to `ai_prediction`

## Test plan
- [x] 7 unit tests: all keys present, no-override equals AI, override captured, transcript preserved, snapshot fields, scoring conformance, empty transcript edge case
- [x] All tests passing locally

Closes #23

🤖 Generated with [Claude Code](https://claude.com/claude-code)