### PR TITLE
Audit fixes for PR #56: happy-path coverage + unroutable + taxonomy + provenance

### DIFF
--- a/agent/classify.py
+++ b/agent/classify.py
@@ -3,15 +3,27 @@
 `classify(turns, caller_phone) -> dict` is the contract consumed by
 `evaluation/run_eval.py`. It chains all nodes in sequence:
 
-  Extract → Classify → Risk → Validate → Location → Vendor → Clarify → Summary → TrainerLog
+  Extract → Classify → Location → Risk → Validate → Vendor → Clarify → Summary → TrainerLog
 
-Each node is fault-isolated: if an LLM-backed node raises, the pipeline
-falls back to safe defaults (needs_human_review=True, no 911 dispatch)
-and still returns a schema-valid prediction dict.
+Each node is fault-isolated:
+
+- Extract / Classify / Risk are load-bearing — if they raise, the whole
+  call falls back to a schema-valid "escalate to human" prediction via
+  `_safe_fallback()` (needs_human_review=True, no 911 dispatch).
+- Location / Vendor / Clarification soft-degrade — if they raise, the
+  pipeline continues with safe defaults for that node and a logged
+  warning, because their downstream consumers (summary, trainer log)
+  can handle None / empty values.
+- Vendor selection returning `VendorSelection(vendor_id=None, ...)` is
+  the "unroutable" path: the validator's `needs_human_review` is
+  promoted to True with a `vendor_escalation` reason so the scorer's
+  unroutable-case rule (dispatched=None AND needs_human_review=True)
+  is satisfied. The summary node frames the escalation explicitly.
 """
 from __future__ import annotations
 
 import logging
+from dataclasses import replace
 from typing import Any, Dict, List, Optional
 
 from agent.data import profiles
@@ -38,8 +50,12 @@ def _flatten(turns: List[dict]) -> str:
 def _safe_fallback(turns: List[dict], error: str) -> Dict[str, Any]:
     """Return a safe prediction on pipeline failure — avoids false-911."""
     full_transcript = _flatten(turns)
+    # (ELEVATOR, minor_issue) is the only minor_issue pair in the canonical
+    # taxonomy. modal_risk in the derived table is LOW; we hold to MEDIUM
+    # here because the fallback always escalates and "I don't know" should
+    # not present as LOW to the reviewer.
     base = {
-        "category": "OTHER",
+        "category": "ELEVATOR",
         "subcategory": "minor_issue",
         "risk_level": "MEDIUM",
         "needs_human_review": True,
@@ -130,10 +146,8 @@ def classify(turns: List[dict], caller_phone: Optional[str]) -> Dict[str, Any]:
     is_emergency = risk_level == "EMERGENCY"
 
     # ── Step 5: Validator gate ───────────────────────────────────────
-    fallback_invoked = (
-        classification.reasoning is not None
-        and "fallback" in classification.reasoning.lower()
-    )
+    # H2: read the structured flag instead of substring-matching reasoning.
+    fallback_invoked = classification.is_fallback
     try:
         validator_result = validate(
             subcategory=subcategory,
@@ -162,6 +176,17 @@ def classify(turns: List[dict], caller_phone: Optional[str]) -> Dict[str, Any]:
     except Exception as e:
         logger.warning("vendor selection failed: %s", e)
         vendor = VendorSelection(vendor_id=None, vendor_name=None, reason=f"error:{e}")
+
+    # B2: no qualified vendor → escalate. The scorer's unroutable-case rule
+    # (dispatched in (None, "") AND pr_h) requires both halves; without this
+    # promotion, low/medium routine calls with no vendor match would score
+    # wrong on vendor (10%), HITL-F1 (15%), and auto-resolution (10%).
+    if vendor.vendor_id is None and not validator_result.needs_human_review:
+        validator_result = replace(
+            validator_result,
+            needs_human_review=True,
+            reasons=[*validator_result.reasons, "vendor_escalation:no_qualified_vendor"],
+        )
 
     # ── Step 7: Clarification ────────────────────────────────────────
     try:
@@ -202,7 +227,7 @@ def classify(turns: List[dict], caller_phone: Optional[str]) -> Dict[str, Any]:
         confidence_subcategory=confidence_sub,
         validator_reasons=list(validator_result.reasons),
         risk_reasons=list(risk.reasons),
-        retrieved_record_ids=[],
+        retrieved_record_ids=list(classification.retrieved_record_ids),
     )
 
     trainer_log = assemble_trainer_log(

--- a/agent/nodes/classify.py
+++ b/agent/nodes/classify.py
@@ -106,6 +106,19 @@ class Classification(BaseModel):
         description="1-2 sentence justification — what in the caller's complaint or "
         "the retrieved tickets drove this label. Captured into trainer_log."
     )
+    is_fallback: bool = Field(
+        default=False,
+        description="Internal flag — True only when the classifier had to use the "
+        "category-only fallback path. The validator gate reads this directly "
+        "instead of substring-matching the reasoning string.",
+    )
+    retrieved_record_ids: List[str] = Field(
+        default_factory=list,
+        description="Internal field — ticket IDs of the historical records the "
+        "classifier retrieved. Populated by `classify()`, never by the LLM; "
+        "consumed by trainer_log so the fine-tune corpus can re-anchor to "
+        "the records that drove each prediction.",
+    )
 
     @field_validator("reasoning")
     @classmethod
@@ -377,36 +390,42 @@ def classify(
     prompt = build_prompt(extraction, records)
     structured = llm.with_structured_output(Classification)
 
+    result: Classification
     try:
-        return structured.invoke(prompt)
+        result = structured.invoke(prompt)
     except ValidationError as first_err:
         logger.warning(
             "classifier first-pass validation failed (%s); retrying with "
             "explicit pair enumeration",
             first_err,
         )
-
-    # Retry: tell the LLM exactly which (category, subcategory) pairs are valid.
-    pair_block = "\n".join(
-        f"  ({cat!r}, {sub!r})"
-        for cat, sub in taxonomy.all_pairs()
-    )
-    retry_prompt = (
-        prompt
-        + "\n\n# RETRY GUIDANCE\nYour previous answer used a (category, subcategory) "
-        "pair that doesn't exist in the taxonomy. The complete list of valid pairs is:\n"
-        + pair_block
-        + "\n\nPick exactly one of these pairs.\n"
-    )
-    try:
-        return structured.invoke(retry_prompt)
-    except ValidationError as second_err:
-        logger.error(
-            "classifier retry validation also failed (%s); falling back "
-            "to category-only via retrieval consensus",
-            second_err,
+        # Retry: tell the LLM exactly which (category, subcategory) pairs are valid.
+        pair_block = "\n".join(
+            f"  ({cat!r}, {sub!r})"
+            for cat, sub in taxonomy.all_pairs()
         )
-        return _category_only_fallback(records)
+        retry_prompt = (
+            prompt
+            + "\n\n# RETRY GUIDANCE\nYour previous answer used a (category, subcategory) "
+            "pair that doesn't exist in the taxonomy. The complete list of valid pairs is:\n"
+            + pair_block
+            + "\n\nPick exactly one of these pairs.\n"
+        )
+        try:
+            result = structured.invoke(retry_prompt)
+        except ValidationError as second_err:
+            logger.error(
+                "classifier retry validation also failed (%s); falling back "
+                "to category-only via retrieval consensus",
+                second_err,
+            )
+            result = _category_only_fallback(records)
+
+    # Plumb retrieval provenance through to trainer_log (issue #29 §8.3).
+    # Done after the LLM call so the model can't pollute the field — the
+    # default `[]` it would emit gets overwritten with the real IDs.
+    result.retrieved_record_ids = [r.ticket_id for r in records if r.ticket_id]
+    return result
 
 
 def _category_only_fallback(records: List[RetrievedRecord]) -> Classification:
@@ -433,4 +452,5 @@ def _category_only_fallback(records: List[RetrievedRecord]) -> Classification:
         confidence_category=0.2,
         confidence_subcategory=0.1,
         reasoning="(fallback: classifier retries exhausted; category from retrieval consensus, subcategory arbitrary — escalate to human reviewer)",
+        is_fallback=True,
     )

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -1,21 +1,47 @@
-"""Integration tests for the agent pipeline (agent.classify:classify).
+"""Integration tests for the agent orchestrator (`agent.classify:classify`).
 
-Tests the orchestrator's fallback path and schema conformance.
-Full end-to-end testing requires LLM dependencies (pydantic, langchain);
-these tests validate the safe-fallback path and output schema.
+These tests patch every node import on `agent.classify` so the orchestrator's
+glue logic — fault isolation, fallback-flag propagation, unroutable
+escalation, retrieval provenance — can be exercised without touching the
+LLM, chroma, or any I/O. The helper-only path (`_safe_fallback`, `_flatten`)
+is also covered, but the bulk of the surface area is happy-path glue.
+
+Patches target module-level imports on `agent.classify`, e.g.
+`agent.classify.extract`, `agent.classify.classify_call`, etc. Python's
+import system has already bound those names in the orchestrator's
+namespace by the time the test runs, so patching the module attribute is
+both correct and faster than patching the underlying definition.
 """
 from __future__ import annotations
 
 import sys
