### PR TITLE
issue-18: clarification policy and single-question node

### DIFF
--- a/agent/nodes/clarify.py
+++ b/agent/nodes/clarify.py
@@ -1,0 +1,193 @@
+"""Clarification policy and single-question generator.
+
+Decides whether the agent should ask one targeted clarifying question
+before committing to a routing decision. Returns
+`needs_clarification: bool` (consumed by the top-level prediction) plus
+a question string to surface in the call summary / reviewer payload.
+
+The trigger is a disjunction over four signals — fires conservatively
+to preserve the auto-resolution rate (10% rubric weight). Each signal
+was tuned against `true_needs_clarification` on the labeled dev set;
+the combination hits F1 ≥ 0.6.
+
+Signals (ANY one fires the gate):
+
+1. **Sparse caller** — first caller utterance ≤6 words AND total caller
+   speech across all turns ≤24 words. Distinguishes vague callers
+   (median 6 words first / 20 words total) from "hard" cases that
+   *also* start short but back-fill detail (median 5 / 29).
+
+2. **Generic opening phrase** — caller's first utterance matches
+   patterns like "there's an issue with X", "something's wrong with Y",
+   "the doors are being weird". These are category-name-as-symptom
+   and almost always signal an under-specified call.
+
+3. **Caller self-corrects on floor** — caller mentions multiple
+   different floor numbers in their own speech (typically
+   "Floor X ... I meant Floor Y"). This catches the location_conflict
+   case_type, where intake operators historically logged the wrong
+   floor before the caller corrected them. Beats a building-vs-
+   floor_count check on this corpus because the caller rarely names
+   the building explicitly when self-correcting.
+
+The clarification policy is the *second* line of human-attention
+triage, after the HITL gate (#15). HITL pauses for full reviewer
+judgement; clarification asks the *caller* one disambiguating question.
+Issue #16 wires both into the orchestrator.
+"""
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from typing import List, Optional, Tuple
+
+from agent.data import buildings, profiles
+from agent.nodes.classify import Classification
+from agent.nodes.extract import Extraction
+
+
+# Tuned thresholds (dev-set sweep, see PR notes).
+SPARSE_FIRST_TURN_WORDS = 6
+SPARSE_TOTAL_WORDS = 24
+
+# "Issue with X" patterns — caller uses category-level term as the
+# whole symptom rather than describing a specific failure.
+_GENERIC_OPENING_RX = re.compile(
+    r"(?:there'?s an issue with|something(?:'s| is)? wrong with|"
+    r"having (?:a |an )?problem(?:s)? with|"
+    r"(?:the|our|my) [a-z\s]+(?:'s| is)? (?:doing something|being weird|not working|off))",
+    re.IGNORECASE,
+)
+
+# Building-name-shaped tokens in caller text. CBRE buildings are
+# multi-token Title Case names ("Pacific Ridge Medical Plaza").
+_BUILDING_NAME_RX = re.compile(r"\b([A-Z][a-z]+(?:\s+[A-Z][a-z]+){1,4})\b")
+_FLOOR_NUM_RX = re.compile(r"floor\s+(\d+)", re.IGNORECASE)
+
+
+@dataclass(frozen=True)
+class ClarificationDecision:
+    needs_clarification: bool
+    question: Optional[str]
+    reasons: Tuple[str, ...]
+
+
+def _sparse_caller(turns: List[dict]) -> bool:
+    """True when the caller's contribution is unusually sparse —
+    short opener AND limited total speech across all turns."""
+    caller_turns = [t.get("text", "") for t in turns if t.get("speaker") == "caller"]
+    if not caller_turns:
+        return False
+    first_words = len(caller_turns[0].split())
+    total_words = sum(len(t.split()) for t in caller_turns)
+    return first_words <= SPARSE_FIRST_TURN_WORDS and total_words <= SPARSE_TOTAL_WORDS
+
+
+def _generic_opening(turns: List[dict]) -> bool:
+    """True when the caller's first utterance uses a generic 'issue with X'
+    style of opening rather than a specific symptom description."""
+    first = next((t.get("text", "") for t in turns if t.get("speaker") == "caller"), "")
+    return bool(_GENERIC_OPENING_RX.search(first))
+
+
+def _floor_self_correction(turns: List[dict]) -> Optional[Tuple[int, int]]:
+    """Detect the caller naming MULTIPLE distinct floor numbers in their
+    own speech. The location_conflict cases in the dev set follow a
+    "Floor X ... I meant Floor Y" pattern; multiple distinct floors
+    inside the caller's own utterances is a clean proxy.
+
+    Returns `(first_floor, corrected_floor)` or None.
+    """
+    seen: List[int] = []
+    for t in turns:
+        if t.get("speaker") != "caller":
+            continue
+        for m in _FLOOR_NUM_RX.findall(t.get("text", "")):
+            n = int(m)
+            if n not in seen:
+                seen.append(n)
+    if len(seen) >= 2:
+        return (seen[0], seen[1])
+    return None
+
+
+def _build_question(
+    *,
+    floor_correction: Optional[Tuple[int, int]],
+    is_sparse: bool,
+    is_generic: bool,
+) -> str:
+    """Pick the most useful single question. Priority: address the
+    most-resolvable ambiguity first."""
+    if floor_correction:
+        f1, f2 = floor_correction
+        return (
+            f"Just to confirm — is the issue on Floor {f1} or Floor {f2}?"
+        )
+    if is_sparse or is_generic:
+        return (
+            "Could you tell me a bit more about what's going wrong — for "
+            "example, what specifically isn't working and how long it's "
+            "been like that?"
+        )
+    return (
+        "Could you describe the issue in a bit more detail so I can route "
+        "it correctly?"
+    )
+
+
+def needs_clarification(
+    turns: List[dict],
+    extraction: Extraction,
+    classification: Classification,
+    *,
+    caller_phone: Optional[str] = None,
+) -> ClarificationDecision:
+    """Decide whether to ask one disambiguating question.
+
+    Args:
+        turns: the original turn list (the signals look at speaker
+            structure and word counts, not just the extracted fields).
+        extraction: structured fields from `agent.nodes.extract`.
+            Currently consumed only to surface in the question; future
+            iterations may use `extraction.confidence` as a fifth signal.
+        classification: classifier output (#11). Reserved for future use
+            in compounded-uncertainty detection.
+        caller_phone: phone number for profile-vs-transcript check.
+
+    Returns:
+        `ClarificationDecision(needs_clarification, question, reasons)`.
+        `reasons` is captured into trainer_log for inspectability.
+    """
+    reasons: List[str] = []
+
+    is_sparse = _sparse_caller(turns)
+    is_generic = _generic_opening(turns)
+    floor_correction = _floor_self_correction(turns)
+
+    if is_sparse:
+        reasons.append("sparse_caller:short_first_turn_and_low_total_speech")
+    if is_generic:
+        reasons.append("generic_opening:caller_used_category_as_symptom")
+    if floor_correction:
+        f1, f2 = floor_correction
+        reasons.append(
+            f"floor_self_correction:caller_said_floor_{f1}_then_floor_{f2}"
+        )
+
+    needs = bool(reasons)
+    question = (
+        _build_question(
+            floor_correction=floor_correction,
+            is_sparse=is_sparse,
+            is_generic=is_generic,
+        )
+        if needs
+        else None
+    )
+
+    return ClarificationDecision(
+        needs_clarification=needs,
+        question=question,
+        reasons=tuple(reasons),
+    )

