### PR TITLE
issue-2: schema-conformance test + CI gate

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,56 @@
+name: test
+
+# Runs the fast (no-LLM) test suite on every push and pull request.
+# The contract test (tests/test_contract.py) is the CI gate per issue #2:
+# any drift in the `classify()` output schema must fail loudly before merge.
+#
+# Real-LLM E2E tests (test_extract, test_classify) live in `make test-llm`
+# and are gated on a developer's local OPENAI_API_KEY — not run in CI to
+# keep PRs cheap and the API key out of the workflow scope.
+
+on:
+  push:
+    branches: ["**"]
+  pull_request:
+    branches: [main]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+          cache: "pip"
+          cache-dependency-path: requirements.txt
+
+      - name: Install runtime deps
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+
+      - name: Run schema-conformance canary (issue #2)
+        # This is the gate. A failure here means `classify()`'s output
+        # shape drifted from `evaluation.prediction.Prediction` —
+        # silent rubric breakage is the most likely consequence.
+        run: python tests/test_contract.py
+
+      - name: Run remaining fast tests (no API key required)
+        # These pass against the data files committed to the repo. Any
+        # that need real LLM calls are skipped via OPENAI_API_KEY guards
+        # already in the test files.
+        run: |
+          for f in tests/test_audit.py \
+                   tests/test_buildings.py \
+                   tests/test_clarify.py \
+                   tests/test_hitl.py \
+                   tests/test_profiles.py \
+                   tests/test_risk.py \
+                   tests/test_risk_assignment.py \
+                   tests/test_vendors.py; do
+            echo "=== $f ==="
+            python $f
+          done

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,36 @@
+.PHONY: help test test-contract test-fast test-llm install build-index lint
+
+PY ?= python3
+VENV ?= .venv
+VENV_PY := $(VENV)/bin/python
+
+help:  ## Show this help
+	@awk 'BEGIN {FS = ":.*##"; printf "Targets:\n"} /^[a-zA-Z_-]+:.*?##/ { printf "  %-18s %s\n", $$1, $$2 }' $(MAKEFILE_LIST)
+
+install:  ## Create .venv and install requirements
+	$(PY) -m venv $(VENV)
+	$(VENV_PY) -m pip install --upgrade pip
+	$(VENV_PY) -m pip install -r requirements.txt
+
+build-index:  ## Build the RAG vector index (issue #7)
+	$(VENV_PY) -m agent.rag.build_index
+
+test-contract:  ## Run the schema-conformance canary (issue #2). Required to pass on every commit.
+	$(VENV_PY) tests/test_contract.py
+
+test-fast:  ## Run every test that doesn't need OPENAI_API_KEY. Should be < 30s on a laptop.
+	@for f in tests/test_audit.py tests/test_buildings.py tests/test_clarify.py tests/test_contract.py \
+	          tests/test_hitl.py tests/test_profiles.py tests/test_risk.py tests/test_risk_assignment.py \
+	          tests/test_vendors.py; do \
+		echo "=== $$f ==="; $(VENV_PY) $$f || exit 1; \
+	done
+
+test-llm:  ## Run the real-OpenAI E2E tests. Requires OPENAI_API_KEY in .env.
+	@for f in tests/test_extract.py tests/test_classify.py; do \
+		echo "=== $$f ==="; $(VENV_PY) $$f || exit 1; \
+	done
+
+test: test-fast  ## Default `make test` runs the fast suite (CI gate). LLM tests via `make test-llm`.
+
+lint:  ## (placeholder) Add ruff / mypy here if/when adopted.
+	@echo "no linter configured yet"

--- a/tests/test_contract.py
+++ b/tests/test_contract.py
@@ -1,0 +1,321 @@
+"""Schema conformance test for `agent.classify:classify`.
+
+This is the canary that fires the moment any downstream node breaks the
+output contract — silent schema drift is the most common way to zero out
+the rubric (missing fields → wrong on the corresponding axis).
+
+Design intent (from issue #2):
+
+- Round-trip the agent's output through `evaluation.prediction.Prediction`
+  + `TrainerLog`. If a key is missing, mistyped, or out of the canonical
+  enum, instantiation raises and this test fails loudly.
+- Run in < 5s without hitting any LLM. The reference classify on main is
+  currently a stub (issue #1) so direct calls are deterministic and free.
+  Once the LLM-backed orchestrator (#56 / #24) lands, this test will need
+  to monkey-patch the chat client — at that point the conformance check
+  here becomes the gating CI test for the full pipeline.
+- At least 3 fixture transcripts (per AC). We use real dev transcripts
+  spanning anonymous + known callers, varying turn counts.
+
+The test is structurally independent of any specific node implementation
+— it asserts only what `evaluation.prediction.Prediction` enforces +
+the rubric's downstream expectations:
+
+  - all required fields present and typed correctly
+  - `risk_level` ∈ {LOW, MEDIUM, HIGH, EMERGENCY}
+  - `dispatched_emergency_services` is a `bool`, not a truthy non-bool
+  - `call_summary` is a non-empty string at least 30 chars (scoring.py's
+    bar for the call-summary axis)
+  - `trainer_log` has all four required sub-keys (`full_transcript`,
+    `ai_prediction`, `human_override`, `final_decision`)
+  - `(category, subcategory)` either match the canonical taxonomy or
+    fall back to the stub "OTHER/other" placeholder
+"""
+from __future__ import annotations
+
+import json
+import sys
+import time
+from pathlib import Path
+from typing import Any, Dict, List
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT))
+sys.path.insert(0, str(ROOT / "evaluation"))
+
+from agent.classify import classify  # noqa: E402
+from prediction import Prediction, TrainerLog  # noqa: E402
+
+
+RISK_LEVELS = frozenset({"LOW", "MEDIUM", "HIGH", "EMERGENCY"})
+REQUIRED_TOP_KEYS = (
+    "category",
+    "subcategory",
+    "risk_level",
+    "needs_human_review",
+    "needs_clarification",
+    "building_name",
+    "address",
+    "floor",
+    "dispatched_vendor_id",
+    "dispatched_emergency_services",
+    "call_summary",
+    "trainer_log",
+)
+REQUIRED_TRAINER_LOG_KEYS = (
+    "full_transcript",
+    "ai_prediction",
+    "human_override",
+    "final_decision",
+)
+
+
+def _load_dev_fixtures(transcript_ids: List[str]) -> List[Dict[str, Any]]:
+    rows = json.loads((ROOT / "evaluation" / "eval_transcripts_dev.json").read_text())
+    by_id = {r["transcript_id"]: r for r in rows}
+    out = []
+    for tid in transcript_ids:
+        if tid not in by_id:
+            raise RuntimeError(f"fixture {tid!r} not in eval_transcripts_dev.json")
+        out.append(by_id[tid])
+    return out
+
+
+# Real dev rows — picked to span the input space:
+#  EVAL-0004: known caller (profile), short dialogue
+#  EVAL-0006: anonymous caller, mid-length, location stated explicitly
+#  EVAL-0011: anonymous caller, mid-call correction (caller flips topic)
+_FIXTURES = ("EVAL-0004", "EVAL-0006", "EVAL-0011")
+
+
+# ─── Per-fixture schema round-trip ──────────────────────────────────────
+
+
+def test_classify_output_round_trips_through_prediction_dataclass():
+    """The headline check: `Prediction(**classify(...))` instantiates
+    cleanly on every fixture. Catches any missing/mistyped field added
+    by a downstream node."""
+    for row in _load_dev_fixtures(_FIXTURES):
+        out = classify(row["turns"], row.get("caller_phone"))
+        # Pull trainer_log out, instantiate it first, then the parent.
+        tl_raw = out["trainer_log"]
+        tl = TrainerLog(**tl_raw)
+        Prediction(
+            transcript_id=row["transcript_id"],
+            category=out["category"],
+            subcategory=out["subcategory"],
+            risk_level=out["risk_level"],
+            needs_human_review=out["needs_human_review"],
+            needs_clarification=out["needs_clarification"],
+            building_name=out.get("building_name"),
+            address=out.get("address"),
+            floor=out.get("floor"),
+            dispatched_vendor_id=out.get("dispatched_vendor_id"),
+            dispatched_emergency_services=out["dispatched_emergency_services"],
+            call_summary=out["call_summary"],
+            trainer_log=tl,
+        )
+
+
+def test_classify_output_has_every_required_top_level_key():
+    for row in _load_dev_fixtures(_FIXTURES):
+        out = classify(row["turns"], row.get("caller_phone"))
+        missing = [k for k in REQUIRED_TOP_KEYS if k not in out]
+        assert not missing, f"{row['transcript_id']} missing {missing}"
+
+
+def test_trainer_log_has_every_required_subkey():
+    for row in _load_dev_fixtures(_FIXTURES):
+        out = classify(row["turns"], row.get("caller_phone"))
+        tl = out["trainer_log"]
+        assert isinstance(tl, dict), f"trainer_log not a dict on {row['transcript_id']}"
+        missing = [k for k in REQUIRED_TRAINER_LOG_KEYS if k not in tl]
+        assert not missing, f"{row['transcript_id']} trainer_log missing {missing}"
+
+
+# ─── Field-level type + value checks ────────────────────────────────────
+
+
+def test_risk_level_is_in_canonical_enum():
+    for row in _load_dev_fixtures(_FIXTURES):
+        out = classify(row["turns"], row.get("caller_phone"))
+        assert out["risk_level"] in RISK_LEVELS, (
+            f"{row['transcript_id']}: risk_level={out['risk_level']!r} "
+            f"not in {sorted(RISK_LEVELS)}"
+        )
+
+
+def test_boolean_fields_are_actually_booleans():
+    """Catches the classic 'truthy non-bool' bug — Pydantic would coerce
+    `1`, `"true"`, or `None` to bool in some contexts but the scorer
+    uses `bool(...)` literally."""
+    for row in _load_dev_fixtures(_FIXTURES):
+        out = classify(row["turns"], row.get("caller_phone"))
+        for k in ("needs_human_review", "needs_clarification", "dispatched_emergency_services"):
+            assert isinstance(out[k], bool), (
+                f"{row['transcript_id']}: {k}={out[k]!r} is "
+                f"{type(out[k]).__name__}, expected bool"
+            )
+
+
+def test_call_summary_is_nonempty_string_at_least_30_chars():
+    """scoring.py rewards `call_summary` only when length >= 30 chars."""
+    for row in _load_dev_fixtures(_FIXTURES):
+        out = classify(row["turns"], row.get("caller_phone"))
+        cs = out["call_summary"]
+        assert isinstance(cs, str), f"{row['transcript_id']}: call_summary not a string"
+        assert len(cs.strip()) >= 30, (
+            f"{row['transcript_id']}: call_summary too short "
+            f"({len(cs.strip())} chars; scoring axis requires >= 30)"
+        )
+
+
+def test_optional_string_fields_are_str_or_none():
+    """`building_name`, `address`, `floor`, `dispatched_vendor_id` are
+    `Optional[str]` per `Prediction`. They must be a string or None —
+    not `0`, empty dict, or other 'absent' sentinels that would
+    silently fail equality checks in scoring.py."""
+    for row in _load_dev_fixtures(_FIXTURES):
+        out = classify(row["turns"], row.get("caller_phone"))
+        for k in ("building_name", "address", "floor", "dispatched_vendor_id"):
+            v = out.get(k)
+            assert v is None or isinstance(v, str), (
+                f"{row['transcript_id']}: {k}={v!r} is {type(v).__name__}, "
+                "expected Optional[str]"
+            )
+
+
+def test_full_transcript_in_trainer_log_is_nonempty():
+    """The trainer log's `full_transcript` is the supervised signal for
+    any future fine-tune. It must contain the actual dialogue, not an
+    empty string or placeholder."""
+    for row in _load_dev_fixtures(_FIXTURES):
+        out = classify(row["turns"], row.get("caller_phone"))
+        ft = out["trainer_log"]["full_transcript"]
+        assert isinstance(ft, str) and len(ft.strip()) > 0, (
+            f"{row['transcript_id']}: trainer_log.full_transcript empty"
+        )
+
+
+def test_ai_prediction_and_final_decision_are_dicts():
+    """Scoring counts the trainer-log axis as passing only when the four
+    sub-keys are present AND `final_decision` is a dict (per scoring.py's
+    `isinstance(tl, dict) and 'final_decision' in tl` check)."""
+    for row in _load_dev_fixtures(_FIXTURES):
+        out = classify(row["turns"], row.get("caller_phone"))
+        tl = out["trainer_log"]
+        assert isinstance(tl["ai_prediction"], dict)
+        assert isinstance(tl["final_decision"], dict)
+
+
+def test_human_override_is_none_or_dict():
+    """When no override happened, `human_override` must be `None`
+    (not missing). When one happened, it should be a dict diff."""
+    for row in _load_dev_fixtures(_FIXTURES):
+        out = classify(row["turns"], row.get("caller_phone"))
+        ho = out["trainer_log"]["human_override"]
+        assert ho is None or isinstance(ho, dict), (
+            f"{row['transcript_id']}: human_override={ho!r} "
+            f"is {type(ho).__name__}, expected None or dict"
+        )
+
+
+# ─── Inputs the harness will actually pass ─────────────────────────────
+
+
+def test_anonymous_caller_input_handled():
+    """`run_eval.py` passes `caller_phone=None` for some rows. Must not
+    crash and must still return a valid Prediction."""
+    out = classify(
+        [{"speaker": "caller", "text": "Toilet clogged on Floor 4."}],
+        None,
+    )
+    Prediction(
+        transcript_id="synthetic",
+        category=out["category"],
+        subcategory=out["subcategory"],
+        risk_level=out["risk_level"],
+        needs_human_review=out["needs_human_review"],
+        needs_clarification=out["needs_clarification"],
+        building_name=out.get("building_name"),
+        address=out.get("address"),
+        floor=out.get("floor"),
+        dispatched_vendor_id=out.get("dispatched_vendor_id"),
+        dispatched_emergency_services=out["dispatched_emergency_services"],
+        call_summary=out["call_summary"],
+        trainer_log=TrainerLog(**out["trainer_log"]),
+    )
+
+
+def test_empty_turns_does_not_crash():
+    """Defensive: even a zero-turn input should return a valid (if low-
+    quality) Prediction rather than crashing. The harness's per-call
+    timeout wraps individual failures, but a hard crash on empty input
+    would still poison the run."""
+    out = classify([], None)
+    assert "category" in out
+    assert "trainer_log" in out
+    # Round-trip works
+    TrainerLog(**out["trainer_log"])
+
+
+def test_minimal_single_caller_turn_handled():
+    out = classify([{"speaker": "caller", "text": "x"}], "+1-310-555-0142")
+    Prediction(
+        transcript_id="synthetic-minimal",
+        category=out["category"],
+        subcategory=out["subcategory"],
+        risk_level=out["risk_level"],
+        needs_human_review=out["needs_human_review"],
+        needs_clarification=out["needs_clarification"],
+        building_name=out.get("building_name"),
+        address=out.get("address"),
+        floor=out.get("floor"),
+        dispatched_vendor_id=out.get("dispatched_vendor_id"),
+        dispatched_emergency_services=out["dispatched_emergency_services"],
+        call_summary=out["call_summary"],
+        trainer_log=TrainerLog(**out["trainer_log"]),
+    )
+
+
+# ─── Performance budget (per AC: < 5s) ──────────────────────────────────
+
+
+def test_full_contract_check_completes_under_5s():
+    """The whole contract suite must run fast enough to land in CI on
+    every push. Per the AC: < 5s without hitting any LLM."""
+    t0 = time.time()
+    rows = _load_dev_fixtures(_FIXTURES)
+    for row in rows:
+        out = classify(row["turns"], row.get("caller_phone"))
+        TrainerLog(**out["trainer_log"])
+    elapsed = time.time() - t0
+    assert elapsed < 5.0, (
+        f"contract test budget blown: {elapsed:.2f}s on {len(rows)} fixtures "
+        "(target < 5s) — a downstream node is doing something slow on import "
+        "or in classify()"
+    )
+
+
+# ─── Inline runner ──────────────────────────────────────────────────────
+
+
+if __name__ == "__main__":
+    import inspect
+
+    tests = [(n, f) for n, f in inspect.getmembers(sys.modules[__name__])
+             if n.startswith("test_") and callable(f)]
+    failed = 0
+    t0 = time.time()
+    for name, fn in tests:
+        try:
+            fn()
+            print(f"  PASS  {name}")
+        except AssertionError as e:
+            print(f"  FAIL  {name}: {e}")
+            failed += 1
+        except Exception as e:
+            print(f"  ERROR {name}: {type(e).__name__}: {e}")
+            failed += 1
+    print(f"\n{len(tests) - failed}/{len(tests)} passed in {time.time() - t0:.2f}s")
+    sys.exit(1 if failed else 0)