+from contextlib import ExitStack
 from pathlib import Path
+from typing import Any, Optional
+from unittest.mock import patch
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from agent import classify as orchestrator  # noqa: E402
+from agent.data import taxonomy as taxonomy_mod  # noqa: E402
+from agent.nodes.classify import (  # noqa: E402
+    CategoryEnum,
+    Classification,
+    SubcategoryEnum,
+)
+from agent.nodes.clarify import ClarificationDecision  # noqa: E402
+from agent.nodes.extract import Extraction, FieldConfidence  # noqa: E402
+from agent.nodes.location import ResolvedLocation  # noqa: E402
+from agent.nodes.risk import RiskAssignment  # noqa: E402
+from agent.nodes.validator import ValidatorResult  # noqa: E402
+from agent.nodes.vendor_select import VendorSelection  # noqa: E402
 
 
 SAMPLE_TURNS = [
     {"speaker": "agent", "text": "CBRE maintenance, this is Dana. What's going on?"},
     {"speaker": "caller", "text": "The breakroom sink on Floor 9 won't drain."},
 ]
+SAMPLE_PHONE = "+15551234567"
 
 REQUIRED_KEYS = {
     "category", "subcategory", "risk_level", "needs_human_review",
@@ -23,117 +49,413 @@ REQUIRED_KEYS = {
     "dispatched_vendor_id", "dispatched_emergency_services",
     "call_summary", "trainer_log",
 }
+TRAINER_LOG_REQUIRED_KEYS = {
+    "full_transcript", "ai_prediction", "human_override", "final_decision",
+}
 
-TRAINER_LOG_REQUIRED_KEYS = {"full_transcript", "ai_prediction", "human_override", "final_decision"}
+
+# ─── Fixture builders ──────────────────────────────────────────────────
 
 
-def _import_safe_fallback():
-    """Import just the _safe_fallback and _flatten without triggering LLM imports."""
-    import importlib.util
-    spec = importlib.util.spec_from_file_location(
-        "agent_classify",
-        str(Path(__file__).resolve().parents[1] / "agent" / "classify.py"),
+def _good_extraction(**overrides: Any) -> Extraction:
+    base = dict(
+        problem_summary="sink won't drain",
+        building_name="Pacific Ridge Medical Plaza",
+        floor="Floor 9",
+        suite=None,
+        urgency_cues=[],
+        caller_role="tenant",
+        language="en",
+        confidence=FieldConfidence(
+            problem_summary=0.9, building_name=0.8, floor=0.9,
+            suite=0.0, caller_role=0.6,
+        ),
     )
-    # We can't load the module normally because it imports pydantic at top level.
-    # Instead, read the file and extract the helper functions we need to test.
-    source = (Path(__file__).resolve().parents[1] / "agent" / "classify.py").read_text()
+    base.update(overrides)
+    return Extraction(**base)
 
-    # Execute only the _flatten and _safe_fallback functions in isolation
-    ns = {"__name__": "agent.classify", "logging": __import__("logging")}
-    # Extract the two functions we need (they have no LLM deps)
-    lines = source.split("\n")
-    in_func = False
-    func_lines = []
-    target_funcs = {"def _flatten", "def _safe_fallback"}
-    current_indent = 0
 
-    for line in lines:
-        if any(line.startswith(t) for t in target_funcs):
-            in_func = True
-            func_lines.append(line)
-            current_indent = len(line) - len(line.lstrip())
-        elif in_func:
-            if line.strip() == "" or line.startswith(" ") or line.startswith("\t"):
-                func_lines.append(line)
+def _good_classification(
+    *,
+    is_fallback: bool = False,
+    retrieved_record_ids: Optional[list] = None,
+    category: str = "PLUMBING",
+    subcategory: str = "drainage_backup",
+    confidence_category: float = 0.9,
+    confidence_subcategory: float = 0.9,
+) -> Classification:
+    return Classification(
+        category=CategoryEnum(category),
+        subcategory=SubcategoryEnum(subcategory),
+        confidence_category=confidence_category,
+        confidence_subcategory=confidence_subcategory,
+        reasoning="stub",
+        is_fallback=is_fallback,
+        retrieved_record_ids=(
+            ["TKT-2024-00001", "TKT-2024-00002"]
+            if retrieved_record_ids is None
+            else retrieved_record_ids
+        ),
+    )
+
+
+def _good_location(**overrides: Any) -> ResolvedLocation:
+    base = dict(
+        building_name="Pacific Ridge Medical Plaza",
+        address="3200 Pacific Coast Hwy",
+        floor="Floor 9",
+        city="Long Beach",
+        building_type="medical",
+        floor_check="ok",
+        source_building="transcript",
+        source_floor="transcript",
+    )
+    base.update(overrides)
+    return ResolvedLocation(**base)
+
+
+_RISK_SCORE = {"LOW": 0.0, "MEDIUM": 0.33, "HIGH": 0.67, "EMERGENCY": 1.0}
+
+
+def _good_risk(band: str = "MEDIUM") -> RiskAssignment:
+    return RiskAssignment(
+        band=band,
+        score=_RISK_SCORE[band],
+        base_risk=band,
+        reasons=("base_risk_for_subcategory",),
+    )
+
+
+def _validator(
+    *, needs_human_review: bool = False, dispatched_emergency_services: bool = False
+) -> ValidatorResult:
+    reasons = (
+        ["auto_resolve:no_flags_fired"]
+        if not needs_human_review
+        else ["high_band:always_pause"]
+    )
+    return ValidatorResult(
+        needs_human_review=needs_human_review,
+        dispatched_emergency_services=dispatched_emergency_services,
+        reasons=reasons,
+    )
+
+
+def _vendor(vendor_id: Optional[str] = "v_002") -> VendorSelection:
+    return VendorSelection(
+        vendor_id=vendor_id,
+        vendor_name="AquaFix Plumbing" if vendor_id else None,
+        reason="selected" if vendor_id else "no_match",
+    )
+
+
+def _clarification(needs: bool = False) -> ClarificationDecision:
+    return ClarificationDecision(
+        needs_clarification=needs, question=None, reasons=(),
+    )
+
+
+# ─── Patch harness ─────────────────────────────────────────────────────
+
+
+_DEFAULTS = {
+    "extract": _good_extraction,
+    "classify_call": _good_classification,
+    "reconcile": _good_location,
+    "assign_risk": _good_risk,
+    "validate": _validator,
+    "select_vendor": _vendor,
+    "needs_clarification": _clarification,
+}
+
+
+def _run(**overrides: Any) -> dict:
+    """Run the orchestrator with each node patched.
+
+    For each node name in `_DEFAULTS`, pass the override value (an instance,
+    a callable, or an `Exception` instance/class) or omit to use the default
+    happy-path fixture. Returns the orchestrator's output dict.
+    """
+    with ExitStack() as stack:
+        for name, default_factory in _DEFAULTS.items():
+            override = overrides.get(name)
+            if override is None:
+                value = default_factory()
+                stack.enter_context(
+                    patch.object(orchestrator, name, return_value=value)
+                )
+            elif isinstance(override, Exception) or (
+                isinstance(override, type) and issubclass(override, BaseException)
+            ):
+                stack.enter_context(
+                    patch.object(orchestrator, name, side_effect=override)
+                )
+            elif callable(override) and not isinstance(override, type):
+                # Callable spies — let them observe kwargs.
+                stack.enter_context(
+                    patch.object(orchestrator, name, side_effect=override)
+                )
             else:
-                in_func = False
-                func_lines.append("")
-
-    func_code = "\n".join(func_lines)
-    exec(compile(func_code, "<test>", "exec"), ns)
-    return ns["_safe_fallback"], ns["_flatten"]
+                stack.enter_context(
+                    patch.object(orchestrator, name, return_value=override)
+                )
+        return orchestrator.classify(SAMPLE_TURNS, SAMPLE_PHONE)
 
 
-_safe_fallback, _flatten = _import_safe_fallback()
-
-
-def test_prediction_schema_has_all_keys():
-    """Verify output keys match what scoring.py expects."""
-    result = _safe_fallback(SAMPLE_TURNS, "test error")
-    assert REQUIRED_KEYS.issubset(result.keys()), f"Missing keys: {REQUIRED_KEYS - result.keys()}"
-
-
-def test_trainer_log_has_required_keys():
-    """trainer_log must have full_transcript, ai_prediction, human_override, final_decision."""
-    result = _safe_fallback(SAMPLE_TURNS, "test error")
-    tl = result["trainer_log"]
-    assert isinstance(tl, dict)
-    assert TRAINER_LOG_REQUIRED_KEYS.issubset(tl.keys()), f"Missing: {TRAINER_LOG_REQUIRED_KEYS - tl.keys()}"
-
-
-def test_safe_fallback_no_false_911():
-    """Fallback path must never dispatch emergency services."""
-    result = _safe_fallback(SAMPLE_TURNS, "any error")
-    assert result["dispatched_emergency_services"] is False
-    assert result["needs_human_review"] is True
-
-
-def test_safe_fallback_has_call_summary():
-    """Call summary must be >= 30 chars to pass scoring."""
-    result = _safe_fallback(SAMPLE_TURNS, "test")
-    assert len(result["call_summary"]) >= 30
-
-
-def test_full_transcript_in_trainer_log():
-    """Trainer log must contain the full transcript text."""
-    result = _safe_fallback(SAMPLE_TURNS, "test")
-    tl = result["trainer_log"]
-    assert "breakroom sink" in tl["full_transcript"]
-    assert "[CALLER]" in tl["full_transcript"]
+# ─── Helper-only coverage ──────────────────────────────────────────────
 
 
 def test_flatten_preserves_speaker_tags():
-    """_flatten produces [AGENT]/[CALLER] tagged lines."""
-    text = _flatten(SAMPLE_TURNS)
+    text = orchestrator._flatten(SAMPLE_TURNS)
     assert "[AGENT]" in text
     assert "[CALLER]" in text
     assert "breakroom sink" in text
 
 
-def test_safe_fallback_final_decision_matches_base():
-    """When no override, final_decision should mirror the base prediction."""
-    result = _safe_fallback(SAMPLE_TURNS, "err")
+def test_safe_fallback_schema():
+    result = orchestrator._safe_fallback(SAMPLE_TURNS, "test error")
+    assert REQUIRED_KEYS.issubset(result.keys())
+    assert TRAINER_LOG_REQUIRED_KEYS.issubset(result["trainer_log"].keys())
+    assert result["dispatched_emergency_services"] is False
+    assert result["needs_human_review"] is True
+    assert len(result["call_summary"]) >= 30
+    assert "breakroom sink" in result["trainer_log"]["full_transcript"]
+
+
+def test_safe_fallback_uses_valid_taxonomy_pair():
+    """H1: fallback must produce a (category, subcategory) the scorer can match."""
+    result = orchestrator._safe_fallback(SAMPLE_TURNS, "x")
+    assert taxonomy_mod.is_valid_category(result["category"]), (
+        f"fallback category {result['category']!r} not in canonical taxonomy"
+    )
+    assert taxonomy_mod.is_valid_pair(result["category"], result["subcategory"]), (
+        f"fallback ({result['category']}, {result['subcategory']}) not a valid pair"
+    )
+
+
+def test_safe_fallback_final_decision_mirrors_base():
+    result = orchestrator._safe_fallback(SAMPLE_TURNS, "x")
     tl = result["trainer_log"]
     assert tl["human_override"] is None
     assert tl["final_decision"]["needs_human_review"] is True
     assert tl["final_decision"]["dispatched_emergency_services"] is False
 
 
+# ─── Happy-path orchestrator glue ──────────────────────────────────────
+
+
+def test_happy_path_returns_schema_valid_dict():
+    result = _run()
+    assert REQUIRED_KEYS.issubset(result.keys()), (
+        f"missing keys: {REQUIRED_KEYS - result.keys()}"
+    )
+    assert TRAINER_LOG_REQUIRED_KEYS.issubset(result["trainer_log"].keys())
+
+
+def test_happy_path_dispatches_vendor():
+    result = _run()
+    assert result["dispatched_vendor_id"] == "v_002"
+    assert result["needs_human_review"] is False
+    assert result["dispatched_emergency_services"] is False
+
+
+def test_happy_path_carries_location_fields():
+    result = _run()
+    assert result["building_name"] == "Pacific Ridge Medical Plaza"
+    assert result["floor"] == "Floor 9"
+    assert result["address"] == "3200 Pacific Coast Hwy"
+
+
+def test_happy_path_call_summary_is_nonempty():
+    result = _run()
+    assert isinstance(result["call_summary"], str)
+    assert len(result["call_summary"]) >= 30
+
+
+# ─── Fault isolation ───────────────────────────────────────────────────
+
+
+def test_extract_failure_returns_safe_fallback():
+    result = _run(extract=RuntimeError("extract boom"))
+    assert result["needs_human_review"] is True
+    assert result["dispatched_emergency_services"] is False
+    assert result["dispatched_vendor_id"] is None
+    assert "extract" in result["call_summary"].lower()
+
+
+def test_classify_failure_returns_safe_fallback():
+    result = _run(classify_call=RuntimeError("classify boom"))
+    assert result["needs_human_review"] is True
+    assert result["dispatched_emergency_services"] is False
+    assert result["dispatched_vendor_id"] is None
+
+
+def test_risk_failure_returns_safe_fallback():
+    result = _run(assign_risk=RuntimeError("risk boom"))
+    assert result["needs_human_review"] is True
+    assert result["dispatched_emergency_services"] is False
+
+
+def test_location_failure_soft_degrades():
+    """Location is non-load-bearing: pipeline continues with raw extraction."""
+    result = _run(reconcile=RuntimeError("location boom"))
+    assert REQUIRED_KEYS.issubset(result.keys())
+    assert result["building_name"] == "Pacific Ridge Medical Plaza"
+    assert result["address"] is None
+
+
+def test_vendor_failure_soft_degrades_and_escalates():
+    """Vendor exception → no dispatch + B2 promotion to human review."""
+    result = _run(select_vendor=RuntimeError("vendor boom"))
+    assert result["dispatched_vendor_id"] is None
+    assert result["needs_human_review"] is True
+
+
+def test_clarification_failure_soft_degrades():
+    result = _run(needs_clarification=RuntimeError("clarify boom"))
+    assert result["needs_clarification"] is False
+    assert REQUIRED_KEYS.issubset(result.keys())
+
+
+# ─── B2: unroutable promotion ──────────────────────────────────────────
+
+
+def test_unroutable_promotes_needs_human_review_on_routine_call():
+    """B2: vendor returns None on a call the validator auto-resolved.
+
+    Without the promotion, the orchestrator would emit
+    `dispatched_vendor_id=None` AND `needs_human_review=False`, which
+    fails the scorer's unroutable rule on 2/6 dev cases (EVAL-0162,
+    EVAL-0415) and silently degrades 3 axes (vendor, HITL-F1, auto-res).
+    """
+    result = _run(
+        validate=_validator(needs_human_review=False),
+        select_vendor=_vendor(vendor_id=None),
+    )
+    assert result["dispatched_vendor_id"] is None
+    assert result["needs_human_review"] is True, (
+        "no qualified vendor must promote needs_human_review"
+    )
+    reasons = result["trainer_log"]["ai_prediction"]["validator_reasons"]
+    assert any("vendor_escalation" in r for r in reasons), (
+        f"expected vendor_escalation reason, got {reasons}"
+    )
+
+
+def test_unroutable_does_not_double_flag_when_validator_already_paused():
+    """Validator already paused (HIGH risk) + vendor None: no duplicate reason."""
+    result = _run(
+        validate=_validator(needs_human_review=True),
+        select_vendor=_vendor(vendor_id=None),
+    )
+    reasons = result["trainer_log"]["ai_prediction"]["validator_reasons"]
+    vendor_reasons = [r for r in reasons if "vendor_escalation" in r]
+    assert len(vendor_reasons) == 0, (
+        "vendor_escalation should not fire when validator already paused"
+    )
+    assert result["needs_human_review"] is True
+
+
+# ─── H2: is_fallback propagation ──────────────────────────────────────
+
+
+def test_is_fallback_propagates_to_validator():
+    """H2: fallback flag is read directly from Classification.is_fallback.
+
+    Before the fix, the orchestrator substring-matched the reasoning
+    string. A reword would silently break the validator-gate's
+    fallback-pause rule.
+    """
+    captured: dict = {}
+
+    def _spy_validate(**kwargs):
+        captured.update(kwargs)
+        return _validator(needs_human_review=True)
+
+    _run(
+        classify_call=_good_classification(is_fallback=True),
+        validate=_spy_validate,
+    )
+    assert captured.get("fallback_invoked") is True
+
+
+def test_is_fallback_false_propagates_to_validator():
+    captured: dict = {}
+
+    def _spy_validate(**kwargs):
+        captured.update(kwargs)
+        return _validator(needs_human_review=False)
+
+    _run(
+        classify_call=_good_classification(is_fallback=False),
+        validate=_spy_validate,
+    )
+    assert captured.get("fallback_invoked") is False
+
+
+# ─── H3: retrieval provenance ──────────────────────────────────────────
+
+
+def test_trainer_log_carries_retrieved_record_ids():
+    """H3: classifier-side record IDs flow into ai_prediction."""
+    result = _run(
+        classify_call=_good_classification(
+            retrieved_record_ids=["TKT-A", "TKT-B", "TKT-C"],
+        ),
+    )
+    ai_pred = result["trainer_log"]["ai_prediction"]
+    assert ai_pred["retrieved_record_ids"] == ["TKT-A", "TKT-B", "TKT-C"]
+
+
+def test_trainer_log_handles_empty_record_ids():
+    """Empty retrieval (the no-records-found edge case) still produces a list."""
+    result = _run(
+        classify_call=_good_classification(retrieved_record_ids=[]),
+    )
+    assert result["trainer_log"]["ai_prediction"]["retrieved_record_ids"] == []
+
+
+# ─── No false-911 guarantee ────────────────────────────────────────────
+
+
+def test_no_false_911_on_routine_dispatch():
+    result = _run()
+    assert result["dispatched_emergency_services"] is False
+
+
+def test_911_only_when_validator_dispatches():
+    """If validator says dispatch_911, the orchestrator surfaces it."""
+    result = _run(
+        validate=ValidatorResult(
+            needs_human_review=True,
+            dispatched_emergency_services=True,
+            reasons=["emergency_dispatch:fire_smoke"],
+        ),
+    )
+    assert result["dispatched_emergency_services"] is True
+
+
+# ─── Inline runner ─────────────────────────────────────────────────────
+
+
 if __name__ == "__main__":
     import inspect
+    import traceback
 
-    tests = [(n, f) for n, f in inspect.getmembers(sys.modules[__name__])
-             if n.startswith("test_") and callable(f)]
+    tests = [
+        (n, f) for n, f in inspect.getmembers(sys.modules[__name__])
+        if n.startswith("test_") and callable(f)
+    ]
     failed = 0
     for name, fn in sorted(tests):
         try:
             fn()
             print(f"  PASS  {name}")
-        except AssertionError as e:
-            print(f"  FAIL  {name}: {e}")
-            failed += 1
         except Exception as e:
-            print(f"  ERROR {name}: {type(e).__name__}: {e}")
+            print(f"  FAIL  {name}: {type(e).__name__}: {e}")
+            if not isinstance(e, AssertionError):
+                traceback.print_exc()
             failed += 1
-    print(f"\n{len(tests) - failed}/{len(tests)} passed")
+    total = len(tests)
+    print(f"\n{total - failed}/{total} passed, {failed} failed")
     sys.exit(1 if failed else 0)


### PR DESCRIPTION
Audit follow-up to #56 — five fixes from the pre-merge review, targeting the `issue-24` branch so they ride along when #56 merges to main.

## What's in here

| ID | Severity | Fix |
|---|---|---|
| **B1** | Blocker | Replaced source-text-parsing hack in `tests/test_pipeline.py` with `unittest.mock.patch` on the orchestrator's imported nodes. Coverage went from 7 helper-only tests → **22 tests** spanning happy-path, every fault-isolation branch, the unroutable promotion, fallback propagation, and retrieval provenance. |
| **B2** | Blocker | When `select_vendor()` returns `None` on a call the validator already auto-resolved, promote `needs_human_review=True` and append a `vendor_escalation:no_qualified_vendor` reason. The scorer's unroutable rule needs both halves; without this, 2 of 6 dev unroutable cases (`EVAL-0162` and `EVAL-0415`) would mis-score on **vendor (10%) + HITL-F1 (15%) + auto-resolution (10%)**. |
| **H1** | High | Fallback now writes `("ELEVATOR", "minor_issue")` instead of `("OTHER", "minor_issue")`. `"OTHER"` isn't in the canonical taxonomy and `minor_issue` belongs to `ELEVATOR`, so the old pair zeroed two axes on every fallback by construction. |
| **H2** | High | Added `Classification.is_fallback: bool` (set to `True` only in `_category_only_fallback`). The orchestrator now reads `classification.is_fallback` directly instead of `"fallback" in classification.reasoning.lower()` — any reword would have silently broken the validator's fallback-pause rule. |
| **H3** | High | Added `Classification.retrieved_record_ids: List[str]`, populated by `classify()` after the LLM call (the LLM's default `[]` gets overwritten with real ticket IDs). Orchestrator plumbs the IDs into `ai_prediction.retrieved_record_ids` instead of the previous hardcoded `[]`. Design doc §8.3 (PR #59) relies on this for fine-tune replay. |

Bonus: M1 from the audit — orchestrator docstring sequence corrected to match the actual code path (`Location` runs before `Risk`, not after).

## Validation

```
$ python tests/test_pipeline.py
22/22 passed, 0 failed
$ python tests/test_classify.py
21/21 passed, 0 failed         # is_fallback / retrieved_record_ids defaulted — no breaks
$ python tests/test_clarify.py
18/18 passed
$ python tests/test_risk_assignment.py
17/17 passed
$ python tests/test_hitl.py
13/13 passed
```

## How to land

Merge this into `issue-24` first; PR #56 then ships to main with the fixes included. The audit's M2 (`after_hours` hardcoded) and M3 (`_LIFE_SAFETY_SUBCATEGORIES` deduplication) are deliberately out of scope — both are cosmetic and can land in a follow-up.

## Notes for reviewer

- The new `is_fallback` and `retrieved_record_ids` fields on `Classification` are defaulted, so every existing construction site (including `_category_only_fallback` and the test fixtures in `test_classify.py`) keeps working unchanged.
- The B2 promotion only fires when `vendor.vendor_id is None AND not validator_result.needs_human_review` — so it doesn't double-flag the case where the validator already paused for HIGH risk and the vendor coincidentally returned None. A dedicated test (`test_unroutable_does_not_double_flag_when_validator_already_paused`) guards this.
- The test harness uses `ExitStack` so each test can override any subset of the 7 nodes. Override values can be instances, callables (used as spies for kwarg capture), or exceptions (used as `side_effect`).