### PR TITLE
feat: LangGraph interrupt/resume/override HITL path (issue #17)

### DIFF
--- a/agent/graph.py
+++ b/agent/graph.py
@@ -1,0 +1,209 @@
+"""LangGraph pipeline with interrupt/resume/override HITL semantics.
+
+Wraps the sequential orchestrator (`agent.classify`) into a LangGraph
+StateGraph that supports:
+
+1. **Interrupt** — when the validator gate fires `needs_human_review=True`,
+   the graph pauses via `interrupt()` and surfaces a review payload.
+2. **Resume (approve)** — `Command(resume={"action": "approve"})` continues
+   with the AI's prediction unchanged.
+3. **Resume (override)** — `Command(resume={"action": "override", "fields": {...}})`
+   replaces specified fields and records the diff in trainer_log.human_override.
+4. **Post-execution override** — `update_state()` on a completed checkpoint
+   modifies the final decision after the fact (supervisor review).
+
+Thread-ID strategy: `f"call-{transcript_id}"` — one thread per call,
+enabling replay and audit trail via the checkpointer.
+
+During eval (no live human), the harness auto-approves every interrupt
+so scoring completes without blocking. This is documented behavior per
+the issue #17 spec.
+"""
+from __future__ import annotations
+
+from typing import Any, Dict, List, Optional, TypedDict
+
+from langgraph.checkpoint.memory import InMemorySaver
+from langgraph.graph import END, START, StateGraph
+from langgraph.types import Command, interrupt
+
+from agent.classify import classify as run_pipeline
+from agent.nodes.trainer_log import assemble_trainer_log, build_ai_prediction
+
+
+class CallState(TypedDict, total=False):
+    """Graph state shape — carries the full prediction through the pipeline."""
+    transcript_id: str
+    turns: List[dict]
+    caller_phone: Optional[str]
+    prediction: Dict[str, Any]
+    needs_human_review: bool
+    review_payload: Dict[str, Any]
+    human_override: Optional[Dict[str, Any]]
+
+
+def _run_pipeline_node(state: CallState) -> dict:
+    """Execute the full classification pipeline (all 9 nodes).
+
+    This is the load-bearing node — it runs extract, classify, location,
+    risk, validate, vendor, clarify, summary, and trainer_log assembly.
+    """
+    turns = state["turns"]
+    caller_phone = state.get("caller_phone")
+
+    prediction = run_pipeline(turns, caller_phone)
+
+    needs_review = bool(prediction.get("needs_human_review", False))
+
+    return {
+        "prediction": prediction,
+        "needs_human_review": needs_review,
+        "review_payload": {
+            "type": "review_required" if needs_review else "auto_resolved",
+            "category": prediction.get("category"),
+            "subcategory": prediction.get("subcategory"),
+            "risk_level": prediction.get("risk_level"),
+            "dispatched_vendor_id": prediction.get("dispatched_vendor_id"),
+            "dispatched_emergency_services": prediction.get("dispatched_emergency_services"),
+            "call_summary": prediction.get("call_summary"),
+            "validator_reasons": (
+                prediction.get("trainer_log", {})
+                .get("ai_prediction", {})
+                .get("validator_reasons", [])
+            ),
+        },
+    }
+
+
+def _review_gate_node(state: CallState) -> dict:
+    """Conditionally interrupt for human review.
+
+    If the validator flagged `needs_human_review=True`, this node calls
+    `interrupt()` which pauses the graph. The human (or eval harness)
+    resumes with either:
+      - {"action": "approve"}
+      - {"action": "override", "fields": {"risk_level": "LOW", ...}}
+    """
+    if not state.get("needs_human_review"):
+        return {"human_override": None}
+
+    decision = interrupt(state["review_payload"])
+
+    action = decision.get("action", "approve") if isinstance(decision, dict) else "approve"
+
+    if action == "override" and isinstance(decision, dict):
+        override_fields = decision.get("fields", {})
+        prediction = state["prediction"]
+        updated_prediction = {**prediction, **override_fields}
+
+        ai_pred = prediction.get("trainer_log", {}).get("ai_prediction", {})
+        updated_prediction["trainer_log"] = assemble_trainer_log(
+            full_transcript=prediction.get("trainer_log", {}).get("full_transcript", ""),
+            ai_prediction=ai_pred,
+            human_override=override_fields,
+            final_decision={**ai_pred, **override_fields},
+        )
+
+        return {
+            "prediction": updated_prediction,
+            "human_override": override_fields,
+        }
+
+    return {"human_override": None}
+
+
+def build_graph() -> StateGraph:
+    """Construct the StateGraph (uncompiled). Call .compile(checkpointer=...) to use."""
+    workflow = StateGraph(CallState)
+
+    workflow.add_node("run_pipeline", _run_pipeline_node)
+    workflow.add_node("review_gate", _review_gate_node)
+
+    workflow.add_edge(START, "run_pipeline")
+    workflow.add_edge("run_pipeline", "review_gate")
+    workflow.add_edge("review_gate", END)
+
+    return workflow
+
+
+def compile_graph(*, checkpointer=None):
+    """Compile the graph with a checkpointer. Defaults to InMemorySaver."""
+    if checkpointer is None:
+        checkpointer = InMemorySaver()
+    workflow = build_graph()
+    return workflow.compile(checkpointer=checkpointer)
+
+
+def invoke_call(
+    graph,
+    *,
+    transcript_id: str,
+    turns: List[dict],
+    caller_phone: Optional[str] = None,
+    auto_approve: bool = True,
+) -> Dict[str, Any]:
+    """Run a single call through the graph with interrupt handling.
+
+    Args:
+        graph: compiled StateGraph.
+        transcript_id: unique ID for thread/checkpoint.
+        turns: dialogue turn list.
+        caller_phone: caller phone number (optional).
+        auto_approve: if True (eval mode), automatically approves any
+            interrupt without human intervention.
+
+    Returns:
+        The final prediction dict.
+    """
+    config = {"configurable": {"thread_id": f"call-{transcript_id}"}}
+
+    initial_state = {
+        "transcript_id": transcript_id,
+        "turns": turns,
+        "caller_phone": caller_phone,
+    }
+
+    output = graph.invoke(initial_state, config)
+
+    if auto_approve:
+        state = graph.get_state(config)
+        if state.next:
+            output = graph.invoke(
+                Command(resume={"action": "approve"}), config
+            )
+
+    return output.get("prediction", output)
+
+
+def override_after_execution(
+    graph,
+    *,
+    transcript_id: str,
+    override_fields: Dict[str, Any],
+) -> None:
+    """Post-execution override via update_state().
+
+    Modifies the checkpoint for a completed call — simulates a supervisor
+    correcting the AI's decision during post-shift review.
+    """
+    config = {"configurable": {"thread_id": f"call-{transcript_id}"}}
+
+    state = graph.get_state(config)
+    if not state.values:
+        raise ValueError(f"No checkpoint found for thread call-{transcript_id}")
+
+    prediction = state.values.get("prediction", {})
+    ai_pred = prediction.get("trainer_log", {}).get("ai_prediction", {})
+
+    updated_prediction = {**prediction, **override_fields}
+    updated_prediction["trainer_log"] = assemble_trainer_log(
+        full_transcript=prediction.get("trainer_log", {}).get("full_transcript", ""),
+        ai_prediction=ai_pred,
+        human_override=override_fields,
+        final_decision={**ai_pred, **override_fields},
+    )
+
+    graph.update_state(
+        config,
+        {"prediction": updated_prediction, "human_override": override_fields},
+    )

--- a/tests/test_graph.py
+++ b/tests/test_graph.py
@@ -1,0 +1,313 @@
+"""Tests for `agent.graph` — LangGraph interrupt/resume/override HITL path.
+
+Two layers:
+1. Unit tests of the node functions (no LangGraph runtime needed).
+2. Integration tests using the compiled graph with InMemorySaver
+   (requires langgraph to be installed).
+
+Tests in layer 2 are skipped if langgraph is not importable.
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from typing import Any, Dict
+from unittest.mock import patch
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+try:
+    from langgraph.checkpoint.memory import InMemorySaver
+    from langgraph.types import Command
+    HAS_LANGGRAPH = True
+except ImportError:
+    HAS_LANGGRAPH = False
+
+try:
+    from agent import graph as graph_mod
+except ImportError:
+    graph_mod = None
+
+
+# ─── Fixtures ─────────────────────────────────────────────────────────
+
+SAMPLE_TURNS = [
+    {"speaker": "agent", "text": "CBRE maintenance, what's going on?"},
+    {"speaker": "caller", "text": "Pipe burst on Floor 3, water everywhere."},
+]
+
+SAMPLE_PREDICTION = {
+    "category": "PLUMBING",
+    "subcategory": "pipe_leak",
+    "risk_level": "HIGH",
+    "needs_human_review": True,
+    "needs_clarification": False,
+    "building_name": "Pacific Ridge Medical Plaza",
+    "address": "3200 Pacific Coast Hwy",
+    "floor": "Floor 3",
+    "dispatched_vendor_id": "v_002",
+    "dispatched_emergency_services": False,
+    "call_summary": "Pipe burst on Floor 3 at Pacific Ridge. HIGH risk. Dispatched AquaFix Plumbing.",
+    "trainer_log": {
+        "full_transcript": "[AGENT] CBRE maintenance\n[CALLER] Pipe burst",
+        "ai_prediction": {
+            "category": "PLUMBING",
+            "subcategory": "pipe_leak",
+            "risk_level": "HIGH",
+            "dispatched_vendor_id": "v_002",
+            "dispatched_emergency_services": False,
+            "needs_human_review": True,
+            "needs_clarification": False,
+            "confidence_category": 0.9,
+            "confidence_subcategory": 0.85,
+            "validator_reasons": ["high_band:always_pause"],
+            "risk_reasons": ["base_risk=HIGH"],
+            "retrieved_record_ids": ["TKT-001"],
+        },
+        "human_override": None,
+        "final_decision": {
+            "category": "PLUMBING",
+            "subcategory": "pipe_leak",
+            "risk_level": "HIGH",
+            "dispatched_vendor_id": "v_002",
+            "dispatched_emergency_services": False,
+            "needs_human_review": True,
+            "needs_clarification": False,
+        },
+    },
+}
+
+ROUTINE_PREDICTION = {
+    **SAMPLE_PREDICTION,
+    "risk_level": "LOW",
+    "needs_human_review": False,
+    "trainer_log": {
+        **SAMPLE_PREDICTION["trainer_log"],
+        "ai_prediction": {
+            **SAMPLE_PREDICTION["trainer_log"]["ai_prediction"],
+            "risk_level": "LOW",
+            "needs_human_review": False,
+            "validator_reasons": ["auto_resolve:no_flags_fired"],
+        },
+    },
+}
+
+
+# ─── Unit tests: _run_pipeline_node ───────────────────────────────────
+
+
+def _skip_no_langgraph():
+    if graph_mod is None:
+        print("  SKIP (langgraph not installed)")
+        return True
+    return False
+
+
+def test_run_pipeline_node_calls_classify():
+    """Node calls agent.classify.classify and wraps result."""
+    if _skip_no_langgraph():
+        return
+    state = {
+        "turns": SAMPLE_TURNS,
+        "caller_phone": "+15551234567",
+    }
+    with patch.object(graph_mod, "run_pipeline", return_value=SAMPLE_PREDICTION):
+        result = graph_mod._run_pipeline_node(state)
+
+    assert result["prediction"] == SAMPLE_PREDICTION
+    assert result["needs_human_review"] is True
+    assert result["review_payload"]["type"] == "review_required"
+    assert result["review_payload"]["category"] == "PLUMBING"
+
+
+def test_run_pipeline_node_auto_resolved():
+    """Routine call gets review_payload type=auto_resolved."""
+    if _skip_no_langgraph():
+        return
+    state = {"turns": SAMPLE_TURNS, "caller_phone": None}
+    with patch.object(graph_mod, "run_pipeline", return_value=ROUTINE_PREDICTION):
+        result = graph_mod._run_pipeline_node(state)
+
+    assert result["needs_human_review"] is False
+    assert result["review_payload"]["type"] == "auto_resolved"
+
+
+# ─── Unit tests: _review_gate_node ───────────────────────────────────
+
+
+def test_review_gate_skips_when_no_review_needed():
+    """Auto-resolved calls pass through without interrupt."""
+    if _skip_no_langgraph():
+        return
+    state = {
+        "needs_human_review": False,
+        "prediction": ROUTINE_PREDICTION,
+        "review_payload": {"type": "auto_resolved"},
+    }
+    result = graph_mod._review_gate_node(state)
+    assert result["human_override"] is None
+
+
+# ─── Unit tests: build_graph structure ────────────────────────────────
+
+
+def test_build_graph_has_expected_nodes():
+    """Graph contains run_pipeline and review_gate nodes."""
+    if _skip_no_langgraph():
+        return
+    workflow = graph_mod.build_graph()
+    node_names = set(workflow.nodes.keys())
+    assert "run_pipeline" in node_names
+    assert "review_gate" in node_names
+
+
+# ─── Integration tests (require langgraph) ───────────────────────────
+
+
+def test_full_graph_auto_approve_routine_call():
+    """Routine call goes through without interrupt."""
+    if _skip_no_langgraph():
+        return
+
+    with patch.object(graph_mod, "run_pipeline", return_value=ROUTINE_PREDICTION):
+        compiled = graph_mod.compile_graph()
+        result = graph_mod.invoke_call(
+            compiled,
+            transcript_id="TEST-001",
+            turns=SAMPLE_TURNS,
+            caller_phone=None,
+            auto_approve=True,
+        )
+
+    assert result["category"] == "PLUMBING"
+    assert result["needs_human_review"] is False
+
+
+def test_full_graph_auto_approve_high_risk_call():
+    """HIGH risk call hits interrupt, auto_approve resumes it."""
+    if _skip_no_langgraph():
+        return
+
+    with patch.object(graph_mod, "run_pipeline", return_value=SAMPLE_PREDICTION):
+        compiled = graph_mod.compile_graph()
+        result = graph_mod.invoke_call(
+            compiled,
+            transcript_id="TEST-002",
+            turns=SAMPLE_TURNS,
+            caller_phone="+15551234567",
+            auto_approve=True,
+        )
+
+    assert result["category"] == "PLUMBING"
+    assert result["risk_level"] == "HIGH"
+
+
+def test_full_graph_override_changes_prediction():
+    """Override via Command(resume) modifies the prediction."""
+    if _skip_no_langgraph():
+        return
+
+    with patch.object(graph_mod, "run_pipeline", return_value=SAMPLE_PREDICTION):
+        compiled = graph_mod.compile_graph()
+        config = {"configurable": {"thread_id": "call-TEST-003"}}
+
+        compiled.invoke(
+            {
+                "transcript_id": "TEST-003",
+                "turns": SAMPLE_TURNS,
+                "caller_phone": None,
+            },
+            config,
+        )
+
+        state = compiled.get_state(config)
+        if state.next:
+            output = compiled.invoke(
+                Command(resume={
+                    "action": "override",
+                    "fields": {"risk_level": "MEDIUM", "needs_human_review": False},
+                }),
+                config,
+            )
+            prediction = output.get("prediction", output)
+            assert prediction["risk_level"] == "MEDIUM"
+            assert prediction["trainer_log"]["human_override"] == {
+                "risk_level": "MEDIUM",
+                "needs_human_review": False,
+            }
+
+
+def test_update_state_post_execution_override():
+    """update_state() modifies a completed checkpoint."""
+    if _skip_no_langgraph():
+        return
+
+    with patch.object(graph_mod, "run_pipeline", return_value=ROUTINE_PREDICTION):
+        compiled = graph_mod.compile_graph()
+        graph_mod.invoke_call(
+            compiled,
+            transcript_id="TEST-004",
+            turns=SAMPLE_TURNS,
+            auto_approve=True,
+        )
+
+        graph_mod.override_after_execution(
+            compiled,
+            transcript_id="TEST-004",
+            override_fields={"subcategory": "drainage_backup"},
+        )
+
+        config = {"configurable": {"thread_id": "call-TEST-004"}}
+        state = compiled.get_state(config)
+        prediction = state.values.get("prediction", {})
+        assert prediction["subcategory"] == "drainage_backup"
+        assert prediction["trainer_log"]["human_override"] == {"subcategory": "drainage_backup"}
+
+
+def test_thread_id_strategy():
+    """Thread IDs follow the f'call-{transcript_id}' convention."""
+    if _skip_no_langgraph():
+        return
+
+    with patch.object(graph_mod, "run_pipeline", return_value=ROUTINE_PREDICTION):
+        compiled = graph_mod.compile_graph()
+        graph_mod.invoke_call(
+            compiled,
+            transcript_id="EVAL-0042",
+            turns=SAMPLE_TURNS,
+            auto_approve=True,
+        )
+
+        config = {"configurable": {"thread_id": "call-EVAL-0042"}}
+        state = compiled.get_state(config)
+        assert state.values is not None
+        assert "prediction" in state.values
+
+
+# ─── Inline runner ─────────────────────────────────────────────────────
+
+
+if __name__ == "__main__":
+    import inspect
+
+    tests = [(n, f) for n, f in inspect.getmembers(sys.modules[__name__])
+             if n.startswith("test_") and callable(f)]
+    failed = 0
+    skipped = 0
+    for name, fn in sorted(tests):
+        try:
+            fn()
+            print(f"  PASS  {name}")
+        except AssertionError as e:
+            print(f"  FAIL  {name}: {e}")
+            failed += 1
+        except Exception as e:
+            if "langgraph" in str(e).lower() or "SKIP" in str(e):
+                print(f"  SKIP  {name}: {e}")
+                skipped += 1
+            else:
+                print(f"  ERROR {name}: {type(e).__name__}: {e}")
+                failed += 1
+    total = len(tests)
+    print(f"\n{total - failed - skipped}/{total} passed, {skipped} skipped, {failed} failed")
+    sys.exit(1 if failed else 0)


### PR DESCRIPTION
## Summary
- Implements `agent/graph.py` — LangGraph StateGraph wrapping the orchestrator with full HITL semantics
- **Interrupt**: `interrupt()` fires at the review gate when `needs_human_review=True`, surfacing a payload with the AI's classification + reasons
- **Resume (approve)**: `Command(resume={"action": "approve"})` continues unchanged
- **Resume (override)**: `Command(resume={"action": "override", "fields": {...}})` replaces fields and records diff in `trainer_log.human_override`
- **Post-execution override**: `update_state()` modifies completed checkpoints (supervisor review pattern)
- Thread-ID strategy: `f"call-{transcript_id}"` with `InMemorySaver`
- `invoke_call()` helper with `auto_approve=True` for eval harness (no live human blocks scoring)

## Test plan
- [x] 9 tests: pipeline node wrapping, auto-resolve passthrough, review gate skip, graph structure, full-graph auto-approve (routine + high-risk), override via resume, post-execution update_state, thread-id convention
- [x] Tests gracefully skip when langgraph not installed (dependency issue only)
- [ ] Full integration with langgraph installed: `pip install -r requirements.txt && python tests/test_graph.py`

Closes #17

🤖 Generated with [Claude Code](https://claude.com/claude-code)