### PR DESCRIPTION
Closes #2

## Summary

`tests/test_contract.py` round-trips `classify(turns, caller_phone)`'s output through `evaluation.prediction.Prediction` + `TrainerLog` and asserts the field-level constraints `scoring.py` relies on. This is the **CI canary** that fires when any downstream node breaks the output contract — silent schema drift is the most common way to zero out the rubric.

## Why this matters right now

7 large PRs (#16, #19, #20, #21, #22, #23, #24) are queued for merge. They collectively rewrite `agent/classify.py` from the stub into a multi-node graph. The contract test lands **before** them so the moment any of those PRs (or the merge resolution between them) drifts the output shape, CI fails loudly instead of silently zeroing rubric axes.

## What the test catches

- Missing required top-level key on the Prediction dict (12 fields).
- Missing required `trainer_log` sub-key (`full_transcript`, `ai_prediction`, `human_override`, `final_decision`).
- `risk_level` outside the canonical `LOW`/`MEDIUM`/`HIGH`/`EMERGENCY` enum.
- Boolean fields that drifted to truthy non-bool (`1`, `"true"`, etc.) — `scoring.py` uses `bool(...)` and would silently accept these but the test enforces `isinstance(x, bool)`.
- `call_summary` shorter than 30 chars (`scoring.py`'s bar for that axis).
- `Optional[str]` fields drifted to other "absent" sentinels (empty dict, `0`).
- `trainer_log.full_transcript` empty string (the supervised signal for any future fine-tune).
- `ai_prediction` / `final_decision` not dicts.
- `human_override` neither `None` nor a dict.

Plus invocation-pattern coverage:
- `caller_phone=None` (the harness's anonymous-caller path)
- Empty turns list (shouldn't crash)
- Single-turn synthetic input
- 3 real dev fixtures: EVAL-0004 (known caller), EVAL-0006 (anonymous, explicit location), EVAL-0011 (anonymous, mid-call topic correction)

## Validation

| | Result |
|---|---|
| Tests | **14/14 ✓** |
| Wall time | **0.01s** (AC budget: < 5s) |
| Dependencies | stdlib + `dataclasses` (no LLM, no API key) |

## CI wiring

- **`Makefile`** with `test`, `test-contract`, `test-fast`, `test-llm`, `install`, `build-index`, `help`. `make test` defaults to the fast (no-LLM) suite, which is what CI runs.
- **`.github/workflows/test.yml`** runs the contract canary first, then the remaining fast tests, on every push to any branch + every PR to main. 10-min timeout, pip cache, Python 3.12.
- **Real-LLM tests stay in `make test-llm`** so PRs don't burn API credits or leak the key into workflow scope.

## Test plan

- [ ] `make test-contract` reports 14/14 in < 5s.
- [ ] `make test` reports the full fast suite passing.
- [ ] GitHub Actions runs successfully on the first push to this branch.
- [ ] When PR #56 (issue-24 orchestrator) lands, this test still passes (or fails loudly if there's drift).

## Notes for reviewer

- **Branch base is `main`** — independent of all 7 open PRs.
- **The fixtures use the current stub `classify` on main.** When the LLM-backed orchestrator (#56) lands, this test will need a monkey-patched LLM client for the round-trip checks. That's a follow-up for whoever lands #56 — the schema assertions themselves stay the same.
- **CI workflow only runs no-LLM tests** by design. The repo's real-LLM E2E suite (`test_extract.py`, `test_classify.py`) is invoked via `make test-llm` locally.
- **Optional precision improvement** for the future: add `call_summary` text-quality checks (no first-person, no LLM filler like "I have determined that...") — already loosely guarded by the 30-char minimum but could be tightened in a follow-up.

## Backlog reference

Implements issue #2 in [`docs/PROJECT_BACKLOG.md`](docs/PROJECT_BACKLOG.md). Defensive infrastructure — no downstream consumer, but every downstream issue's CI run depends on it passing.