--- a/tests/test_clarify.py
+++ b/tests/test_clarify.py
@@ -1,0 +1,251 @@
+"""Tests for `agent.nodes.clarify`.
+
+Three layers:
+1. Pure unit tests on each signal function.
+2. Integration tests on `needs_clarification()` over synthetic turn lists.
+3. Real-data tests on the dev set's three trigger patterns.
+"""
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT))
+
+from agent.nodes.classify import CategoryEnum, Classification, SubcategoryEnum  # noqa: E402
+from agent.nodes.clarify import (  # noqa: E402
+    SPARSE_FIRST_TURN_WORDS,
+    SPARSE_TOTAL_WORDS,
+    ClarificationDecision,
+    _floor_self_correction,
+    _generic_opening,
+    _sparse_caller,
+    needs_clarification,
+)
+from agent.nodes.extract import Extraction  # noqa: E402
+
+
+def _stub_extraction(**overrides) -> Extraction:
+    base = {
+        "problem_summary": "stub",
+        "building_name": "Stub Building",
+        "floor": "Floor 1",
+        "suite": "Suite 100",
+        "urgency_cues": [],
+        "caller_role": "tenant",
+        "language": "en",
+        "confidence": {
+            "problem_summary": 0.9, "building_name": 0.9,
+            "floor": 0.9, "suite": 0.9, "caller_role": 0.7,
+        },
+    }
+    base.update(overrides)
+    return Extraction(**base)
+
+
+def _stub_classification(**overrides) -> Classification:
+    return Classification(
+        category=overrides.get("category", CategoryEnum("PLUMBING")),
+        subcategory=overrides.get("subcategory", SubcategoryEnum("pipe_leak")),
+        confidence_category=overrides.get("confidence_category", 0.95),
+        confidence_subcategory=overrides.get("confidence_subcategory", 0.95),
+        reasoning="stub",
+    )
+
+
+# ─── _sparse_caller ─────────────────────────────────────────────────────
+
+
+def test_sparse_caller_fires_on_short_first_and_short_total():
+    turns = [
+        {"speaker": "agent", "text": "Hi, what's going on?"},
+        {"speaker": "caller", "text": "Lights are off."},  # 3 words
+        {"speaker": "agent", "text": "Where?"},
+        {"speaker": "caller", "text": "Floor 8 Suite 803."},  # 3 words; total 6
+    ]
+    assert _sparse_caller(turns) is True
+
+
+def test_sparse_caller_does_not_fire_when_total_speech_is_high():
+    turns = [
+        {"speaker": "caller", "text": "Lights are off."},  # 3 words (short)
+        {"speaker": "caller", "text": " ".join(["word"] * 30)},  # 30 words → total 33
+    ]
+    assert _sparse_caller(turns) is False
+
+
+def test_sparse_caller_does_not_fire_on_detailed_first_turn():
+    turns = [
+        {"speaker": "caller", "text": "Half the suite at Oakwood Corporate Campus on Floor 6 has no power."}
+    ]
+    assert _sparse_caller(turns) is False
+
+
+# ─── _generic_opening ───────────────────────────────────────────────────
+
+
+def test_generic_opening_catches_issue_with_pattern():
+    turns = [{"speaker": "caller", "text": "There's an issue with parking lighting."}]
+    assert _generic_opening(turns) is True
+
+
+def test_generic_opening_catches_being_weird_pattern():
+    turns = [{"speaker": "caller", "text": "The main doors are being weird."}]
+    assert _generic_opening(turns) is True
+
+
+def test_generic_opening_does_not_fire_on_specific_complaint():
+    turns = [{"speaker": "caller", "text": "Toilet clogged in restroom on Floor 4."}]
+    assert _generic_opening(turns) is False
+
+
+# ─── _floor_self_correction ────────────────────────────────────────────
+
+
+def test_floor_self_correction_catches_two_distinct_floors():
+    turns = [
+        {"speaker": "caller", "text": "Soap dispenser on Floor 8 is empty."},
+        {"speaker": "caller", "text": "Sorry, I meant Floor 2."},
+    ]
+    out = _floor_self_correction(turns)
+    assert out == (8, 2)
+
+
+def test_floor_self_correction_does_not_fire_on_single_floor():
+    turns = [{"speaker": "caller", "text": "Stuck on Floor 5, breaker tripped."}]
+    assert _floor_self_correction(turns) is None
+
+
+def test_floor_self_correction_ignores_agent_turns():
+    """Agent might mention different floors when probing — only caller's
+    own floor mentions count."""
+    turns = [
+        {"speaker": "agent", "text": "Are you on Floor 3 or Floor 4?"},
+        {"speaker": "caller", "text": "Floor 4."},
+    ]
+    assert _floor_self_correction(turns) is None
+
+
+def test_floor_self_correction_dedupes_repeat_mentions():
+    turns = [
+        {"speaker": "caller", "text": "Floor 7 has the leak."},
+        {"speaker": "caller", "text": "Yeah, Floor 7 again."},
+    ]
+    assert _floor_self_correction(turns) is None  # same floor mentioned twice
+
+
+# ─── Integration: needs_clarification ──────────────────────────────────
+
+
+def test_needs_clarification_fires_on_sparse_caller():
+    turns = [
+        {"speaker": "agent", "text": "How can I help?"},
+        {"speaker": "caller", "text": "Lights are off."},
+        {"speaker": "agent", "text": "Where?"},
+        {"speaker": "caller", "text": "Floor 8 Suite 803."},
+    ]
+    d = needs_clarification(turns, _stub_extraction(), _stub_classification())
+    assert d.needs_clarification is True
+    assert any("sparse_caller" in r for r in d.reasons)
+    assert d.question is not None
+
+
+def test_needs_clarification_fires_on_generic_opening():
+    turns = [
+        {"speaker": "caller", "text": "There's an issue with parking lighting."},
+        {"speaker": "caller", "text": "Lakeview Executive Suites, Floor 4, Suite 408."},
+    ]
+    d = needs_clarification(turns, _stub_extraction(), _stub_classification())
+    assert d.needs_clarification is True
+    assert any("generic_opening" in r for r in d.reasons)
+
+
+def test_needs_clarification_fires_on_floor_self_correction():
+    turns = [
+        {"speaker": "caller", "text": "Soap dispenser on Floor 8 is empty."},
+        {"speaker": "agent", "text": "Eastlake Medical Plaza only has 6 floors."},
+        {"speaker": "caller", "text": "Sorry, I meant Floor 2. I'm flustered."},
+    ]
+    d = needs_clarification(turns, _stub_extraction(), _stub_classification())
+    assert d.needs_clarification is True
+    assert any("floor_self_correction" in r for r in d.reasons)
+    assert "Floor 8" in d.question or "Floor 2" in d.question
+
+
+def test_needs_clarification_does_not_fire_on_clear_routine_call():
+    turns = [
+        {"speaker": "caller", "text":
+            "Half the suite at Oakwood Corporate Campus on Floor 6 in Suite 605 "
+            "has no power, and the breaker keeps tripping."}
+    ]
+    d = needs_clarification(turns, _stub_extraction(), _stub_classification())
+    assert d.needs_clarification is False
+    assert d.question is None
+
+
+def test_needs_clarification_returns_decision_dataclass():
+    turns = [{"speaker": "caller", "text": "Working fine."}]
+    d = needs_clarification(turns, _stub_extraction(), _stub_classification())
+    assert isinstance(d, ClarificationDecision)
+    assert isinstance(d.needs_clarification, bool)
+
+
+# ─── Real-data fixture tests ───────────────────────────────────────────
+
+
+def _load_dev(tid: str) -> dict:
+    rows = json.loads(open("evaluation/eval_transcripts_dev.json").read())
+    return next(r for r in rows if r["transcript_id"] == tid)
+
+
+def test_real_clarification_case_eval_0274_pauses():
+    """EVAL-0274 ('Lights are off.') is a true clarification case."""
+    row = _load_dev("EVAL-0274")
+    d = needs_clarification(row["turns"], _stub_extraction(),
+                             _stub_classification(),
+                             caller_phone=row["caller_phone"])
+    assert d.needs_clarification is True
+
+
+def test_real_location_conflict_case_eval_0668_pauses():
+    """EVAL-0668: caller says Floor 8 then corrects to Floor 2."""
+    row = _load_dev("EVAL-0668")
+    d = needs_clarification(row["turns"], _stub_extraction(),
+                             _stub_classification(),
+                             caller_phone=row["caller_phone"])
+    assert d.needs_clarification is True
+
+
+def test_real_normal_case_eval_0019_does_not_pause():
+    """EVAL-0019 is a routine power-outage call with a detailed first
+    utterance — should auto-resolve, not pause."""
+    row = _load_dev("EVAL-0019")
+    d = needs_clarification(row["turns"], _stub_extraction(),
+                             _stub_classification(),
+                             caller_phone=row["caller_phone"])
+    assert d.needs_clarification is False
+
+
+# ─── Inline runner ─────────────────────────────────────────────────────
+
+
+if __name__ == "__main__":
+    import inspect
+
+    tests = [(n, f) for n, f in inspect.getmembers(sys.modules[__name__])
+             if n.startswith("test_") and callable(f)]
+    failed = 0
+    for name, fn in tests:
+        try:
+            fn()
+            print(f"  PASS  {name}")
+        except AssertionError as e:
+            print(f"  FAIL  {name}: {e}")
+            failed += 1
+        except Exception as e:
+            print(f"  ERROR {name}: {type(e).__name__}: {e}")
+            failed += 1
+    print(f"\n{len(tests) - failed}/{len(tests)} passed")
+    sys.exit(1 if failed else 0)


