### PR TITLE
feat: call_summary generator — operator-style narrative (issue #22)

### DIFF
--- a/agent/nodes/summary.py
+++ b/agent/nodes/summary.py
@@ -1,0 +1,133 @@
+"""Call summary generator — 2-3 sentence operator narrative.
+
+Produces a terse, factual, action-oriented summary suitable for
+shift handoff. No first-person, no LLM filler, no apologies.
+
+Style target: "Pipe leak reported at Pacific Ridge Medical Plaza,
+Floor 3. MEDIUM risk. Dispatched AquaFix Plumbing (v_002)."
+
+Length cap: ~280 characters. If an LLM-generated summary exceeds
+the cap, it gets truncated at the last sentence boundary under limit.
+"""
+from __future__ import annotations
+
+from typing import Optional
+
+
+_MAX_CHARS = 280
+
+_SUBCATEGORY_DESCRIPTIONS = {
+    "access_control": "access control issue",
+    "active_threat": "active threat",
+    "air_quality": "air quality concern",
+    "appliance_kitchen": "kitchen appliance issue",
+    "auto_door": "automatic door malfunction",
+    "carpet_floor": "carpet/flooring damage",
+    "controls_bms": "building controls issue",
+    "door_mechanical": "mechanical door issue",
+    "drainage_backup": "drainage backup",
+    "entrapment": "person trapped",
+    "fire_smoke": "fire/smoke detected",
+    "gas_chemical": "gas or chemical hazard",
+    "glass_damage": "glass damage",
+    "infestation": "pest infestation",
+    "landscaping": "landscaping issue",
+    "lighting": "lighting failure",
+    "low_voltage_data": "low-voltage/data issue",
+    "malfunction": "equipment malfunction",
+    "minor_issue": "minor maintenance issue",
+    "no_cooling": "no cooling",
+    "no_heating": "no heating",
+    "panel_hazard": "electrical panel hazard",
+    "parking_lighting": "parking area lighting issue",
+    "pavement_damage": "pavement damage",
+    "pipe_leak": "pipe leak",
+    "power_outage": "power outage",
+    "refrigerant": "refrigerant issue",
+    "restroom_fixture": "restroom fixture issue",
+    "restroom_supplies": "restroom supply issue",
+    "roof_leak": "roof leak",
+    "signage_fencing": "signage/fencing issue",
+    "slip_trip": "slip/trip hazard",
+    "structural": "structural concern",
+    "suspicious_person": "suspicious person reported",
+    "unauthorized_access": "unauthorized access",
+    "waste_odor": "waste/odor issue",
+}
+
+
+def generate_summary(
+    *,
+    subcategory: Optional[str] = None,
+    risk_level: Optional[str] = None,
+    building_name: Optional[str] = None,
+    floor: Optional[str] = None,
+    city: Optional[str] = None,
+    vendor_name: Optional[str] = None,
+    vendor_id: Optional[str] = None,
+    dispatched_emergency_services: bool = False,
+    needs_human_review: bool = False,
+    unroutable: bool = False,
+) -> str:
+    """Generate a 2-3 sentence operator-style call summary.
+
+    Returns:
+        Summary string, capped at ~280 characters.
+    """
+    problem = _SUBCATEGORY_DESCRIPTIONS.get(subcategory or "", subcategory or "maintenance issue")
+    problem = problem[0].upper() + problem[1:]
+
+    location_parts = []
+    if building_name:
+        location_parts.append(building_name)
+    if floor:
+        location_parts.append(floor)
+    if city and not building_name:
+        location_parts.append(city)
+
+    if location_parts:
+        sentence1 = f"{problem} reported at {', '.join(location_parts)}."
+    else:
+        sentence1 = f"{problem} reported."
+
+    sentence2 = f"{risk_level or 'MEDIUM'} risk."
+
+    if dispatched_emergency_services:
+        sentence3 = "Emergency services dispatched."
+    elif unroutable or (vendor_id is None and needs_human_review):
+        sentence3 = "Escalated to human review — no qualified vendor available."
+    elif needs_human_review:
+        if vendor_name:
+            sentence3 = f"Flagged for review. {vendor_name} dispatched pending approval."
+        else:
+            sentence3 = "Flagged for human review prior to dispatch."
+    elif vendor_name:
+        sentence3 = f"Dispatched {vendor_name}."
+    elif vendor_id:
+        sentence3 = f"Dispatched vendor {vendor_id}."
+    else:
+        sentence3 = "Routed for dispatch."
+
+    summary = f"{sentence1} {sentence2} {sentence3}"
+
+    if len(summary) > _MAX_CHARS:
+        summary = _truncate(summary)
+
+    return summary
+
+
+def _truncate(text: str) -> str:
+    """Truncate at last sentence boundary under the cap."""
+    if len(text) <= _MAX_CHARS:
+        return text
+    sentences = text.split(". ")
+    result = ""
+    for s in sentences:
+        candidate = f"{result}. {s}" if result else s
+        if not candidate.endswith("."):
+            candidate += "."
+        if len(candidate) <= _MAX_CHARS:
+            result = candidate.rstrip(".")
+        else:
+            break
+    return (result + ".") if result else text[:_MAX_CHARS]

--- a/tests/test_summary.py
+++ b/tests/test_summary.py
@@ -1,0 +1,167 @@
+"""Tests for `agent.nodes.summary`.
+
+Validates summary generation style, length, and content.
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from agent.nodes.summary import generate_summary, _MAX_CHARS  # noqa: E402
+
+
+# ─── Style and content tests ─────────────────────────────────────────
+
+
+def test_basic_summary_structure():
+    """Summary includes problem, location, risk, and action."""
+    s = generate_summary(
+        subcategory="pipe_leak",
+        risk_level="MEDIUM",
+        building_name="Pacific Ridge Medical Plaza",
+        floor="Floor 3",
+        vendor_name="AquaFix Plumbing",
+        vendor_id="v_002",
+    )
+    assert "Pipe leak" in s
+    assert "Pacific Ridge" in s
+    assert "Floor 3" in s
+    assert "MEDIUM risk" in s
+    assert "AquaFix Plumbing" in s
+
+
+def test_emergency_dispatch_summary():
+    """Emergency services dispatched note."""
+    s = generate_summary(
+        subcategory="fire_smoke",
+        risk_level="EMERGENCY",
+        building_name="One Commerce Center",
+        floor="Floor 7",
+        dispatched_emergency_services=True,
+    )
+    assert "Fire/smoke" in s
+    assert "Emergency services dispatched" in s
+    assert "EMERGENCY risk" in s
+
+
+def test_unroutable_escalation_summary():
+    """Unroutable case mentions escalation."""
+    s = generate_summary(
+        subcategory="pipe_leak",
+        risk_level="HIGH",
+        building_name="Metro Center Offices",
+        city="Burbank",
+        needs_human_review=True,
+        unroutable=True,
+    )
+    assert "Escalated" in s or "escalat" in s.lower()
+
+
+def test_flagged_for_review_with_vendor():
+    """Human review flagged but vendor pre-selected."""
+    s = generate_summary(
+        subcategory="unauthorized_access",
+        risk_level="HIGH",
+        building_name="Metro Center Offices",
+        floor="Floor 8",
+        vendor_name="SecureGuard Services",
+        vendor_id="v_026",
+        needs_human_review=True,
+    )
+    assert "review" in s.lower()
+    assert "SecureGuard" in s
+
+
+def test_no_first_person():
+    """Summary must not contain first-person language."""
+    s = generate_summary(
+        subcategory="door_mechanical",
+        risk_level="LOW",
+        building_name="Bayshore Commons",
+        floor="Floor 2",
+        vendor_name="DoorTech",
+        vendor_id="v_010",
+    )
+    assert " I " not in s
+    assert " we " not in s.lower()
+    assert "determined" not in s.lower()
+
+
+# ─── Length constraint ────────────────────────────────────────────────
+
+
+def test_length_under_cap():
+    """Summary must not exceed the 280-char cap."""
+    s = generate_summary(
+        subcategory="pipe_leak",
+        risk_level="MEDIUM",
+        building_name="The Very Long Building Name That Takes Up Many Characters International Plaza",
+        floor="Floor 27",
+        city="San Francisco",
+        vendor_name="AquaFix Professional Plumbing and Water Restoration Services LLC",
+        vendor_id="v_002",
+    )
+    assert len(s) <= _MAX_CHARS
+
+
+def test_minimum_length_for_scoring():
+    """Summary must be at least 30 chars to pass scoring.py."""
+    s = generate_summary(
+        subcategory="minor_issue",
+        risk_level="LOW",
+    )
+    assert len(s) >= 30
+
+
+# ─── Fixture summaries for manual review ─────────────────────────────
+
+
+def test_fixture_summaries_printable():
+    """Print 5 fixture summaries for manual style review."""
+    fixtures = [
+        dict(subcategory="pipe_leak", risk_level="MEDIUM",
+             building_name="Pacific Ridge Medical Plaza", floor="Floor 3",
+             vendor_name="AquaFix Plumbing", vendor_id="v_002"),
+        dict(subcategory="fire_smoke", risk_level="EMERGENCY",
+             building_name="One Commerce Center", floor="Floor 7",
+             city="Irvine", dispatched_emergency_services=True),
+        dict(subcategory="unauthorized_access", risk_level="HIGH",
+             building_name="Metro Center Offices", floor="Floor 8",
+             vendor_name="SecureGuard", vendor_id="v_026",
+             needs_human_review=True),
+        dict(subcategory="door_mechanical", risk_level="LOW",
+             building_name="Bayshore Commons", floor="Floor 2",
+             vendor_name="DoorTech Repairs", vendor_id="v_010"),
+        dict(subcategory="gas_chemical", risk_level="EMERGENCY",
+             building_name="Harbor Industrial Complex",
+             city="Long Beach", needs_human_review=True,
+             unroutable=True),
+    ]
+    for i, f in enumerate(fixtures, 1):
+        s = generate_summary(**f)
+        assert len(s) >= 30, f"Fixture {i} too short"
+        assert len(s) <= _MAX_CHARS, f"Fixture {i} exceeds cap"
+        # Print for manual review
+        print(f"  [{i}] ({len(s)} chars) {s}")
+
+
+if __name__ == "__main__":
+    import inspect
+
+    tests = [(n, f) for n, f in inspect.getmembers(sys.modules[__name__])
+             if n.startswith("test_") and callable(f)]
+    failed = 0
+    for name, fn in sorted(tests):
+        try:
+            fn()
+            print(f"  PASS  {name}")
+        except AssertionError as e:
+            print(f"  FAIL  {name}: {e}")
+            failed += 1
+        except Exception as e:
+            print(f"  ERROR {name}: {type(e).__name__}: {e}")
+            failed += 1
+    print(f"\n{len(tests) - failed}/{len(tests)} passed")
+    sys.exit(1 if failed else 0)


### PR DESCRIPTION
## Summary
- Implements `agent/nodes/summary.py` — deterministic 2-3 sentence operator-style call summary
- Includes: what's wrong, where, risk level, action taken (dispatch/escalate/review)
- No first-person, no LLM filler, no apologies
- 280-char cap with sentence-boundary truncation
- Subcategory → human-readable description mapping for all 36 subcategories

## Test plan
- [x] 8 tests: structure, emergency dispatch, unroutable escalation, review+vendor, no first-person, length cap, minimum scoring length, 5 fixture summaries for manual review
- [x] All tests passing locally
- [x] Fixture summaries reviewed for style match

Closes #22

🤖 Generated with [Claude Code](https://claude.com/claude-code)