### PR DESCRIPTION
Closes #18

## Summary

`agent/nodes/clarify.py` decides whether the agent should ask one targeted clarifying question before committing to a routing decision. Returns `needs_clarification: bool` (consumed by the top-level prediction) plus a question string for the reviewer payload.

The clarification policy is the *second* line of human-attention triage after the HITL gate (#15): HITL pauses for full reviewer judgement; clarification asks the **caller** themselves one disambiguating question.

## Trigger rule

Fires on **any** of three signals:

1. **Sparse caller** — first caller utterance ≤6 words AND total caller speech across all turns ≤24 words. Distinguishes vague callers (median 6/20 in dev) from "hard" cases that also start short but back-fill detail (median 5/29).

2. **Generic opening** — caller's first utterance matches `"there's an issue with X"`, `"the doors are being weird"`, `"[X] isn't working"` patterns. Catches category-name-as-symptom calls.

3. **Floor self-correction** — caller mentions multiple distinct floor numbers in their own speech (typically *"Floor X ... I meant Floor Y"*). Catches the `location_conflict` case_type cleanly.

## Single-question generator

Priority — address the most-resolvable ambiguity first:

| Trigger | Question |
|---|---|
| Floor correction | "Just to confirm — is the issue on Floor X or Floor Y?" |
| Sparse / generic | "Could you tell me a bit more about what's going wrong — what specifically isn't working and how long?" |

## What we tried + dropped

- **Profile-vs-transcript building mismatch**: precision 0.19 alone (too noisy from extraction / regex artifacts).
- **Floor-out-of-range against building registry**: 0 fires on dev because caller text doesn't include the building name in a regex-detectable shape during the conflict cases. Replaced with the self-correction signal — same intent, much cleaner detection.

## Validation

| Layer | Result |
|---|---|
| Pure unit tests on each signal | 10/10 ✓ |
| Integration tests on `needs_clarification()` | 5/5 ✓ |
| Real dev-fixture tests (EVAL-0274 clarification, EVAL-0668 location_conflict, EVAL-0019 routine) | 3/3 ✓ |
| **End-to-end F1 on full 200-row dev set** | **0.750** (target ≥ 0.6) |
| Precision | 0.675 |
| Recall | 0.844 |
| Confusion | TP=27 FP=13 TN=155 FN=5 |

## Test plan

- [ ] `python tests/test_clarify.py` reports 18/18.
- [ ] `python -c "from agent.nodes.clarify import needs_clarification; ..."` against EVAL-0668 returns `needs_clarification=True` with a floor-clarifying question.
- [ ] EVAL-0019 (routine detailed call) returns `needs_clarification=False`.

## Notes for reviewer

- **Branch base is `main`** — uses `agent/nodes/extract.py`, `agent/nodes/classify.py`, `agent/data/buildings.py`, and `agent/data/profiles.py` from already-merged PRs. Merge order: `... → #15 → #18`.
- **The 13 dev-set FPs** split across `normal` (over-broad generic-phrase matches) and `hard` (short opening followed by detailed clarification — sparse-caller over-triggers there). Tightening either signal pushed F1 below 0.7; current settings are the F1 maximum.
- **The dropped profile-mismatch signal** was the single biggest accuracy lift when removed — bumped F1 from 0.585 to 0.750 because it was firing on routine known-caller calls where the regex didn't match the canonical building name.

## Backlog reference

Implements issue #18 in [`docs/PROJECT_BACKLOG.md`](docs/PROJECT_BACKLOG.md). Direct downstream consumer: #16 (validator gate / orchestrator wires `needs_clarification` into the top-level prediction and uses the `question` for the reviewer payload).
