### PR TITLE
eval: commit stacked-main dev baseline (composite 90.88)

### DIFF
--- a/eval_runs/README.md
+++ b/eval_runs/README.md
@@ -100,3 +100,4 @@ Output is deterministic modulo the documented LLM-provider noise floor
 | 2026-05-19T05:15:15Z | `33fc3bc` | 87.95 | 0 | baseline — fixed pipeline (issues #16/#19/#20/#21 + orchestrator) |
 | 2026-05-19T (run b)  | `7511166` | 88.30 | 0 | issue #63/#64 — trap-cascade HITL rule, `cascade_excludes=[waste_odor]`. hitl_f1 68.42 → 71.94 (+3.52), auto_resolution 85.88 (unchanged). Predictions: `eval_runs/dev_issue63.json`. |
 | 2026-05-19T (run c)  | `98b2c16` | 88.10 | 0 | issue #65 — phone-history fallback + profile-echo override (fields axis 88.0 → 91.0, +3.0; small LLM-noise dips on subcategory/risk). Predictions: `eval_runs/dev_issue65.json`. |
+| 2026-05-19T (run d)  | `8262a79` | 90.88 | 0 | stacked main: #68 + #69 + #70 all merged. clarif_f1 0.75→0.92, auto_res 85.9→97.7, hitl_f1 +3.0, fields +3.0, vendor +3.0. Predictions: `eval_runs/dev_stacked.json`. |

--- a/eval_runs/dev_stacked.json
+++ b/eval_runs/dev_stacked.json
@@ -1,0 +1,14636 @@
+[
+  {
+    "category": "PLUMBING",
+    "subcategory": "drainage_backup",
+    "risk_level": "LOW",
+    "needs_human_review": false,
+    "needs_clarification": false,
+    "building_name": "Summit Office Towers",
+    "address": "800 Summit Blvd",
+    "floor": "Floor 9",
+    "dispatched_vendor_id": "v_002",
+    "dispatched_emergency_services": false,
+    "call_summary": "Drainage backup reported at Summit Office Towers, Floor 9. LOW risk. Dispatched Metro Drain & Pipe.",
+    "trainer_log": {
+      "full_transcript": "[AGENT] CBRE maintenance, this is Dana. What's going on?\n[CALLER] Good morning, sorry, The breakroom sink on Floor 9 won't drain \u2014 it's full and not going anywhere.\n[AGENT] Okay. Is the water overflowing onto the floor?\n[CALLER] Yeah, hold on, there's definitely a smell.\n[AGENT] Got it. I'll get someone out as soon as I can \u2014 should hear back within the hour.",
+      "ai_prediction": {
+        "category": "PLUMBING",
+        "subcategory": "drainage_backup",
+        "risk_level": "LOW",
+        "dispatched_vendor_id": "v_002",
+        "dispatched_emergency_services": false,
+        "needs_human_review": false,
+        "needs_clarification": false,
+        "confidence_category": 0.95,
+        "confidence_subcategory": 0.95,
+        "validator_reasons": [
+          "auto_resolve:no_flags_fired"
+        ],
+        "risk_reasons": [
+          "base_risk:LOW"
+        ],
+        "retrieved_record_ids": [
+          "TKT-2022-07267",
+          "TKT-2024-01245",
+          "TKT-2024-06765",
+          "TKT-2024-01050",
+          "TKT-2023-05123",
+          "TKT-2022-01120",
+          "TKT-2023-02699",
+          "TKT-2022-01528"
+        ]
+      },
+      "human_override": null,
+      "final_decision": {
+        "category": "PLUMBING",
+        "subcategory": "drainage_backup",
+        "risk_level": "LOW",
+        "dispatched_vendor_id": "v_002",
+        "dispatched_emergency_services": false,
+        "needs_human_review": false,
+        "needs_clarification": false,
+        "confidence_category": 0.95,
+        "confidence_subcategory": 0.95,
+        "validator_reasons": [
+          "auto_resolve:no_flags_fired"
+        ],
+        "risk_reasons": [
+          "base_risk:LOW"
+        ],
+        "retrieved_record_ids": [
+          "TKT-2022-07267",
+          "TKT-2024-01245",
+          "TKT-2024-06765",
+          "TKT-2024-01050",
+          "TKT-2023-05123",
+          "TKT-2022-01120",
+          "TKT-2023-02699",
+          "TKT-2022-01528"
+        ]
+      }
+    },
+    "transcript_id": "EVAL-0004"
+  },
+  {
+    "category": "ELEVATOR",
+    "subcategory": "malfunction",
+    "risk_level": "MEDIUM",
+    "needs_human_review": true,
+    "needs_clarification": false,
+    "building_name": "Torrance Gateway Center",
+    "address": "3500 Carson St",
+    "floor": "Floor 2",
+    "dispatched_vendor_id": "v_016",
+    "dispatched_emergency_services": false,
+    "call_summary": "Equipment malfunction reported at Torrance Gateway Center, Floor 2. MEDIUM risk. Flagged for review. Skyline Elevator Co dispatched pending approval.",
+    "trainer_log": {
+      "full_transcript": "[AGENT] CBRE facilities, this is Sam. What's going on?\n[CALLER] Elevator stopped with someone inside \u2014 but the doors are fully open on the ground floor, they just can't get it to go.\n[AGENT] Okay \u2014 can you confirm there's no actual fire or injury right now?\n[CALLER] Uh, no, they're out of the car. It's just stuck empty.\n[AGENT] Which building and floor are you at?\n[CALLER] Torrance Gateway Center, Floor 2, Suite 205.\n[AGENT] Alright \u2014 sending a vendor over and giving the PM a heads-up.",
+      "ai_prediction": {
+        "category": "ELEVATOR",
+        "subcategory": "malfunction",
+        "risk_level": "MEDIUM",
+        "dispatched_vendor_id": "v_016",
+        "dispatched_emergency_services": false,
+        "needs_human_review": true,
+        "needs_clarification": false,
+        "confidence_category": 0.9,
+        "confidence_subcategory": 0.9,
+        "validator_reasons": [
+          "trap_cascade_subcategory:malfunction(high-audit cell at HIGH/EMERGENCY \u2014 possible under-classification)"
+        ],
+        "risk_reasons": [
+          "base_risk:MEDIUM"
+        ],
+        "retrieved_record_ids": [
+          "TKT-2022-07741",
+          "TKT-2024-02205",
+          "TKT-2022-05482",
+          "TKT-2024-02223",
+          "TKT-2024-03417",
+          "TKT-2022-05998",
+          "TKT-2022-00391",
+          "TKT-2023-09029"
+        ]
+      },
+      "human_override": null,
+      "final_decision": {
+        "category": "ELEVATOR",
+        "subcategory": "malfunction",
+        "risk_level": "MEDIUM",
+        "dispatched_vendor_id": "v_016",
+        "dispatched_emergency_services": false,
+        "needs_human_review": true,
+        "needs_clarification": false,
+        "confidence_category": 0.9,
+        "confidence_subcategory": 0.9,
+        "validator_reasons": [
+          "trap_cascade_subcategory:malfunction(high-audit cell at HIGH/EMERGENCY \u2014 possible under-classification)"
+        ],
+        "risk_reasons": [
+          "base_risk:MEDIUM"
+        ],
+        "retrieved_record_ids": [
+          "TKT-2022-07741",
+          "TKT-2024-02205",
+          "TKT-2022-05482",
+          "TKT-2024-02223",
+          "TKT-2024-03417",
+          "TKT-2022-05998",
+          "TKT-2022-00391",
+          "TKT-2023-09029"
+        ]
+      }
+    },
+    "transcript_id": "EVAL-0006"
+  },
+  {
+    "category": "JANITORIAL",
+    "subcategory": "waste_odor",
+    "risk_level": "LOW",
+    "needs_human_review": false,
+    "needs_clarification": false,
+    "building_name": "Civic Center Tower",
+    "address": "300 Civic Center Dr",
+    "floor": "Floor 1",
+    "dispatched_vendor_id": "v_025",
+    "dispatched_emergency_services": false,
+    "call_summary": "Waste/odor issue reported at Civic Center Tower, Floor 1. LOW risk. Dispatched ProClean Facility Services.",
+    "trainer_log": {
+      "full_transcript": "[AGENT] CBRE maintenance \u2014 what's going on?\n[CALLER] [background: phone ringing] Hearing scratching in the walls \u2014 I think we have rodents.\n[AGENT] Alright. What kind of pest?\n[CALLER] Like, hmm, actually \u2014 I don't think it's rodents. Trash hasn't been emptied and that's probably the smell.\n[AGENT] Got it \u2014 updating the ticket. How bad is the smell?\n[CALLER] Uh, just near the breakroom.\n[AGENT] Can you confirm the building and floor?\n[CALLER] Civic Center Tower, I mean, Floor 1, Suite 108.\n[AGENT] Alright, I've put a ticket in \u2014 vendor will swing by during business hours.",
+      "ai_prediction": {
+        "category": "JANITORIAL",
+        "subcategory": "waste_odor",
+        "risk_level": "LOW",
+        "dispatched_vendor_id": "v_025",
+        "dispatched_emergency_services": false,
+        "needs_human_review": false,
+        "needs_clarification": false,
+        "confidence_category": 0.95,
+        "confidence_subcategory": 0.95,
+        "validator_reasons": [
+          "auto_resolve:no_flags_fired"
+        ],
+        "risk_reasons": [
+          "base_risk:LOW"
+        ],
+        "retrieved_record_ids": [
+          "TKT-2022-04771",
+          "TKT-2024-00141",
+          "TKT-2024-03531",
+          "TKT-2023-01829",
+          "TKT-2024-00348",
+          "TKT-2024-03612",
+          "TKT-2023-06161",
+          "TKT-2024-02214"
+        ]
+      },
+      "human_override": null,
+      "final_decision": {
+        "category": "JANITORIAL",
+        "subcategory": "waste_odor",
+        "risk_level": "LOW",
+        "dispatched_vendor_id": "v_025",
+        "dispatched_emergency_services": false,
+        "needs_human_review": false,
+        "needs_clarification": false,
+        "confidence_category": 0.95,
+        "confidence_subcategory": 0.95,
+        "validator_reasons": [
+          "auto_resolve:no_flags_fired"
+        ],
+        "risk_reasons": [
+          "base_risk:LOW"
+        ],
+        "retrieved_record_ids": [
+          "TKT-2022-04771",
+          "TKT-2024-00141",
+          "TKT-2024-03531",
+          "TKT-2023-01829",
+          "TKT-2024-00348",
+          "TKT-2024-03612",
+          "TKT-2023-06161",
+          "TKT-2024-02214"
+        ]
+      }
+    },
+    "transcript_id": "EVAL-0011"
+  },
+  {
+    "category": "ELECTRICAL",
+    "subcategory": "power_outage",
+    "risk_level": "HIGH",
+    "needs_human_review": true,
+    "needs_clarification": false,
+    "building_name": "Oakwood Corporate Campus - Building A",
+    "address": "400 Oakwood Pkwy",
+    "floor": "Floor 6",
+    "dispatched_vendor_id": "v_007",
+    "dispatched_emergency_services": false,
+    "call_summary": "Power outage reported at Oakwood Corporate Campus - Building A, Floor 6. HIGH risk. Flagged for review. Voltwise Commercial Electrical dispatched pending approval.",
+    "trainer_log": {
+      "full_transcript": "[AGENT] CBRE maintenance line, what do you need?\n[CALLER] Hello, Half the suite at Oakwood Corporate Campus - Building A on Floor 6 in Suite 605 has no power - breaker keeps tripping.\n[AGENT] Understood. Are the emergency lights on?\n[CALLER] Whole floor, sorry, all the lights and outlets.\n[AGENT] Sending a tech your way now. You'll hear from them en route.\n[CALLER] Like, alright, appreciate it.",
+      "ai_prediction": {
+        "category": "ELECTRICAL",
+        "subcategory": "power_outage",
+        "risk_level": "HIGH",
+        "dispatched_vendor_id": "v_007",
+        "dispatched_emergency_services": false,
+        "needs_human_review": true,
+        "needs_clarification": false,
+        "confidence_category": 0.95,
+        "confidence_subcategory": 0.95,
+        "validator_reasons": [
+          "high_band:always_pause"
+        ],
+        "risk_reasons": [
+          "base_risk:HIGH"
+        ],
+        "retrieved_record_ids": [
+          "TKT-2024-08649",
+          "TKT-2022-07357",
+          "TKT-2024-04500",
+          "TKT-2022-04348",
+          "TKT-2023-03311",
+          "TKT-2024-06999",
+          "TKT-2023-00458",
+          "TKT-2023-07121"
+        ]
+      },
+      "human_override": null,
+      "final_decision": {
+        "category": "ELECTRICAL",
+        "subcategory": "power_outage",
+        "risk_level": "HIGH",
+        "dispatched_vendor_id": "v_007",
+        "dispatched_emergency_services": false,
+        "needs_human_review": true,
+        "needs_clarification": false,
+        "confidence_category": 0.95,
+        "confidence_subcategory": 0.95,
+        "validator_reasons": [
+          "high_band:always_pause"
+        ],
+        "risk_reasons": [
+          "base_risk:HIGH"
+        ],
+        "retrieved_record_ids": [
+          "TKT-2024-08649",
+          "TKT-2022-07357",
+          "TKT-2024-04500",
+          "TKT-2022-04348",
+          "TKT-2023-03311",
+          "TKT-2024-06999",
+          "TKT-2023-00458",
+          "TKT-2023-07121"
+        ]
+      }
+    },
+    "transcript_id": "EVAL-0019"
+  },
+  {
+    "category": "GROUNDS_EXTERIOR",
+    "subcategory": "parking_lighting",
+    "risk_level": "LOW",
+    "needs_human_review": false,
+    "needs_clarification": false,
+    "building_name": "The Atrium at South Coast",
+    "address": "3100 Bristol St",
+    "floor": "Floor 4",
+    "dispatched_vendor_id": "v_008",
+    "dispatched_emergency_services": false,
+    "call_summary": "Parking area lighting issue reported at The Atrium at South Coast, Floor 4. LOW risk. Dispatched Rapid Response Electricians.",
+    "trainer_log": {
+      "full_transcript": "[AGENT] CBRE maintenance line, what do you need?\n[CALLER] Hi there, Half the parking lot is dark \u2014 multiple lights out.\n[AGENT] Okay, I see. How many fixtures are out?\n[CALLER] The back row is all out.\n[AGENT] Can you tell me the building, floor, and suite?\n[CALLER] The Atrium at South Coast, Floor 4.\n[AGENT] Alright, I'll send a vendor over. You'll get a text once they're rolling.\n[CALLER] Got it, thanks.",
+      "ai_prediction": {
+        "category": "GROUNDS_EXTERIOR",
+        "subcategory": "parking_lighting",
+        "risk_level": "LOW",
+        "dispatched_vendor_id": "v_008",
+        "dispatched_emergency_services": false,
+        "needs_human_review": false,
+        "needs_clarification": false,
+        "confidence_category": 0.9,
+        "confidence_subcategory": 0.9,
+        "validator_reasons": [
+          "auto_resolve:no_flags_fired"
+        ],
+        "risk_reasons": [
+          "base_risk:LOW"
+        ],
+        "retrieved_record_ids": [
+          "TKT-2024-00300",
+          "TKT-2024-02253",
+          "TKT-2024-03423",
+          "TKT-2022-08455",
+          "TKT-2023-05675",
+          "TKT-2023-04784",
+          "TKT-2023-02969",
+          "TKT-2023-00701"
+        ]
+      },
+      "human_override": null,
+      "final_decision": {
+        "category": "GROUNDS_EXTERIOR",
+        "subcategory": "parking_lighting",
+        "risk_level": "LOW",
+        "dispatched_vendor_id": "v_008",
+        "dispatched_emergency_services": false,
+        "needs_human_review": false,
+        "needs_clarification": false,
+        "confidence_category": 0.9,
+        "confidence_subcategory": 0.9,
+        "validator_reasons": [
+          "auto_resolve:no_flags_fired"
+        ],
+        "risk_reasons": [
+          "base_risk:LOW"
+        ],
+        "retrieved_record_ids": [
+          "TKT-2024-00300",
+          "TKT-2024-02253",
+          "TKT-2024-03423",
+          "TKT-2022-08455",
+          "TKT-2023-05675",
+          "TKT-2023-04784",
+          "TKT-2023-02969",
+          "TKT-2023-00701"
+        ]
+      }
+    },
+    "transcript_id": "EVAL-0020"
+  },
+  {
+    "category": "PLUMBING",
+    "subcategory": "restroom_fixture",
+    "risk_level": "LOW",
+    "needs_human_review": false,
+    "needs_clarification": true,
+    "building_name": "Inland Empire Logistics Center",
+    "address": "12000 Etiwanda Ave",
+    "floor": "Ground Floor",
+    "dispatched_vendor_id": "v_002",
+    "dispatched_emergency_services": false,
+    "call_summary": "Restroom fixture issue reported at Inland Empire Logistics Center, Ground Floor. LOW risk. Dispatched Metro Drain & Pipe.",
+    "trainer_log": {
+      "full_transcript": "[AGENT] Hi, CBRE facilities. What can I do for you?\n[CALLER] You know, there's an issue with restroom fixture.\n[AGENT] Is it overflowing or just running?\n[CALLER] Just running continuously.\n[AGENT] Which building and floor are you at?\n[CALLER] Inland Empire Logistics Center, Ground Floor.\n[AGENT] Got the ticket open. Vendor should make it out during business hours.",
+      "ai_prediction": {
+        "category": "PLUMBING",
+        "subcategory": "restroom_fixture",
+        "risk_level": "LOW",
+        "dispatched_vendor_id": "v_002",
+        "dispatched_emergency_services": false,
+        "needs_human_review": false,
+        "needs_clarification": true,
+        "confidence_category": 0.95,
+        "confidence_subcategory": 0.95,
+        "validator_reasons": [
+          "auto_resolve:no_flags_fired"
+        ],
+        "risk_reasons": [
+          "base_risk:LOW"
+        ],
+        "retrieved_record_ids": [
+          "TKT-2023-03701",
+          "TKT-2024-05265",
+          "TKT-2022-01435",
+          "TKT-2023-01160",
+          "TKT-2024-09777",
+          "TKT-2022-05551",
+          "TKT-2022-01498",
+          "TKT-2024-01917"
+        ]
+      },
+      "human_override": null,
+      "final_decision": {
+        "category": "PLUMBING",
+        "subcategory": "restroom_fixture",
+        "risk_level": "LOW",
+        "dispatched_vendor_id": "v_002",
+        "dispatched_emergency_services": false,
+        "needs_human_review": false,
+        "needs_clarification": true,
+        "confidence_category": 0.95,
+        "confidence_subcategory": 0.95,
+        "validator_reasons": [
+          "auto_resolve:no_flags_fired"
+        ],
+        "risk_reasons": [
+          "base_risk:LOW"
+        ],
+        "retrieved_record_ids": [
+          "TKT-2023-03701",
+          "TKT-2024-05265",
+          "TKT-2022-01435",
+          "TKT-2023-01160",
+          "TKT-2024-09777",
+          "TKT-2022-05551",
+          "TKT-2022-01498",
+          "TKT-2024-01917"
+        ]
+      }
+    },
+    "transcript_id": "EVAL-0022"
+  },
+  {
+    "category": "DOORS_ACCESS",
+    "subcategory": "door_mechanical",
+    "risk_level": "LOW",
+    "needs_human_review": false,
+    "needs_clarification": false,
+    "building_name": "Baxter Building",
+    "address": "900 Harbor Dr",
+    "floor": "Floor 4",
+    "dispatched_vendor_id": "v_010",
+    "dispatched_emergency_services": false,
+    "call_summary": "Mechanical door issue reported at Baxter Building, Floor 4. LOW risk. Dispatched All-Site Facilities Co.",
+    "trainer_log": {
+      "full_transcript": "[AGENT] Maintenance, what's the situation?\n[CALLER] Good afternoon, Handle on the conference room door came off.\n[AGENT] Got it. Can the door be secured?\n[CALLER] It's an interior door to the suite.\n[AGENT] What's your building, floor, suite?\n[CALLER] Baxter Building, Floor 4, Suite 401.\n[AGENT] Got the ticket open. Vendor should make it out during business hours.\n[CALLER] Thanks, bye.",
+      "ai_prediction": {
+        "category": "DOORS_ACCESS",
+        "subcategory": "door_mechanical",
+        "risk_level": "LOW",
+        "dispatched_vendor_id": "v_010",
+        "dispatched_emergency_services": false,
+        "needs_human_review": false,
+        "needs_clarification": false,
+        "confidence_category": 0.95,
+        "confidence_subcategory": 0.95,
+        "validator_reasons": [
+          "auto_resolve:no_flags_fired"
+        ],
+        "risk_reasons": [
+          "base_risk:LOW"
+        ],
+        "retrieved_record_ids": [
+          "TKT-2022-08599",
+          "TKT-2024-01140",
+          "TKT-2024-01089",
+          "TKT-2023-08012",
+          "TKT-2023-01742",
+          "TKT-2024-04578",
+          "TKT-2024-06825",
+          "TKT-2024-01185"
+        ]
+      },
+      "human_override": null,
+      "final_decision": {
+        "category": "DOORS_ACCESS",
+        "subcategory": "door_mechanical",
+        "risk_level": "LOW",
+        "dispatched_vendor_id": "v_010",
+        "dispatched_emergency_services": false,
+        "needs_human_review": false,
+        "needs_clarification": false,
+        "confidence_category": 0.95,
+        "confidence_subcategory": 0.95,
+        "validator_reasons": [
+          "auto_resolve:no_flags_fired"
+        ],
+        "risk_reasons": [
+          "base_risk:LOW"
+        ],
+        "retrieved_record_ids": [
+          "TKT-2022-08599",
+          "TKT-2024-01140",
+          "TKT-2024-01089",
+          "TKT-2023-08012",
+          "TKT-2023-01742",
+          "TKT-2024-04578",
+          "TKT-2024-06825",
+          "TKT-2024-01185"
+        ]
+      }
+    },
+    "transcript_id": "EVAL-0025"
+  },
+  {
+    "category": "ELEVATOR",
+    "subcategory": "malfunction",
+    "risk_level": "MEDIUM",
+    "needs_human_review": true,
+    "needs_clarification": false,
+    "building_name": "Redwood Corporate Plaza",
+    "address": "2400 Redwood Hwy",
+    "floor": "Floor 4",
+    "dispatched_vendor_id": "v_017",
+    "dispatched_emergency_services": false,
+    "call_summary": "Equipment malfunction reported at Redwood Corporate Plaza, Floor 4. MEDIUM risk. Flagged for review. Valley Elevator Service dispatched pending approval.",
+    "trainer_log": {
+      "full_transcript": "[AGENT] CBRE facilities, this is Sam. What's going on?\n[CALLER] Good afternoon, Elevator is stuck on the ground floor, nobody was in it.\n[AGENT] Mhm. Is the car moving at all?\n[CALLER] Doors open, like, car hasn't left the lobby.\n[AGENT] Which building and floor are you at?\n[CALLER] Redwood Corporate Plaza, Floor 4, Suite 408.\n[AGENT] Bumping this up to the on-call supervisor \u2014 vendor's going out as we speak.\n[AGENT] I'm not seeing anyone in the pool who fully covers this \u2014 I'll escalate to the on-call PM to route manually.\n[CALLER] Okay, uh, please hurry.",
+      "ai_prediction": {
+        "category": "ELEVATOR",
+        "subcategory": "malfunction",
+        "risk_level": "MEDIUM",
+        "dispatched_vendor_id": "v_017",
+        "dispatched_emergency_services": false,
+        "needs_human_review": true,
+        "needs_clarification": false,
+        "confidence_category": 0.9,
+        "confidence_subcategory": 0.9,
+        "validator_reasons": [
+          "trap_cascade_subcategory:malfunction(high-audit cell at HIGH/EMERGENCY \u2014 possible under-classification)"
+        ],
+        "risk_reasons": [
+          "base_risk:MEDIUM"
+        ],
+        "retrieved_record_ids": [
+          "TKT-2022-07741",
+          "TKT-2022-00391",
+          "TKT-2024-03417",
+          "TKT-2024-02205",
+          "TKT-2024-01425",
+          "TKT-2024-05019",
+          "TKT-2023-07646",
+          "TKT-2022-04444"
+        ]
+      },
+      "human_override": null,
+      "final_decision": {
+        "category": "ELEVATOR",
+        "subcategory": "malfunction",
+        "risk_level": "MEDIUM",
+        "dispatched_vendor_id": "v_017",
+        "dispatched_emergency_services": false,
+        "needs_human_review": true,
+        "needs_clarification": false,
+        "confidence_category": 0.9,
+        "confidence_subcategory": 0.9,
+        "validator_reasons": [
+          "trap_cascade_subcategory:malfunction(high-audit cell at HIGH/EMERGENCY \u2014 possible under-classification)"
+        ],
+        "risk_reasons": [
+          "base_risk:MEDIUM"
+        ],
+        "retrieved_record_ids": [
+          "TKT-2022-07741",
+          "TKT-2022-00391",
+          "TKT-2024-03417",
+          "TKT-2024-02205",
+          "TKT-2024-01425",
+          "TKT-2024-05019",
+          "TKT-2023-07646",
+          "TKT-2022-04444"
+        ]
+      }
+    },
+    "transcript_id": "EVAL-0027"
+  },
+  {
+    "category": "PEST_SPECIALTY",
+    "subcategory": "infestation",
+    "risk_level": "MEDIUM",
+    "needs_human_review": false,
+    "needs_clarification": false,
+    "building_name": "Pacific Ridge Medical Plaza",
+    "address": "3200 Pacific Coast Hwy",
+    "floor": "Floor 7",
+    "dispatched_vendor_id": "v_030",
+    "dispatched_emergency_services": false,
+    "call_summary": "Pest infestation reported at Pacific Ridge Medical Plaza, Floor 7. MEDIUM risk. Dispatched Westside Pest Control.",
+    "trainer_log": {
+      "full_transcript": "[AGENT] CBRE maintenance, this is Dana. What's going on?\n[CALLER] There's something living in here that shouldn't be.\n[AGENT] Okay, can you describe what you're seeing or smelling?\n[CALLER] There's droppings behind the trash bins.\n[AGENT] How often are you seeing them?\n[CALLER] Hold on, there's droppings behind the trash bins.\n[AGENT] Can you confirm the building and floor?\n[CALLER] Pacific Ridge Medical Plaza, Floor 7, Suite 610.\n[AGENT] Alright, I've put a ticket in \u2014 vendor will swing by during business hours.",
+      "ai_prediction": {
+        "category": "PEST_SPECIALTY",
+        "subcategory": "infestation",
+        "risk_level": "MEDIUM",
+        "dispatched_vendor_id": "v_030",
+        "dispatched_emergency_services": false,
+        "needs_human_review": false,
+        "needs_clarification": false,
+        "confidence_category": 0.95,
+        "confidence_subcategory": 0.95,
+        "validator_reasons": [
+          "auto_resolve:no_flags_fired"
+        ],
+        "risk_reasons": [
+          "base_risk:LOW",
+          "sensitive_building:medical"
+        ],
+        "retrieved_record_ids": [
+          "TKT-2022-09499",
+          "TKT-2024-05604",
+          "TKT-2024-04998",
+          "TKT-2023-01886",
+          "TKT-2022-02389",
+          "TKT-2022-09517",
+          "TKT-2024-05955",
+          "TKT-2024-09741"
+        ]
+      },
+      "human_override": null,
+      "final_decision": {
+        "category": "PEST_SPECIALTY",
+        "subcategory": "infestation",
+        "risk_level": "MEDIUM",
+        "dispatched_vendor_id": "v_030",
+        "dispatched_emergency_services": false,
+        "needs_human_review": false,
+        "needs_clarification": false,
+        "confidence_category": 0.95,
+        "confidence_subcategory": 0.95,
+        "validator_reasons": [
+          "auto_resolve:no_flags_fired"
+        ],
+        "risk_reasons": [
+          "base_risk:LOW",
+          "sensitive_building:medical"
+        ],
+        "retrieved_record_ids": [
+          "TKT-2022-09499",
+          "TKT-2024-05604",
+          "TKT-2024-04998",
+          "TKT-2023-01886",
+          "TKT-2022-02389",
+          "TKT-2022-09517",
+          "TKT-2024-05955",
+          "TKT-2024-09741"
+        ]
+      }
+    },
+    "transcript_id": "EVAL-0032"
+  },
+  {
+    "category": "PEST_SPECIALTY",
+    "subcategory": "infestation",
+    "risk_level": "LOW",
+    "needs_human_review": false,
+    "needs_clarification": false,
+    "building_name": "Airport Business Center",
+    "address": "9200 Airport Blvd",
+    "floor": "Floor 5",
+    "dispatched_vendor_id": "v_030",
+    "dispatched_emergency_services": false,
+    "call_summary": "Pest infestation reported at Airport Business Center, Floor 5. LOW risk. Dispatched Westside Pest Control.",
+    "trainer_log": {
+      "full_transcript": "[AGENT] CBRE maintenance line, what do you need?\n[CALLER] Sorry, stinks in the breakroom \u2014 trash or something.\n[AGENT] Mhm. Is it affecting the whole floor or just one area?\n[CALLER] Wait \u2014 actually I just saw a mouse under the fridge. It's not the trash, like, we have rodents.\n[AGENT] Got it \u2014 updating the ticket. What kind of pest?\n[CALLER] Seeing one or two a day for a week.\n[AGENT] Where exactly \u2014 which suite?\n[CALLER] Uh, airport Business Center, Floor 5, Suite 504.\n[AGENT] Alright, I'll send a vendor over. You'll get a text once they're rolling.",
+      "ai_prediction": {
+        "category": "PEST_SPECIALTY",
+        "subcategory": "infestation",
+        "risk_level": "LOW",
+        "dispatched_vendor_id": "v_030",
+        "dispatched_emergency_services": false,
+        "needs_human_review": false,
+        "needs_clarification": false,
+        "confidence_category": 0.95,
+        "confidence_subcategory": 0.95,
+        "validator_reasons": [
+          "auto_resolve:no_flags_fired"
+        ],
+        "risk_reasons": [
+          "base_risk:LOW"
+        ],
+        "retrieved_record_ids": [
+          "TKT-2023-08021",
+          "TKT-2024-09093",
+          "TKT-2022-03766",
+          "TKT-2022-02899",
+          "TKT-2022-00994",
+          "TKT-2024-04992",
+          "TKT-2022-08056",
+          "TKT-2022-07123"
+        ]
+      },
+      "human_override": null,
+      "final_decision": {
+        "category": "PEST_SPECIALTY",
+        "subcategory": "infestation",
+        "risk_level": "LOW",
+        "dispatched_vendor_id": "v_030",
+        "dispatched_emergency_services": false,
+        "needs_human_review": false,
+        "needs_clarification": false,
+        "confidence_category": 0.95,
+        "confidence_subcategory": 0.95,
+        "validator_reasons": [
+          "auto_resolve:no_flags_fired"
+        ],
+        "risk_reasons": [
+          "base_risk:LOW"
+        ],
+        "retrieved_record_ids": [
+          "TKT-2023-08021",
+          "TKT-2024-09093",
+          "TKT-2022-03766",
+          "TKT-2022-02899",
+          "TKT-2022-00994",
+          "TKT-2024-04992",
+          "TKT-2022-08056",
+          "TKT-2022-07123"
+        ]
+      }
+    },
+    "transcript_id": "EVAL-0038"
+  },
+  {
+    "category": "LIFE_SAFETY",
+    "subcategory": "structural",
+    "risk_level": "EMERGENCY",
+    "needs_human_review": true,
+    "needs_clarification": true,
+    "building_name": "Pacific Ridge Medical Plaza",
+    "address": "3200 Pacific Coast Hwy",
+    "floor": "Floor 6",
+    "dispatched_vendor_id": null,
+    "dispatched_emergency_services": false,
+    "call_summary": "Structural concern reported at Pacific Ridge Medical Plaza, Floor 6. EMERGENCY risk. Escalated to human review \u2014 no qualified vendor available.",
+    "trainer_log": {
+      "full_transcript": "[AGENT] CBRE dispatch, talk to me.\n[CALLER] Ceiling piece fell.\n[AGENT] Is anyone injured?\n[CALLER] Area's clear, I moved everyone back.\n[AGENT] Which building and floor are you at?\n[CALLER] Pacific Ridge Medical Plaza, Floor 6, Suite 610.\n[AGENT] Tricky one \u2014 I'll involve the PM and get a tech dispatched at the same time.",
+      "ai_prediction": {
+        "category": "LIFE_SAFETY",
+        "subcategory": "structural",
+        "risk_level": "EMERGENCY",
+        "dispatched_vendor_id": null,
+        "dispatched_emergency_services": false,
+        "needs_human_review": true,
+        "needs_clarification": true,
+        "confidence_category": 0.9,
+        "confidence_subcategory": 0.9,
+        "validator_reasons": [
+          "emergency_band:always_pause"
+        ],
+        "risk_reasons": [
+          "base_risk:HIGH",
+          "sensitive_building:medical"
+        ],
+        "retrieved_record_ids": [
+          "TKT-2023-04274",
+          "TKT-2022-08797",
+          "TKT-2022-08896",
+          "TKT-2022-01570",
+          "TKT-2023-05018",
+          "TKT-2024-03825",
+          "TKT-2024-00237",
+          "TKT-2023-08291"
+        ]
+      },
+      "human_override": null,
+      "final_decision": {
+        "category": "LIFE_SAFETY",
+        "subcategory": "structural",
+        "risk_level": "EMERGENCY",
+        "dispatched_vendor_id": null,
+        "dispatched_emergency_services": false,
+        "needs_human_review": true,
+        "needs_clarification": true,
+        "confidence_category": 0.9,
+        "confidence_subcategory": 0.9,
+        "validator_reasons": [
+          "emergency_band:always_pause"
+        ],
+        "risk_reasons": [
+          "base_risk:HIGH",
+          "sensitive_building:medical"
+        ],
+        "retrieved_record_ids": [
+          "TKT-2023-04274",
+          "TKT-2022-08797",
+          "TKT-2022-08896",
+          "TKT-2022-01570",
+          "TKT-2023-05018",
+          "TKT-2024-03825",
+          "TKT-2024-00237",
+          "TKT-2023-08291"
+        ]
+      }
+    },
+    "transcript_id": "EVAL-0039"
+  },
+  {
+    "category": "GROUNDS_EXTERIOR",
+    "subcategory": "signage_fencing",
+    "risk_level": "LOW",
+    "needs_human_review": false,
+    "needs_clarification": false,
+    "building_name": "Canyon View Business Center",
+    "address": "4400 Canyon View Dr",
+    "floor": "Floor 3",
+    "dispatched_vendor_id": "v_029",
+    "dispatched_emergency_services": false,
+    "call_summary": "Signage/fencing issue reported at Canyon View Business Center, Floor 3. LOW risk. Dispatched Golden State Exterior Maintenance.",
+    "trainer_log": {
+      "full_transcript": "[AGENT] CBRE facilities \u2014 how can I help?\n[CALLER] Hi there, Fence is leaning bad, wind must have done it.\n[AGENT] Understood. Could it fall and hurt someone?\n[CALLER] [door closing] Hold on, not blocking anything but it looks bad.\n[AGENT] Can you confirm the building and floor?\n[CALLER] Canyon View Business Center, Floor 3.\n[AGENT] Got it. I'll get someone out as soon as I can \u2014 should hear back within the hour.\n[CALLER] Okay, please hurry.",
+      "ai_prediction": {
+        "category": "GROUNDS_EXTERIOR",
+        "subcategory": "signage_fencing",
+        "risk_level": "LOW",
+        "dispatched_vendor_id": "v_029",
+        "dispatched_emergency_services": false,
+        "needs_human_review": false,
+        "needs_clarification": false,
+        "confidence_category": 0.95,
+        "confidence_subcategory": 0.95,
+        "validator_reasons": [
+          "auto_resolve:no_flags_fired"
+        ],
+        "risk_reasons": [
+          "base_risk:LOW"
+        ],
+        "retrieved_record_ids": [
+          "TKT-2024-03567",
+          "TKT-2023-03824",
+          "TKT-2022-04942",
+          "TKT-2024-08451",
+          "TKT-2023-00674",
+          "TKT-2023-08471",
+          "TKT-2023-05453",
+          "TKT-2022-09889"
+        ]
+      },
+      "human_override": null,
+      "final_decision": {
+        "category": "GROUNDS_EXTERIOR",
+        "subcategory": "signage_fencing",
+        "risk_level": "LOW",
+        "dispatched_vendor_id": "v_029",
+        "dispatched_emergency_services": false,
+        "needs_human_review": false,
+        "needs_clarification": false,
+        "confidence_category": 0.95,
+        "confidence_subcategory": 0.95,
+        "validator_reasons": [
+          "auto_resolve:no_flags_fired"
+        ],
+        "risk_reasons": [
+          "base_risk:LOW"
+        ],
+        "retrieved_record_ids": [
+          "TKT-2024-03567",
+          "TKT-2023-03824",
+          "TKT-2022-04942",
+          "TKT-2024-08451",
+          "TKT-2023-00674",
+          "TKT-2023-08471",
+          "TKT-2023-05453",
+          "TKT-2022-09889"
+        ]
+      }
+    },
+    "transcript_id": "EVAL-0041"
+  },
+  {
+    "category": "DOORS_ACCESS",
+    "subcategory": "glass_damage",
+    "risk_level": "MEDIUM",
+    "needs_human_review": false,
+    "needs_clarification": false,
+    "building_name": "North Hollywood Arts Center",
+    "address": "5200 Lankershim Blvd",
+    "floor": "Floor 1",
+    "dispatched_vendor_id": "v_019",
+    "dispatched_emergency_services": false,
+    "call_summary": "Glass damage reported at North Hollywood Arts Center, Floor 1. MEDIUM risk. Dispatched Clear View Glazing.",
+    "trainer_log": {
+      "full_transcript": "[AGENT] CBRE facilities \u2014 how can I help?\n[CALLER] Like, something happened to the window in the front.\n[AGENT] Okay, can you describe what you're seeing or smelling?\n[CALLER] It's the main lobby window.\n[AGENT] Can the opening be secured?\n[CALLER] No injuries.\n[AGENT] Which building and floor are you at?\n[CALLER] North Hollywood Arts Center, Floor 1, Suite 101.\n[AGENT] I'll get a tech out \u2014 they'll text you when they're heading over.",
+      "ai_prediction": {
+        "category": "DOORS_ACCESS",
+        "subcategory": "glass_damage",
+        "risk_level": "MEDIUM",
+        "dispatched_vendor_id": "v_019",
+        "dispatched_emergency_services": false,
+        "needs_human_review": false,
+        "needs_clarification": false,
+        "confidence_category": 0.95,
+        "confidence_subcategory": 0.95,
+        "validator_reasons": [
+          "auto_resolve:no_flags_fired"
+        ],
+        "risk_reasons": [
+          "base_risk:MEDIUM"
+        ],
+        "retrieved_record_ids": [
+          "TKT-2022-02863",
+          "TKT-2024-00333",
+          "TKT-2023-07226",
+          "TKT-2024-09444",
+          "TKT-2024-03420",
+          "TKT-2022-08950",
+          "TKT-2023-00728",
+          "TKT-2022-04468"
+        ]
+      },
+      "human_override": null,
+      "final_decision": {
+        "category": "DOORS_ACCESS",
+        "subcategory": "glass_damage",
+        "risk_level": "MEDIUM",
+        "dispatched_vendor_id": "v_019",
+        "dispatched_emergency_services": false,
+        "needs_human_review": false,
+        "needs_clarification": false,
+        "confidence_category": 0.95,
+        "confidence_subcategory": 0.95,
+        "validator_reasons": [
+          "auto_resolve:no_flags_fired"
+        ],
+        "risk_reasons": [
+          "base_risk:MEDIUM"
+        ],
+        "retrieved_record_ids": [
+          "TKT-2022-02863",
+          "TKT-2024-00333",
+          "TKT-2023-07226",
+          "TKT-2024-09444",
+          "TKT-2024-03420",
+          "TKT-2022-08950",
+          "TKT-2023-00728",
+          "TKT-2022-04468"
+        ]
+      }
+    },
+    "transcript_id": "EVAL-0047"
+  },
+  {
+    "category": "PEST_SPECIALTY",
+    "subcategory": "infestation",
+    "risk_level": "LOW",
+    "needs_human_review": false,
+    "needs_clarification": false,
+    "building_name": "Canyon View Business Center",
+    "address": "4400 Canyon View Dr",
+    "floor": "Floor 1",
+    "dispatched_vendor_id": "v_030",
+    "dispatched_emergency_services": false,
+    "call_summary": "Pest infestation reported at Canyon View Business Center, Floor 1. LOW risk. Dispatched Westside Pest Control.",
+    "trainer_log": {
+      "full_transcript": "[AGENT] CBRE facilities, this is Sam. What's going on?\n[CALLER] Like, there's something living in here that shouldn't be.\n[AGENT] Okay, can you describe what you're seeing or smelling?\n[CALLER] Seeing one or two a day for a week.\n[AGENT] How often are you seeing them?\n[CALLER] [muffled voices nearby] Seeing one or two a day for a week.\n[AGENT] Which building and floor are you at?\n[CALLER] Canyon View Business Center, Floor 1, Suite 108.\n[AGENT] Alright, I'll send a vendor over. You'll get a text once they're rolling.",
+      "ai_prediction": {
+        "category": "PEST_SPECIALTY",
+        "subcategory": "infestation",
+        "risk_level": "LOW",
+        "dispatched_vendor_id": "v_030",
+        "dispatched_emergency_services": false,
+        "needs_human_review": false,
+        "needs_clarification": false,
+        "confidence_category": 0.95,
+        "confidence_subcategory": 0.95,
+        "validator_reasons": [
+          "auto_resolve:no_flags_fired"
+        ],
+        "risk_reasons": [
+          "base_risk:LOW"
+        ],
+        "retrieved_record_ids": [
+          "TKT-2022-03691",
+          "TKT-2022-02899",
+          "TKT-2024-00342",
+          "TKT-2022-09268",
+          "TKT-2023-01310",
+          "TKT-2023-09416",
+          "TKT-2023-02036",
+          "TKT-2024-03450"
+        ]
+      },
+      "human_override": null,
+      "final_decision": {
+        "category": "PEST_SPECIALTY",
+        "subcategory": "infestation",
+        "risk_level": "LOW",
+        "dispatched_vendor_id": "v_030",
+        "dispatched_emergency_services": false,
+        "needs_human_review": false,
+        "needs_clarification": false,
+        "confidence_category": 0.95,
+        "confidence_subcategory": 0.95,
+        "validator_reasons": [
+          "auto_resolve:no_flags_fired"
+        ],
+        "risk_reasons": [
+          "base_risk:LOW"
+        ],
+        "retrieved_record_ids": [
+          "TKT-2022-03691",
+          "TKT-2022-02899",
+          "TKT-2024-00342",
+          "TKT-2022-09268",
+          "TKT-2023-01310",
+          "TKT-2023-09416",
+          "TKT-2023-02036",
+          "TKT-2024-03450"
+        ]
+      }
+    },
+    "transcript_id": "EVAL-0051"
+  },
+  {
+    "category": "PLUMBING",
+    "subcategory": "pipe_leak",
+    "risk_level": "HIGH",
+    "needs_human_review": true,
+    "needs_clarification": false,
+    "building_name": "Shoreline Tech Campus",
+    "address": "2500 Shoreline Blvd",
+    "floor": "Floor 6",
+    "dispatched_vendor_id": "v_002",
+    "dispatched_emergency_services": false,
+    "call_summary": "Pipe leak reported at Shoreline Tech Campus, Floor 6. HIGH risk. Flagged for review. Metro Drain & Pipe dispatched pending approval.",
+    "trainer_log": {
+      "full_transcript": "[AGENT] CBRE maintenance line, this is Priya \u2014 what do you need?\n[CALLER] Hello, Hey, the wall behind the water fountain is wet \u2014 I think there's a leak inside it.\n[AGENT] Alright. Is the water active or stopped?\n[CALLER] It's coming out pretty fast now, you know, filling up the floor.\n[AGENT] Where exactly \u2014 which suite?\n[CALLER] Uh, shoreline Tech Campus, Floor 6, Suite 605.\n[AGENT] Tech is on the way. You'll get a text once they're rolling.\n[CALLER] You know, okay.",
+      "ai_prediction": {
+        "category": "PLUMBING",
+        "subcategory": "pipe_leak",
+        "risk_level": "HIGH",
+        "dispatched_vendor_id": "v_002",
+        "dispatched_emergency_services": false,
+        "needs_human_review": true,
+        "needs_clarification": false,
+        "confidence_category": 0.95,
+        "confidence_subcategory": 0.95,
+        "validator_reasons": [
+          "high_band:always_pause"
+        ],
+        "risk_reasons": [
+          "base_risk:HIGH",
+          "soft_cue:flooding"
+        ],
+        "retrieved_record_ids": [
+          "TKT-2022-03451",
+          "TKT-2023-04874",
+          "TKT-2022-03826",
+          "TKT-2024-05682",
+          "TKT-2024-03597",
+          "TKT-2023-03998",
+          "TKT-2022-09307",
+          "TKT-2022-07420"
+        ]
+      },
+      "human_override": null,
+      "final_decision": {
+        "category": "PLUMBING",
+        "subcategory": "pipe_leak",
+        "risk_level": "HIGH",
+        "dispatched_vendor_id": "v_002",
+        "dispatched_emergency_services": false,
+        "needs_human_review": true,
+        "needs_clarification": false,
+        "confidence_category": 0.95,
+        "confidence_subcategory": 0.95,
+        "validator_reasons": [
+          "high_band:always_pause"
+        ],
+        "risk_reasons": [
+          "base_risk:HIGH",
+          "soft_cue:flooding"
+        ],
+        "retrieved_record_ids": [
+          "TKT-2022-03451",
+          "TKT-2023-04874",
+          "TKT-2022-03826",
+          "TKT-2024-05682",
+          "TKT-2024-03597",
+          "TKT-2023-03998",
+          "TKT-2022-09307",
+          "TKT-2022-07420"
+        ]
+      }
+    },
+    "transcript_id": "EVAL-0055"
+  },
+  {
+    "category": "GROUNDS_EXTERIOR",
+    "subcategory": "pavement_damage",
+    "risk_level": "LOW",
+    "needs_human_review": false,
+    "needs_clarification": false,
+    "building_name": "Palm Court Offices",
+    "address": "420 Palm Ave",
+    "floor": "Floor 1",
+    "dispatched_vendor_id": "v_029",
+    "dispatched_emergency_services": false,
+    "call_summary": "Pavement damage reported at Palm Court Offices, Floor 1. LOW risk. Dispatched Golden State Exterior Maintenance.",
+    "trainer_log": {
+      "full_transcript": "[AGENT] CBRE maintenance line, what do you need?\n[CALLER] Good morning, There's a pothole by the loading dock at Palm Court Offices on Floor 1 and it's chewing up tires.\n[AGENT] Mhm. Is it a trip hazard?\n[CALLER] Hold on, six inches across maybe, deep.\n[AGENT] Alright, I'll send a vendor over. You'll get a text once they're rolling.\n[CALLER] Got it, thanks.",
+      "ai_prediction": {
+        "category": "GROUNDS_EXTERIOR",
+        "subcategory": "pavement_damage",
+        "risk_level": "LOW",
+        "dispatched_vendor_id": "v_029",
+        "dispatched_emergency_services": false,
+        "needs_human_review": false,
+        "needs_clarification": false,
+        "confidence_category": 0.95,
+        "confidence_subcategory": 0.95,
+        "validator_reasons": [
+          "auto_resolve:no_flags_fired"
+        ],
+        "risk_reasons": [
+          "base_risk:LOW"
+        ],
+        "retrieved_record_ids": [
+          "TKT-2023-03425",
+          "TKT-2023-04091",
+          "TKT-2024-02190",
+          "TKT-2023-09347",
+          "TKT-2022-05824",
+          "TKT-2023-03512",
+          "TKT-2023-05051",
+          "TKT-2024-00810"
+        ]
+      },
+      "human_override": null,
+      "final_decision": {
+        "category": "GROUNDS_EXTERIOR",
+        "subcategory": "pavement_damage",
+        "risk_level": "LOW",
+        "dispatched_vendor_id": "v_029",
+        "dispatched_emergency_services": false,
+        "needs_human_review": false,
+        "needs_clarification": false,
+        "confidence_category": 0.95,
+        "confidence_subcategory": 0.95,
+        "validator_reasons": [
+          "auto_resolve:no_flags_fired"
+        ],
+        "risk_reasons": [
+          "base_risk:LOW"
+        ],
+        "retrieved_record_ids": [
+          "TKT-2023-03425",
+          "TKT-2023-04091",
+          "TKT-2024-02190",
+          "TKT-2023-09347",
+          "TKT-2022-05824",
+          "TKT-2023-03512",
+          "TKT-2023-05051",
+          "TKT-2024-00810"
+        ]
+      }
+    },
+    "transcript_id": "EVAL-0064"
+  },
+  {
+    "category": "DOORS_ACCESS",
+    "subcategory": "auto_door",
+    "risk_level": "LOW",
+    "needs_human_review": false,
+    "needs_clarification": false,
+    "building_name": "Northgate Logistics Hub",
+    "address": "7500 Northgate Way",
+    "floor": null,
+    "dispatched_vendor_id": "v_020",
+    "dispatched_emergency_services": false,
+    "call_summary": "Automatic door malfunction reported at Northgate Logistics Hub. LOW risk. Dispatched SecurePass Access Systems.",
+    "trainer_log": {
+      "full_transcript": "[AGENT] CBRE facilities \u2014 how can I help?\n[CALLER] The main doors are being weird.\n[AGENT] Okay, can you describe what you're seeing or smelling?\n[CALLER] I mean, yeah it's a fire exit.\n[AGENT] Is it stuck open or closed?\n[CALLER] Yeah it's a fire exit.\n[AGENT] Where exactly \u2014 which suite?\n[CALLER] Northgate Logistics Hub, Loading Bay 3.\n[AGENT] Alright, I've put a ticket in \u2014 vendor will swing by during business hours.",
+      "ai_prediction": {
+        "category": "DOORS_ACCESS",
+        "subcategory": "auto_door",
+        "risk_level": "LOW",
+        "dispatched_vendor_id": "v_020",
+        "dispatched_emergency_services": false,
+        "needs_human_review": false,
+        "needs_clarification": false,
+        "confidence_category": 0.9,
+        "confidence_subcategory": 0.9,
+        "validator_reasons": [
+          "auto_resolve:no_flags_fired"
+        ],
+        "risk_reasons": [
+          "base_risk:LOW",
+          "hard_cue:fire",
+          "capped_at_LOW:historical_max for subcategory=auto_door"
+        ],
+        "retrieved_record_ids": [
+          "TKT-2024-03225",
+          "TKT-2024-08097",
+          "TKT-2024-01470",
+          "TKT-2022-02617",
+          "TKT-2024-05592",
+          "TKT-2024-04218",
+          "TKT-2023-01097",
+          "TKT-2023-01193"
+        ]
+      },
+      "human_override": null,
+      "final_decision": {
+        "category": "DOORS_ACCESS",
+        "subcategory": "auto_door",
+        "risk_level": "LOW",
+        "dispatched_vendor_id": "v_020",
+        "dispatched_emergency_services": false,
+        "needs_human_review": false,
+        "needs_clarification": false,
+        "confidence_category": 0.9,
+        "confidence_subcategory": 0.9,
+        "validator_reasons": [
+          "auto_resolve:no_flags_fired"
+        ],
+        "risk_reasons": [
+          "base_risk:LOW",
+          "hard_cue:fire",
+          "capped_at_LOW:historical_max for subcategory=auto_door"
+        ],
+        "retrieved_record_ids": [
+          "TKT-2024-03225",
+          "TKT-2024-08097",
+          "TKT-2024-01470",
+          "TKT-2022-02617",
+          "TKT-2024-05592",
+          "TKT-2024-04218",
+          "TKT-2023-01097",
+          "TKT-2023-01193"
+        ]
+      }
+    },
+    "transcript_id": "EVAL-0065"
+  },
+  {
+    "category": "SECURITY",
+    "subcategory": "unauthorized_access",
+    "risk_level": "HIGH",
+    "needs_human_review": true,
+    "needs_clarification": false,
+    "building_name": "Meridian Business Park",
+    "address": "1500 Meridian Ave",
+    "floor": "Floor 2",
+    "dispatched_vendor_id": "v_027",
+    "dispatched_emergency_services": false,
+    "call_summary": "Unauthorized access reported at Meridian Business Park, Floor 2. HIGH risk. Flagged for review. Elite Protective Services dispatched pending approval.",
+    "trainer_log": {
+      "full_transcript": "[AGENT] Maintenance, what's the situation?\n[CALLER] Someone forced open the door on Floor 2, they got in.\n[AGENT] Mhm. Is anyone in danger?\n[CALLER] Like, he's still in the back corridor.\n[AGENT] Pulling in the supervisor and dispatching a vendor right now.\n[CALLER] Okay.",
+      "ai_prediction": {
+        "category": "SECURITY",
+        "subcategory": "unauthorized_access",
+        "risk_level": "HIGH",
+        "dispatched_vendor_id": "v_027",
+        "dispatched_emergency_services": false,
+        "needs_human_review": true,
+        "needs_clarification": false,
+        "confidence_category": 0.95,
+        "confidence_subcategory": 0.95,
+        "validator_reasons": [
+          "high_band:always_pause"
+        ],
+        "risk_reasons": [
+          "base_risk:HIGH"
+        ],
+        "retrieved_record_ids": [
+          "TKT-2023-01544",
+          "TKT-2022-07900",
+          "TKT-2024-02160",
+          "TKT-2024-04902",
+          "TKT-2022-07240",
+          "TKT-2024-03021",
+          "TKT-2024-04113",
+          "TKT-2023-05174"
+        ]
+      },
+      "human_override": null,
+      "final_decision": {
+        "category": "SECURITY",
+        "subcategory": "unauthorized_access",
+        "risk_level": "HIGH",
+        "dispatched_vendor_id": "v_027",
+        "dispatched_emergency_services": false,
+        "needs_human_review": true,
+        "needs_clarification": false,
+        "confidence_category": 0.95,
+        "confidence_subcategory": 0.95,
+        "validator_reasons": [
+          "high_band:always_pause"
+        ],
+        "risk_reasons": [
+          "base_risk:HIGH"
+        ],
+        "retrieved_record_ids": [
+          "TKT-2023-01544",
+          "TKT-2022-07900",
+          "TKT-2024-02160",
+          "TKT-2024-04902",
+          "TKT-2022-07240",
+          "TKT-2024-03021",
+          "TKT-2024-04113",
+          "TKT-2023-05174"
+        ]
+      }
+    },
+    "transcript_id": "EVAL-0066"
+  },
+  {
+    "category": "ELECTRICAL",
+    "subcategory": "low_voltage_data",
+    "risk_level": "LOW",
+    "needs_human_review": false,
+    "needs_clarification": false,
+    "building_name": "La Jolla Professional Suites",
+    "address": "9400 La Jolla Village Dr",
+    "floor": "Floor 6",
+    "dispatched_vendor_id": "v_011",
+    "dispatched_emergency_services": false,
+    "call_summary": "Low-voltage/data issue reported at La Jolla Professional Suites, Floor 6. LOW risk. Dispatched NetCom Low-Voltage Tech.",
+    "trainer_log": {
+      "full_transcript": "[AGENT] CBRE maintenance line, what do you need?\n[CALLER] Hello, We can't VPN in at La Jolla Professional Suites on Floor 6 in Suite 605, think the network's down for the floor.\n[AGENT] Okay, I see. Is it just network or also phones?\n[CALLER] Some of our medical equipment is offline too.\n[AGENT] Okay, ticket's logged. Someone'll come out during business hours.\n[CALLER] Got it, thanks.",
+      "ai_prediction": {
+        "category": "ELECTRICAL",
+        "subcategory": "low_voltage_data",
+        "risk_level": "LOW",
+        "dispatched_vendor_id": "v_011",
+        "dispatched_emergency_services": false,
+        "needs_human_review": false,
+        "needs_clarification": false,
+        "confidence_category": 0.95,
+        "confidence_subcategory": 0.95,
+        "validator_reasons": [
+          "auto_resolve:no_flags_fired"
+        ],
+        "risk_reasons": [
+          "base_risk:LOW"
+        ],
+        "retrieved_record_ids": [
+          "TKT-2024-09183",
+          "TKT-2024-06984",
+          "TKT-2024-01452",
+          "TKT-2023-06617",
+          "TKT-2024-00960",
+          "TKT-2023-09872",
+          "TKT-2024-09690",
+          "TKT-2024-02388"
+        ]
+      },
+      "human_override": null,
+      "final_decision": {
+        "category": "ELECTRICAL",
+        "subcategory": "low_voltage_data",
+        "risk_level": "LOW",
+        "dispatched_vendor_id": "v_011",
+        "dispatched_emergency_services": false,
+        "needs_human_review": false,
+        "needs_clarification": false,
+        "confidence_category": 0.95,
+        "confidence_subcategory": 0.95,
+        "validator_reasons": [
+          "auto_resolve:no_flags_fired"
+        ],
+        "risk_reasons": [
+          "base_risk:LOW"
+        ],
+        "retrieved_record_ids": [
+          "TKT-2024-09183",
+          "TKT-2024-06984",
+          "TKT-2024-01452",
+          "TKT-2023-06617",
+          "TKT-2024-00960",
+          "TKT-2023-09872",
+          "TKT-2024-09690",
+          "TKT-2024-02388"
+        ]
+      }
+    },
+    "transcript_id": "EVAL-0068"
+  },
+  {
+    "category": "LIFE_SAFETY",
+    "subcategory": "fire_smoke",
+    "risk_level": "EMERGENCY",
+    "needs_human_review": true,
+    "needs_clarification": false,
+    "building_name": "Westfield Commerce Center",
+    "address": "100 Wilshire Blvd",
+    "floor": "Floor 18",
+    "dispatched_vendor_id": null,
+    "dispatched_emergency_services": true,
+    "call_summary": "Fire/smoke detected reported at Westfield Commerce Center, Floor 18. EMERGENCY risk. Emergency services dispatched.",
+    "trainer_log": {
+      "full_transcript": "[AGENT] Hi, CBRE facilities. What can I do for you?\n[CALLER] There's smoke coming from the electrical room, I can see it.\n[AGENT] Understood. Is anyone trapped?\n[CALLER] I see flames in the trash can.\n[AGENT] Can you confirm the building and floor?\n[CALLER] Westfield Commerce Center, Floor 18, Suite 1801.\n[AGENT] Dialing 911 now. Please leave the area if it's safe.\n[CALLER] Thanks, bye.",
+      "ai_prediction": {
+        "category": "LIFE_SAFETY",
+        "subcategory": "fire_smoke",
+        "risk_level": "EMERGENCY",
+        "dispatched_vendor_id": null,
+        "dispatched_emergency_services": true,
+        "needs_human_review": true,
+        "needs_clarification": false,
+        "confidence_category": 0.95,
+        "confidence_subcategory": 0.95,
+        "validator_reasons": [
+          "emergency_band:always_pause",
+          "emergency_dispatch:fire_smoke:hazard_cue_confirmed"
+        ],
+        "risk_reasons": [
+          "base_risk:EMERGENCY",
+          "hard_cue:smoke",
+          "hard_cue:fire",
+          "capped_at_EMERGENCY:historical_max for subcategory=fire_smoke"
+        ],
+        "retrieved_record_ids": [
+          "TKT-2022-01747",
+          "TKT-2022-03901",
+          "TKT-2023-02639",
+          "TKT-2022-07729",
+          "TKT-2022-03139",
+          "TKT-2023-06458",
+          "TKT-2022-03664",
+          "TKT-2022-03301"
+        ]
+      },
+      "human_override": null,
+      "final_decision": {
+        "category": "LIFE_SAFETY",
+        "subcategory": "fire_smoke",
+        "risk_level": "EMERGENCY",
+        "dispatched_vendor_id": null,
+        "dispatched_emergency_services": true,
+        "needs_human_review": true,
+        "needs_clarification": false,
+        "confidence_category": 0.95,
+        "confidence_subcategory": 0.95,
+        "validator_reasons": [
+          "emergency_band:always_pause",
+          "emergency_dispatch:fire_smoke:hazard_cue_confirmed"
+        ],
+        "risk_reasons": [
+          "base_risk:EMERGENCY",
+          "hard_cue:smoke",
+          "hard_cue:fire",
+          "capped_at_EMERGENCY:historical_max for subcategory=fire_smoke"
+        ],
+        "retrieved_record_ids": [
+          "TKT-2022-01747",
+          "TKT-2022-03901",
+          "TKT-2023-02639",
+          "TKT-2022-07729",
+          "TKT-2022-03139",
+          "TKT-2023-06458",
+          "TKT-2022-03664",
+          "TKT-2022-03301"
+        ]
+      }
+    },
+    "transcript_id": "EVAL-0076"
+  },
+  {
+    "category": "ELECTRICAL",
+    "subcategory": "power_outage",
+    "risk_level": "HIGH",
+    "needs_human_review": true,
+    "needs_clarification": false,
+    "building_name": "Greenway Towers",
+    "address": "1200 Greenway Blvd",
+    "floor": "Floor 3",
+    "dispatched_vendor_id": "v_008",
+    "dispatched_emergency_services": false,
+    "call_summary": "Power outage reported at Greenway Towers, Floor 3. HIGH risk. Flagged for review. Rapid Response Electricians dispatched pending approval.",
+    "trainer_log": {
+      "full_transcript": "[AGENT] CBRE dispatch, talk to me.\n[CALLER] Good afternoon, Power is out on our entire floor; lights and outlets both dead.\n[AGENT] Okay. Are the emergency lights on?\n[CALLER] [pa announcement in background] Whole floor, all the lights and outlets.\n[AGENT] Which building and floor are you at?\n[CALLER] [door closing] Greenway Towers, Floor 3, Suite 301.\n[AGENT] Tech is on the way. You'll get a text once they're rolling.\n[CALLER] Um, okay, thanks.",
+      "ai_prediction": {
+        "category": "ELECTRICAL",
+        "subcategory": "power_outage",
+        "risk_level": "HIGH",
+        "dispatched_vendor_id": "v_008",
+        "dispatched_emergency_services": false,
+        "needs_human_review": true,
+        "needs_clarification": false,
+        "confidence_category": 0.95,
+        "confidence_subcategory": 0.95,
+        "validator_reasons": [
+          "high_band:always_pause"
+        ],
+        "risk_reasons": [
+          "base_risk:HIGH"
+        ],
+        "retrieved_record_ids": [
+          "TKT-2024-02910",
+          "TKT-2022-06853",
+          "TKT-2022-04384",
+          "TKT-2022-03049",
+          "TKT-2023-04613",
+          "TKT-2022-03514",
+          "TKT-2022-09001",
+          "TKT-2024-02250"
+        ]
+      },
+      "human_override": null,
+      "final_decision": {
+        "category": "ELECTRICAL",
+        "subcategory": "power_outage",
+        "risk_level": "HIGH",
+        "dispatched_vendor_id": "v_008",
+        "dispatched_emergency_services": false,
+        "needs_human_review": true,
+        "needs_clarification": false,
+        "confidence_category": 0.95,
+        "confidence_subcategory": 0.95,
+        "validator_reasons": [
+          "high_band:always_pause"
+        ],
+        "risk_reasons": [
+          "base_risk:HIGH"
+        ],
+        "retrieved_record_ids": [
+          "TKT-2024-02910",
+          "TKT-2022-06853",
+          "TKT-2022-04384",
+          "TKT-2022-03049",
+          "TKT-2023-04613",
+          "TKT-2022-03514",
+          "TKT-2022-09001",
+          "TKT-2024-02250"
+        ]
+      }
+    },
+    "transcript_id": "EVAL-0081"
+  },
+  {
+    "category": "LIFE_SAFETY",
+    "subcategory": "slip_trip",
+    "risk_level": "LOW",
+    "needs_human_review": false,
+    "needs_clarification": false,
+    "building_name": "University Research Park",
+    "address": "5000 Research Dr",
+    "floor": "Floor 3",
+    "dispatched_vendor_id": "v_025",
+    "dispatched_emergency_services": false,
+    "call_summary": "Slip/trip hazard reported at University Research Park, Floor 3. LOW risk. Dispatched ProClean Facility Services.",
+    "trainer_log": {
+      "full_transcript": "[AGENT] CBRE facilities \u2014 how can I help?\n[CALLER] Hey, Wet floor, no signs, someone already slipped.\n[AGENT] Got it. Has anyone fallen?\n[CALLER] Yeah, sorry, we set up a cone.\n[AGENT] Can you confirm the building and floor?\n[CALLER] University Research Park, Floor 3.\n[AGENT] Got it. I'll get someone out as soon as I can \u2014 should hear back within the hour.\n[CALLER] Thank you.",
+      "ai_prediction": {
+        "category": "LIFE_SAFETY",
+        "subcategory": "slip_trip",
+        "risk_level": "LOW",
+        "dispatched_vendor_id": "v_025",
+        "dispatched_emergency_services": false,
+        "needs_human_review": false,
+        "needs_clarification": false,
+        "confidence_category": 0.95,
+        "confidence_subcategory": 0.95,
+        "validator_reasons": [
+          "auto_resolve:no_flags_fired"
+        ],
+        "risk_reasons": [
+          "base_risk:LOW"
+        ],
+        "retrieved_record_ids": [
+          "TKT-2023-04583",
+          "TKT-2023-09524",
+          "TKT-2022-02269",
+          "TKT-2022-06082",
+          "TKT-2024-07200",
+          "TKT-2023-05261",
+          "TKT-2024-08001",
+          "TKT-2024-06978"
+        ]
+      },
+      "human_override": null,
+      "final_decision": {
+        "category": "LIFE_SAFETY",
+        "subcategory": "slip_trip",
+        "risk_level": "LOW",
+        "dispatched_vendor_id": "v_025",
+        "dispatched_emergency_services": false,
+        "needs_human_review": false,
+        "needs_clarification": false,
+        "confidence_category": 0.95,
+        "confidence_subcategory": 0.95,
+        "validator_reasons": [
+          "auto_resolve:no_flags_fired"
+        ],
+        "risk_reasons": [
+          "base_risk:LOW"
+        ],
+        "retrieved_record_ids": [
+          "TKT-2023-04583",
+          "TKT-2023-09524",
+          "TKT-2022-02269",
+          "TKT-2022-06082",
+          "TKT-2024-07200",
+          "TKT-2023-05261",
+          "TKT-2024-08001",
+          "TKT-2024-06978"
+        ]
+      }
+    },
+    "transcript_id": "EVAL-0084"
+  },
+  {
+    "category": "DOORS_ACCESS",
+    "subcategory": "access_control",
+    "risk_level": "LOW",
+    "needs_human_review": false,
+    "needs_clarification": false,
+    "building_name": "Lakeview Executive Suites",
+    "address": "180 Lakeview Dr",
+    "floor": "Floor 4",
+    "dispatched_vendor_id": "v_020",
+    "dispatched_emergency_services": false,
+    "call_summary": "Access control issue reported at Lakeview Executive Suites, Floor 4. LOW risk. Dispatched SecurePass Access Systems.",
+    "trainer_log": {
+      "full_transcript": "[AGENT] CBRE maintenance line, this is Priya \u2014 what do you need?\n[CALLER] Main door won't latch properly.\n[AGENT] Understood. Can the door be secured?\n[CALLER] Hmm, actually \u2014 the latch is fine. It's the badge reader that's dead \u2014 nothing is registering.\n[AGENT] Got it \u2014 updating the ticket. Is it the main reader or a sub-area?\n[CALLER] We've got a side door still working.\n[AGENT] What's your building, floor, suite?\n[CALLER] Lakeview Executive Suites, Floor 4, Suite 403.\n[AGENT] Okay, I'll line that up now. Confirmation text will come through shortly.",
+      "ai_prediction": {
+        "category": "DOORS_ACCESS",
+        "subcategory": "access_control",
+        "risk_level": "LOW",
+        "dispatched_vendor_id": "v_020",
+        "dispatched_emergency_services": false,
+        "needs_human_review": false,
+        "needs_clarification": false,
+        "confidence_category": 0.95,
+        "confidence_subcategory": 0.95,
+        "validator_reasons": [
+          "auto_resolve:no_flags_fired"
+        ],
+        "risk_reasons": [
+          "base_risk:LOW"
+        ],
+        "retrieved_record_ids": [
+          "TKT-2023-00284",
+          "TKT-2024-07233",
+          "TKT-2024-08160",
+          "TKT-2024-02874",
+          "TKT-2022-07828",
+          "TKT-2024-01809",
+          "TKT-2024-06906",
+          "TKT-2023-09641"
+        ]
+      },
+      "human_override": null,
+      "final_decision": {
+        "category": "DOORS_ACCESS",
+        "subcategory": "access_control",
+        "risk_level": "LOW",
+        "dispatched_vendor_id": "v_020",
+        "dispatched_emergency_services": false,
+        "needs_human_review": false,
+        "needs_clarification": false,
+        "confidence_category": 0.95,
+        "confidence_subcategory": 0.95,
+        "validator_reasons": [
+          "auto_resolve:no_flags_fired"
+        ],
+        "risk_reasons": [
+          "base_risk:LOW"
+        ],
+        "retrieved_record_ids": [
+          "TKT-2023-00284",
+          "TKT-2024-07233",
+          "TKT-2024-08160",
+          "TKT-2024-02874",
+          "TKT-2022-07828",
+          "TKT-2024-01809",
+          "TKT-2024-06906",
+          "TKT-2023-09641"
+        ]
+      }
+    },
+    "transcript_id": "EVAL-0089"
+  },
+  {
+    "category": "JANITORIAL",
+    "subcategory": "carpet_floor",
+    "risk_level": "LOW",
+    "needs_human_review": false,
+    "needs_clarification": false,
+    "building_name": null,
+    "address": null,
+    "floor": "Floor 2",
+    "dispatched_vendor_id": "v_023",
+    "dispatched_emergency_services": false,
+    "call_summary": "Carpet/flooring damage reported at Floor 2. LOW risk. Dispatched Sparkle Commercial Cleaning.",
+    "trainer_log": {
+      "full_transcript": "[AGENT] CBRE maintenance line, what do you need?\n[CALLER] Someone spilled coffee all over the carpet on Floor 2, need it cleaned.\n[AGENT] Alright. Is the stain fresh?\n[CALLER] Yeah, like a large iced coffee.\n[AGENT] Okay, ticket's logged. Someone'll come out during business hours.\n[CALLER] Got it, thanks.",
+      "ai_prediction": {
+        "category": "JANITORIAL",
+        "subcategory": "carpet_floor",
+        "risk_level": "LOW",
+        "dispatched_vendor_id": "v_023",
+        "dispatched_emergency_services": false,
+        "needs_human_review": false,
+        "needs_clarification": false,
+        "confidence_category": 0.95,
+        "confidence_subcategory": 0.95,
+        "validator_reasons": [
+          "auto_resolve:no_flags_fired"
+        ],
+        "risk_reasons": [
+          "base_risk:LOW"
+        ],
+        "retrieved_record_ids": [
+          "TKT-2022-08554",
+          "TKT-2023-04343",
+          "TKT-2024-06915",
+          "TKT-2022-06397",
+          "TKT-2023-03635",
+          "TKT-2024-07269",
+          "TKT-2024-07488",
+          "TKT-2024-08379"
+        ]
+      },
+      "human_override": null,
+      "final_decision": {
+        "category": "JANITORIAL",
+        "subcategory": "carpet_floor",
+        "risk_level": "LOW",
+        "dispatched_vendor_id": "v_023",
+        "dispatched_emergency_services": false,
+        "needs_human_review": false,
+        "needs_clarification": false,
+        "confidence_category": 0.95,
+        "confidence_subcategory": 0.95,
+        "validator_reasons": [
+          "auto_resolve:no_flags_fired"
+        ],
+        "risk_reasons": [
+          "base_risk:LOW"
+        ],
+        "retrieved_record_ids": [
+          "TKT-2022-08554",
+          "TKT-2023-04343",
+          "TKT-2024-06915",
+          "TKT-2022-06397",
+          "TKT-2023-03635",
+          "TKT-2024-07269",
+          "TKT-2024-07488",
+          "TKT-2024-08379"
+        ]
+      }
+    },
+    "transcript_id": "EVAL-0094"
+  },
+  {
+    "category": "HVAC",
+    "subcategory": "no_heating",
+    "risk_level": "LOW",
+    "needs_human_review": false,
+    "needs_clarification": true,
+    "building_name": "Pinnacle Financial Center",
+    "address": "600 Financial Dr",
+    "floor": "Floor 16",
+    "dispatched_vendor_id": "v_014",
+    "dispatched_emergency_services": false,
+    "call_summary": "No heating reported at Pinnacle Financial Center, Floor 16. LOW risk. Dispatched MediCool HVAC Systems.",
+    "trainer_log": {
+      "full_transcript": "[AGENT] CBRE maintenance line, this is Priya \u2014 what do you need?\n[CALLER] There's an issue with no heating.\n[AGENT] How cold is it in there?\n[CALLER] Got a client meeting coming in, this is bad.\n[AGENT] Where exactly \u2014 which suite?\n[CALLER] Pinnacle Financial Center, Floor 16, Suite 1803.\n[AGENT] Got the ticket open. Vendor should make it out during business hours.",
+      "ai_prediction": {
+        "category": "HVAC",
+        "subcategory": "no_heating",
+        "risk_level": "LOW",
+        "dispatched_vendor_id": "v_014",
+        "dispatched_emergency_services": false,
+        "needs_human_review": false,
+        "needs_clarification": true,
+        "confidence_category": 0.95,
+        "confidence_subcategory": 0.95,
+        "validator_reasons": [
+          "auto_resolve:no_flags_fired"
+        ],
+        "risk_reasons": [
+          "base_risk:LOW"
+        ],
+        "retrieved_record_ids": [
+          "TKT-2022-00775",
+          "TKT-2024-07971",
+          "TKT-2023-00308",
+          "TKT-2023-03065",
+          "TKT-2024-04437",
+          "TKT-2024-08217",
+          "TKT-2022-00304",
+          "TKT-2024-05985"
+        ]
+      },
+      "human_override": null,
+      "final_decision": {
+        "category": "HVAC",
+        "subcategory": "no_heating",
+        "risk_level": "LOW",
+        "dispatched_vendor_id": "v_014",
+        "dispatched_emergency_services": false,
+        "needs_human_review": false,
+        "needs_clarification": true,
+        "confidence_category": 0.95,
+        "confidence_subcategory": 0.95,
+        "validator_reasons": [
+          "auto_resolve:no_flags_fired"
+        ],
+        "risk_reasons": [
+          "base_risk:LOW"
+        ],
+        "retrieved_record_ids": [
+          "TKT-2022-00775",
+          "TKT-2024-07971",
+          "TKT-2023-00308",
+          "TKT-2023-03065",
+          "TKT-2024-04437",
+          "TKT-2024-08217",
+          "TKT-2022-00304",
+          "TKT-2024-05985"
+        ]
+      }
+    },
+    "transcript_id": "EVAL-0095"
+  },
+  {
+    "category": "ELECTRICAL",
+    "subcategory": "panel_hazard",
+    "risk_level": "EMERGENCY",
+    "needs_human_review": true,
+    "needs_clarification": false,
+    "building_name": "Central Tower",
+    "address": "700 S Grand Ave",
+    "floor": "Floor 22",
+    "dispatched_vendor_id": "v_008",
+    "dispatched_emergency_services": true,
+    "call_summary": "Electrical panel hazard reported at Central Tower, Floor 22. EMERGENCY risk. Emergency services dispatched.",
+    "trainer_log": {
+      "full_transcript": "[AGENT] CBRE dispatch, talk to me.\n[CALLER] Like, i smell something burning \u2014 maybe electrical?\n[AGENT] Okay, can you describe what you're seeing or smelling?\n[CALLER] No, I haven't touched the breakers.\n[AGENT] Is anyone near the panel right now?\n[CALLER] Nobody's near it, I told everyone to back away.\n[AGENT] Which building and floor are you at?\n[CALLER] Central Tower, Floor 22, Suite 2204.\n[AGENT] Dialing 911 now. Please leave the area if it's safe.",
+      "ai_prediction": {
+        "category": "ELECTRICAL",
+        "subcategory": "panel_hazard",
+        "risk_level": "EMERGENCY",
+        "dispatched_vendor_id": "v_008",
+        "dispatched_emergency_services": true,
+        "needs_human_review": true,
+        "needs_clarification": false,
+        "confidence_category": 0.95,
+        "confidence_subcategory": 0.95,
+        "validator_reasons": [
+          "emergency_band:always_pause",
+          "emergency_dispatch:panel_hazard:hazard_cue_confirmed"
+        ],
+        "risk_reasons": [
+          "base_risk:EMERGENCY"
+        ],
+        "retrieved_record_ids": [
+          "TKT-2024-08127",
+          "TKT-2024-05391",
+          "TKT-2024-00690",
+          "TKT-2023-07805",
+          "TKT-2024-09672",
+          "TKT-2024-06027",
+          "TKT-2023-00065",
+          "TKT-2024-04638"
+        ]
+      },
+      "human_override": null,
+      "final_decision": {
+        "category": "ELECTRICAL",
+        "subcategory": "panel_hazard",
+        "risk_level": "EMERGENCY",
+        "dispatched_vendor_id": "v_008",
+        "dispatched_emergency_services": true,
+        "needs_human_review": true,
+        "needs_clarification": false,
+        "confidence_category": 0.95,
+        "confidence_subcategory": 0.95,
+        "validator_reasons": [
+          "emergency_band:always_pause",
+          "emergency_dispatch:panel_hazard:hazard_cue_confirmed"
+        ],
+        "risk_reasons": [
+          "base_risk:EMERGENCY"
+        ],
+        "retrieved_record_ids": [
+          "TKT-2024-08127",
+          "TKT-2024-05391",
+          "TKT-2024-00690",
+          "TKT-2023-07805",
+          "TKT-2024-09672",
+          "TKT-2024-06027",
+          "TKT-2023-00065",
+          "TKT-2024-04638"
+        ]
+      }
+    },
+    "transcript_id": "EVAL-0096"
+  },
+  {
+    "category": "LIFE_SAFETY",
+    "subcategory": "fire_smoke",
+    "risk_level": "EMERGENCY",
+    "needs_human_review": true,
+    "needs_clarification": false,
+    "building_name": "La Jolla Professional Suites",
+    "address": "9400 La Jolla Village Dr",
+    "floor": "Floor 2",
+    "dispatched_vendor_id": null,
+    "dispatched_emergency_services": true,
+    "call_summary": "Fire/smoke detected reported at La Jolla Professional Suites, Floor 2. EMERGENCY risk. Emergency services dispatched.",
+    "trainer_log": {
+      "full_transcript": "[AGENT] Hi, CBRE facilities. What can I do for you?\n[CALLER] Flames coming from the kitchen, sorry, we evacuated the floor.\n[AGENT] Okay. Can you describe what you're seeing \u2014 flames or just smoke?\n[CALLER] Yes, people are out.\n[AGENT] What's your building, floor, suite?\n[CALLER] La Jolla Professional Suites, Floor 2, Suite 206.\n[AGENT] Dialing 911 now. Please leave the area if it's safe.\n[CALLER] Okay, please hurry.",
+      "ai_prediction": {
+        "category": "LIFE_SAFETY",
+        "subcategory": "fire_smoke",
+        "risk_level": "EMERGENCY",
+        "dispatched_vendor_id": null,
+        "dispatched_emergency_services": true,
+        "needs_human_review": true,
+        "needs_clarification": false,
+        "confidence_category": 0.95,
+        "confidence_subcategory": 0.95,
+        "validator_reasons": [
+          "emergency_band:always_pause",
+          "emergency_dispatch:fire_smoke:hazard_cue_confirmed"
+        ],
+        "risk_reasons": [
+          "base_risk:EMERGENCY",
+          "hard_cue:flames",
+          "capped_at_EMERGENCY:historical_max for subcategory=fire_smoke"
+        ],
+        "retrieved_record_ids": [
+          "TKT-2024-06480",
+          "TKT-2024-02880",
+          "TKT-2024-09834",
+          "TKT-2024-08754",
+          "TKT-2022-00991",
+          "TKT-2023-05294",
+          "TKT-2022-02497",
+          "TKT-2023-01046"
+        ]
+      },
+      "human_override": null,
+      "final_decision": {
+        "category": "LIFE_SAFETY",
+        "subcategory": "fire_smoke",
+        "risk_level": "EMERGENCY",
+        "dispatched_vendor_id": null,
+        "dispatched_emergency_services": true,
+        "needs_human_review": true,
+        "needs_clarification": false,
+        "confidence_category": 0.95,
+        "confidence_subcategory": 0.95,
+        "validator_reasons": [
+          "emergency_band:always_pause",
+          "emergency_dispatch:fire_smoke:hazard_cue_confirmed"
+        ],
+        "risk_reasons": [
+          "base_risk:EMERGENCY",
+          "hard_cue:flames",
+          "capped_at_EMERGENCY:historical_max for subcategory=fire_smoke"
+        ],
+        "retrieved_record_ids": [
+          "TKT-2024-06480",
+          "TKT-2024-02880",
+          "TKT-2024-09834",
+          "TKT-2024-08754",
+          "TKT-2022-00991",
+          "TKT-2023-05294",
+          "TKT-2022-02497",
+          "TKT-2023-01046"
+        ]
+      }
+    },
+    "transcript_id": "EVAL-0098"
+  },
+  {
+    "category": "ELEVATOR",
+    "subcategory": "minor_issue",
+    "risk_level": "LOW",
+    "needs_human_review": false,
+    "needs_clarification": false,
+    "building_name": "Golden State Towers",
+    "address": "900 Golden State Blvd",
+    "floor": "Floor 2",
+    "dispatched_vendor_id": "v_017",
+    "dispatched_emergency_services": false,
+    "call_summary": "Minor maintenance issue reported at Golden State Towers, Floor 2. LOW risk. Dispatched Valley Elevator Service.",
+    "trainer_log": {
+      "full_transcript": "[AGENT] Hi, CBRE facilities. What can I do for you?\n[CALLER] The elevator's doing something weird.\n[AGENT] Okay, can you describe what you're seeing or smelling?\n[CALLER] Hold on, probably fine but sounds awful.\n[AGENT] How long has this been happening?\n[CALLER] You know, been like this for two days now.\n[AGENT] Where exactly \u2014 which suite?\n[CALLER] Golden State Towers, Floor 2, Suite 207.\n[AGENT] Okay, I'll line that up now. Confirmation text will come through shortly.",
+      "ai_prediction": {
+        "category": "ELEVATOR",
+        "subcategory": "minor_issue",
+        "risk_level": "LOW",
+        "dispatched_vendor_id": "v_017",
+        "dispatched_emergency_services": false,
+        "needs_human_review": false,
+        "needs_clarification": false,
+        "confidence_category": 0.9,
+        "confidence_subcategory": 0.9,
+        "validator_reasons": [
+          "auto_resolve:no_flags_fired"
+        ],
+        "risk_reasons": [
+          "base_risk:LOW"
+        ],
+        "retrieved_record_ids": [
+          "TKT-2023-06254",
+          "TKT-2023-06152",
+          "TKT-2022-02146",
+          "TKT-2023-09860",
+          "TKT-2024-04182",
+          "TKT-2022-09103",
+          "TKT-2024-06393",
+          "TKT-2022-06760"
+        ]
+      },
+      "human_override": null,
+      "final_decision": {
+        "category": "ELEVATOR",
+        "subcategory": "minor_issue",
+        "risk_level": "LOW",
+        "dispatched_vendor_id": "v_017",
+        "dispatched_emergency_services": false,
+        "needs_human_review": false,
+        "needs_clarification": false,
+        "confidence_category": 0.9,
+        "confidence_subcategory": 0.9,
+        "validator_reasons": [
+          "auto_resolve:no_flags_fired"
+        ],
+        "risk_reasons": [
+          "base_risk:LOW"
+        ],
+        "retrieved_record_ids": [
+          "TKT-2023-06254",
+          "TKT-2023-06152",
+          "TKT-2022-02146",
+          "TKT-2023-09860",
+          "TKT-2024-04182",
+          "TKT-2022-09103",
+          "TKT-2024-06393",
+          "TKT-2022-06760"
+        ]
+      }
+    },
+    "transcript_id": "EVAL-0099"
+  },
+  {
+    "category": "HVAC",
+    "subcategory": "no_heating",
+    "risk_level": "LOW",
+    "needs_human_review": false,
+    "needs_clarification": false,
+    "building_name": "Inland Empire Logistics Center",
+    "address": "12000 Etiwanda Ave",
+    "floor": "Loading Bay 2",
+    "dispatched_vendor_id": "v_015",
+    "dispatched_emergency_services": false,
+    "call_summary": "No heating reported at Inland Empire Logistics Center, Loading Bay 2. LOW risk. Dispatched Budget Air Climate.",
+    "trainer_log": {
+      "full_transcript": "[AGENT] CBRE maintenance, this is Dana. What's going on?\n[CALLER] I mean, good afternoon, Heat isn't working; it's really cold.\n[AGENT] Okay, I see. Are any vulnerable people \u2014 elderly or infants?\n[CALLER] Um, got a client meeting coming in, this is bad.\n[AGENT] Which building and floor are you at?\n[CALLER] Inland Empire Logistics Center, Loading Bay 2.\n[AGENT] Got it. I'll get someone out as soon as I can \u2014 should hear back within the hour.\n[CALLER] Okay, you know, please hurry.",
+      "ai_prediction": {
+        "category": "HVAC",
+        "subcategory": "no_heating",
+        "risk_level": "LOW",
+        "dispatched_vendor_id": "v_015",
+        "dispatched_emergency_services": false,
+        "needs_human_review": false,
+        "needs_clarification": false,
+        "confidence_category": 0.95,
+        "confidence_subcategory": 0.95,
+        "validator_reasons": [
+          "auto_resolve:no_flags_fired"
+        ],
+        "risk_reasons": [
+          "base_risk:LOW"
+        ],
+        "retrieved_record_ids": [
+          "TKT-2022-00775",
+          "TKT-2023-05909",
+          "TKT-2024-03846",
+          "TKT-2024-01299",
+          "TKT-2024-07971",
+          "TKT-2022-02188",
+          "TKT-2022-03334",
+          "TKT-2022-03181"
+        ]
+      },
+      "human_override": null,
+      "final_decision": {
+        "category": "HVAC",
+        "subcategory": "no_heating",
+        "risk_level": "LOW",
+        "dispatched_vendor_id": "v_015",
+        "dispatched_emergency_services": false,
+        "needs_human_review": false,
+        "needs_clarification": false,
+        "confidence_category": 0.95,
+        "confidence_subcategory": 0.95,
+        "validator_reasons": [
+          "auto_resolve:no_flags_fired"
+        ],
+        "risk_reasons": [
+          "base_risk:LOW"
+        ],
+        "retrieved_record_ids": [
+          "TKT-2022-00775",
+          "TKT-2023-05909",
+          "TKT-2024-03846",
+          "TKT-2024-01299",
+          "TKT-2024-07971",
+          "TKT-2022-02188",
+          "TKT-2022-03334",
+          "TKT-2022-03181"
+        ]
+      }
+    },
+    "transcript_id": "EVAL-0119"
+  },
+  {
+    "category": "HVAC",
+    "subcategory": "air_quality",
+    "risk_level": "MEDIUM",
+    "needs_human_review": true,
+    "needs_clarification": false,
+    "building_name": "La Jolla Professional Suites",
+    "address": "9400 La Jolla Village Dr",
+    "floor": "Floor 6",
+    "dispatched_vendor_id": "v_014",
+    "dispatched_emergency_services": false,
+    "call_summary": "Air quality concern reported at La Jolla Professional Suites, Floor 6. MEDIUM risk. Flagged for review. MediCool HVAC Systems dispatched pending approval.",
+    "trainer_log": {
+      "full_transcript": "[AGENT] Dispatch, what do you need?\n[CALLER] Strong chemical smell in the hallway, you know, like cleaning fluid \u2014 the janitor just mopped with bleach solution.\n[AGENT] Okay \u2014 can you confirm there's no actual fire or injury right now?\n[CALLER] No, just the smell \u2014 no one's hurt, just annoying.\n[AGENT] Can you tell me the building, floor, and suite?\n[CALLER] [door closing] You know, la Jolla Professional Suites, Floor 6, Suite 605.\n[AGENT] Sending a tech your way now. You'll hear from them en route.",
+      "ai_prediction": {
+        "category": "HVAC",
+        "subcategory": "air_quality",
+        "risk_level": "MEDIUM",
+        "dispatched_vendor_id": "v_014",
+        "dispatched_emergency_services": false,
+        "needs_human_review": true,
+        "needs_clarification": false,
+        "confidence_category": 0.95,
+        "confidence_subcategory": 0.95,
+        "validator_reasons": [
+          "trap_prone_subcategory:air_quality(over_escalation_rate=19%)"
+        ],
+        "risk_reasons": [
+          "base_risk:MEDIUM"
+        ],
+        "retrieved_record_ids": [
+          "TKT-2023-00554",
+          "TKT-2024-08193",
+          "TKT-2022-07963",
+          "TKT-2022-07075",
+          "TKT-2023-02927",
+          "TKT-2023-01151",
+          "TKT-2023-01952",
+          "TKT-2023-01883"
+        ]
+      },
+      "human_override": null,
+      "final_decision": {
+        "category": "HVAC",
+        "subcategory": "air_quality",
+        "risk_level": "MEDIUM",
+        "dispatched_vendor_id": "v_014",
+        "dispatched_emergency_services": false,
+        "needs_human_review": true,
+        "needs_clarification": false,
+        "confidence_category": 0.95,
+        "confidence_subcategory": 0.95,
+        "validator_reasons": [
+          "trap_prone_subcategory:air_quality(over_escalation_rate=19%)"
+        ],
+        "risk_reasons": [
+          "base_risk:MEDIUM"
+        ],
+        "retrieved_record_ids": [
+          "TKT-2023-00554",
+          "TKT-2024-08193",
+          "TKT-2022-07963",
+          "TKT-2022-07075",
+          "TKT-2023-02927",
+          "TKT-2023-01151",
+          "TKT-2023-01952",
+          "TKT-2023-01883"
+        ]
+      }
+    },
+    "transcript_id": "EVAL-0121"
+  },
+  {
+    "category": "PLUMBING",
+    "subcategory": "drainage_backup",
+    "risk_level": "MEDIUM",
+    "needs_human_review": false,
+    "needs_clarification": false,
+    "building_name": "Eastlake Medical Plaza",
+    "address": "820 Eastlake Pkwy",
+    "floor": "Floor 3",
+    "dispatched_vendor_id": "v_004",
+    "dispatched_emergency_services": false,
+    "call_summary": "Drainage backup reported at Eastlake Medical Plaza, Floor 3. MEDIUM risk. Dispatched Regency Commercial Plumbing.",
+    "trainer_log": {
+      "full_transcript": "[AGENT] CBRE maintenance \u2014 what's going on?\n[CALLER] Hi there, Kitchen sink drain is completely backed up.\n[AGENT] Understood. Is there a strong sewer smell?\n[CALLER] Sorry, yeah, there's definitely a smell.\n[AGENT] Can you confirm the building and floor?\n[CALLER] Eastlake Medical Plaza, uh, Floor 3, Suite 304.\n[AGENT] Got it. I'll get someone out as soon as I can \u2014 should hear back within the hour.",
+      "ai_prediction": {
+        "category": "PLUMBING",
+        "subcategory": "drainage_backup",
+        "risk_level": "MEDIUM",
+        "dispatched_vendor_id": "v_004",
+        "dispatched_emergency_services": false,
+        "needs_human_review": false,
+        "needs_clarification": false,
+        "confidence_category": 0.95,
+        "confidence_subcategory": 0.95,
+        "validator_reasons": [
+          "auto_resolve:no_flags_fired"
+        ],
+        "risk_reasons": [
+          "base_risk:LOW",
+          "sensitive_building:medical"
+        ],
+        "retrieved_record_ids": [
+          "TKT-2023-02702",
+          "TKT-2023-00242",
+          "TKT-2022-00961",
+          "TKT-2022-02335",
+          "TKT-2023-07628",
+          "TKT-2022-07435",
+          "TKT-2023-04811",
+          "TKT-2023-08693"
+        ]
+      },
+      "human_override": null,
+      "final_decision": {
+        "category": "PLUMBING",
+        "subcategory": "drainage_backup",
+        "risk_level": "MEDIUM",
+        "dispatched_vendor_id": "v_004",
+        "dispatched_emergency_services": false,
+        "needs_human_review": false,
+        "needs_clarification": false,
+        "confidence_category": 0.95,
+        "confidence_subcategory": 0.95,
+        "validator_reasons": [
+          "auto_resolve:no_flags_fired"
+        ],
+        "risk_reasons": [
+          "base_risk:LOW",
+          "sensitive_building:medical"
+        ],
+        "retrieved_record_ids": [
+          "TKT-2023-02702",
+          "TKT-2023-00242",
+          "TKT-2022-00961",
+          "TKT-2022-02335",
+          "TKT-2023-07628",
+          "TKT-2022-07435",
+          "TKT-2023-04811",
+          "TKT-2023-08693"
+        ]
+      }
+    },
+    "transcript_id": "EVAL-0126"
+  },
+  {
+    "category": "ELEVATOR",
+    "subcategory": "malfunction",
+    "risk_level": "MEDIUM",
+    "needs_human_review": true,
+    "needs_clarification": false,
+    "building_name": "Redwood Corporate Plaza",
+    "address": "2400 Redwood Hwy",
+    "floor": "Floor 3",
+    "dispatched_vendor_id": "v_017",
+    "dispatched_emergency_services": false,
+    "call_summary": "Equipment malfunction reported at Redwood Corporate Plaza, Floor 3. MEDIUM risk. Flagged for review. Valley Elevator Service dispatched pending approval.",
+    "trainer_log": {
+      "full_transcript": "[AGENT] Hi, CBRE facilities. What can I do for you?\n[CALLER] The elevator's doing something weird.\n[AGENT] Okay, can you describe what you're seeing or smelling?\n[CALLER] Been like this for two days now.\n[AGENT] How long has this been happening?\n[CALLER] Probably fine but sounds awful.\n[AGENT] Which building and floor are you at?\n[CALLER] Redwood Corporate Plaza, Floor 3, Suite 304.\n[AGENT] Got the ticket open. Vendor should make it out during business hours.",
+      "ai_prediction": {
+        "category": "ELEVATOR",
+        "subcategory": "malfunction",
+        "risk_level": "MEDIUM",
+        "dispatched_vendor_id": "v_017",
+        "dispatched_emergency_services": false,
+        "needs_human_review": true,
+        "needs_clarification": false,
+        "confidence_category": 0.9,
+        "confidence_subcategory": 0.9,
+        "validator_reasons": [
+          "trap_cascade_subcategory:malfunction(high-audit cell at HIGH/EMERGENCY \u2014 possible under-classification)"
+        ],
+        "risk_reasons": [
+          "base_risk:MEDIUM"
+        ],
+        "retrieved_record_ids": [
+          "TKT-2022-00403",
+          "TKT-2024-09756",
+          "TKT-2023-06152",
+          "TKT-2023-02543",
+          "TKT-2023-00194",
+          "TKT-2022-09103",
+          "TKT-2022-02146",
+          "TKT-2024-02412"
+        ]
+      },
+      "human_override": null,
+      "final_decision": {
+        "category": "ELEVATOR",
+        "subcategory": "malfunction",
+        "risk_level": "MEDIUM",
+        "dispatched_vendor_id": "v_017",
+        "dispatched_emergency_services": false,
+        "needs_human_review": true,
+        "needs_clarification": false,
+        "confidence_category": 0.9,
+        "confidence_subcategory": 0.9,
+        "validator_reasons": [
+          "trap_cascade_subcategory:malfunction(high-audit cell at HIGH/EMERGENCY \u2014 possible under-classification)"
+        ],
+        "risk_reasons": [
+          "base_risk:MEDIUM"
+        ],
+        "retrieved_record_ids": [
+          "TKT-2022-00403",
+          "TKT-2024-09756",
+          "TKT-2023-06152",
+          "TKT-2023-02543",
+          "TKT-2023-00194",
+          "TKT-2022-09103",
+          "TKT-2022-02146",
+          "TKT-2024-02412"
+        ]
+      }
+    },
+    "transcript_id": "EVAL-0127"
+  },
+  {
+    "category": "HVAC",
+    "subcategory": "refrigerant",
+    "risk_level": "LOW",
+    "needs_human_review": false,
+    "needs_clarification": false,
+    "building_name": "Metro Center Offices",
+    "address": "650 Metro Center Way",
+    "floor": "Floor 1",
+    "dispatched_vendor_id": "v_012",
+    "dispatched_emergency_services": false,
+    "call_summary": "Refrigerant issue reported at Metro Center Offices, Floor 1. LOW risk. Dispatched Pacific HVAC Services.",
+    "trainer_log": {
+      "full_transcript": "[AGENT] CBRE maintenance \u2014 what's going on?\n[CALLER] [background: hvac hum] Hi, HVAC tech said something about a refrigerant leak last week; still acting up.\n[AGENT] Understood. Is the unit still running?\n[CALLER] Performance dropped a lot since this morning.\n[AGENT] Which building, floor, and suite are you in?\n[CALLER] Sorry, metro Center Offices, Floor 1, Suite 803.\n[AGENT] Alright, I've put a ticket in \u2014 vendor will swing by during business hours.\n[CALLER] You know, alright, appreciate it.",
+      "ai_prediction": {
+        "category": "HVAC",
+        "subcategory": "refrigerant",
+        "risk_level": "LOW",
+        "dispatched_vendor_id": "v_012",
+        "dispatched_emergency_services": false,
+        "needs_human_review": false,
+        "needs_clarification": false,
+        "confidence_category": 0.95,
+        "confidence_subcategory": 0.95,
+        "validator_reasons": [
+          "auto_resolve:no_flags_fired"
+        ],
+        "risk_reasons": [
+          "base_risk:LOW"
+        ],
+        "retrieved_record_ids": [
+          "TKT-2024-02568",
+          "TKT-2023-08258",
+          "TKT-2022-04153",
+          "TKT-2022-06571",
+          "TKT-2024-06294",
+          "TKT-2022-01912",
+          "TKT-2023-07496",
+          "TKT-2022-09061"
+        ]
+      },
+      "human_override": null,
+      "final_decision": {
+        "category": "HVAC",
+        "subcategory": "refrigerant",
+        "risk_level": "LOW",
+        "dispatched_vendor_id": "v_012",
+        "dispatched_emergency_services": false,
+        "needs_human_review": false,
+        "needs_clarification": false,
+        "confidence_category": 0.95,
+        "confidence_subcategory": 0.95,
+        "validator_reasons": [
+          "auto_resolve:no_flags_fired"
+        ],
+        "risk_reasons": [
+          "base_risk:LOW"
+        ],
+        "retrieved_record_ids": [
+          "TKT-2024-02568",
+          "TKT-2023-08258",
+          "TKT-2022-04153",
+          "TKT-2022-06571",
+          "TKT-2024-06294",
+          "TKT-2022-01912",
+          "TKT-2023-07496",
+          "TKT-2022-09061"
+        ]
+      }
+    },
+    "transcript_id": "EVAL-0145"
+  },
+  {
+    "category": "HVAC",
+    "subcategory": "refrigerant",
+    "risk_level": "LOW",
+    "needs_human_review": false,
+    "needs_clarification": false,
+    "building_name": "Pacific Financial Tower",
+    "address": "555 Pacific Ave",
+    "floor": "Floor 4",
+    "dispatched_vendor_id": "v_014",
+    "dispatched_emergency_services": false,
+    "call_summary": "Refrigerant issue reported at Pacific Financial Tower, Floor 4. LOW risk. Dispatched MediCool HVAC Systems.",
+    "trainer_log": {
+      "full_transcript": "[AGENT] Dispatch, what do you need?\n[CALLER] Um, good morning, Chiller is making a hissing sound, AC performance dropping.\n[AGENT] Okay, I see. Is the unit still running?\n[CALLER] Performance dropped a lot since this morning.\n[AGENT] Where exactly \u2014 which suite?\n[CALLER] Pacific Financial Tower, you know, Floor 4, Suite 405.\n[AGENT] Alright, I'll send a vendor over. You'll get a text once they're rolling.\n[CALLER] Thanks, bye.",
+      "ai_prediction": {
+        "category": "HVAC",
+        "subcategory": "refrigerant",
+        "risk_level": "LOW",
+        "dispatched_vendor_id": "v_014",
+        "dispatched_emergency_services": false,
+        "needs_human_review": false,
+        "needs_clarification": false,
+        "confidence_category": 0.9,
+        "confidence_subcategory": 0.9,
+        "validator_reasons": [
+          "auto_resolve:no_flags_fired"
+        ],
+        "risk_reasons": [
+          "base_risk:LOW"
+        ],
+        "retrieved_record_ids": [
+          "TKT-2023-05033",
+          "TKT-2024-00651",
+          "TKT-2024-04170",
+          "TKT-2024-04833",
+          "TKT-2022-04639",
+          "TKT-2022-04675",
+          "TKT-2024-03852",
+          "TKT-2023-03221"
+        ]
+      },
+      "human_override": null,
+      "final_decision": {
+        "category": "HVAC",
+        "subcategory": "refrigerant",
+        "risk_level": "LOW",
+        "dispatched_vendor_id": "v_014",
+        "dispatched_emergency_services": false,
+        "needs_human_review": false,
+        "needs_clarification": false,
+        "confidence_category": 0.9,
+        "confidence_subcategory": 0.9,
+        "validator_reasons": [
+          "auto_resolve:no_flags_fired"
+        ],
+        "risk_reasons": [
+          "base_risk:LOW"
+        ],
+        "retrieved_record_ids": [
+          "TKT-2023-05033",
+          "TKT-2024-00651",
+          "TKT-2024-04170",
+          "TKT-2024-04833",
+          "TKT-2022-04639",
+          "TKT-2022-04675",
+          "TKT-2024-03852",
+          "TKT-2023-03221"
+        ]
+      }
+    },
+    "transcript_id": "EVAL-0152"
+  },
+  {
+    "category": "LIFE_SAFETY",
+    "subcategory": "gas_chemical",
+    "risk_level": "EMERGENCY",
+    "needs_human_review": true,
+    "needs_clarification": true,
+    "building_name": "Baxter Building",
+    "address": "900 Harbor Dr",
+    "floor": "Floor 8",
+    "dispatched_vendor_id": null,
+    "dispatched_emergency_services": true,
+    "call_summary": "Gas or chemical hazard reported at Baxter Building, Floor 8. EMERGENCY risk. Emergency services dispatched.",
+    "trainer_log": {
+      "full_transcript": "[AGENT] CBRE facilities, this is Sam. What's going on?\n[CALLER] Um, i smell something weird here.\n[AGENT] Have you evacuated the area?\n[CALLER] Smells like rotten eggs \u2014 pretty strong.\n[AGENT] Where exactly \u2014 which suite?\n[CALLER] Baxter Building, Floor 8, Suite 803.\n[AGENT] Calling emergency services this second and looping in building ops. Hang on the line if it's safe.",
+      "ai_prediction": {
+        "category": "LIFE_SAFETY",
+        "subcategory": "gas_chemical",
+        "risk_level": "EMERGENCY",
+        "dispatched_vendor_id": null,
+        "dispatched_emergency_services": true,
+        "needs_human_review": true,
+        "needs_clarification": true,
+        "confidence_category": 0.95,
+        "confidence_subcategory": 0.95,
+        "validator_reasons": [
+          "emergency_band:always_pause",
+          "emergency_dispatch:gas_chemical:hazard_cue_confirmed"
+        ],
+        "risk_reasons": [
+          "base_risk:EMERGENCY",
+          "hard_cue:gas leak",
+          "capped_at_EMERGENCY:historical_max for subcategory=gas_chemical"
+        ],
+        "retrieved_record_ids": [
+          "TKT-2022-05917",
+          "TKT-2024-00930",
+          "TKT-2024-04020",
+          "TKT-2022-02779",
+          "TKT-2022-02596",
+          "TKT-2022-01117",
+          "TKT-2022-09391",
+          "TKT-2022-09751"
+        ]
+      },
+      "human_override": null,
+      "final_decision": {
+        "category": "LIFE_SAFETY",
+        "subcategory": "gas_chemical",
+        "risk_level": "EMERGENCY",
+        "dispatched_vendor_id": null,
+        "dispatched_emergency_services": true,
+        "needs_human_review": true,
+        "needs_clarification": true,
+        "confidence_category": 0.95,
+        "confidence_subcategory": 0.95,
+        "validator_reasons": [
+          "emergency_band:always_pause",
+          "emergency_dispatch:gas_chemical:hazard_cue_confirmed"
+        ],
+        "risk_reasons": [
+          "base_risk:EMERGENCY",
+          "hard_cue:gas leak",
+          "capped_at_EMERGENCY:historical_max for subcategory=gas_chemical"
+        ],
+        "retrieved_record_ids": [
+          "TKT-2022-05917",
+          "TKT-2024-00930",
+          "TKT-2024-04020",
+          "TKT-2022-02779",
+          "TKT-2022-02596",
+          "TKT-2022-01117",
+          "TKT-2022-09391",
+          "TKT-2022-09751"
+        ]
+      }
+    },
+    "transcript_id": "EVAL-0153"
+  },
+  {
+    "category": "JANITORIAL",
+    "subcategory": "waste_odor",
+    "risk_level": "LOW",
+    "needs_human_review": false,
+    "needs_clarification": true,
+    "building_name": "Golden State Towers",
+    "address": "900 Golden State Blvd",
+    "floor": "Floor 12",
+    "dispatched_vendor_id": "v_024",
+    "dispatched_emergency_services": false,
+    "call_summary": "Waste/odor issue reported at Golden State Towers, Floor 12. LOW risk. Dispatched Bay Area Cleaning Solutions.",
+    "trainer_log": {
+      "full_transcript": "[AGENT] Dispatch, what do you need?\n[CALLER] There's an issue with waste odor.\n[AGENT] How bad is the smell?\n[CALLER] Pretty bad \u2014 can't really ignore it.\n[AGENT] Can you confirm the building and floor?\n[CALLER] Golden State Towers, Floor 12, Suite 1204.\n[AGENT] Okay, ticket's logged. Someone'll come out during business hours.",
+      "ai_prediction": {
+        "category": "JANITORIAL",
+        "subcategory": "waste_odor",
+        "risk_level": "LOW",
+        "dispatched_vendor_id": "v_024",
+        "dispatched_emergency_services": false,
+        "needs_human_review": false,
+        "needs_clarification": true,
+        "confidence_category": 0.95,
+        "confidence_subcategory": 0.95,
+        "validator_reasons": [
+          "auto_resolve:no_flags_fired"
+        ],
+        "risk_reasons": [
+          "base_risk:LOW"
+        ],
+        "retrieved_record_ids": [
+          "TKT-2022-03841",
+          "TKT-2024-00477",
+          "TKT-2022-00820",
+          "TKT-2023-09704",
+          "TKT-2024-08301",
+          "TKT-2022-09856",
+          "TKT-2022-02917",
+          "TKT-2022-01990"
+        ]
+      },
+      "human_override": null,
+      "final_decision": {
+        "category": "JANITORIAL",
+        "subcategory": "waste_odor",
+        "risk_level": "LOW",
+        "dispatched_vendor_id": "v_024",
+        "dispatched_emergency_services": false,
+        "needs_human_review": false,
+        "needs_clarification": true,
+        "confidence_category": 0.95,
+        "confidence_subcategory": 0.95,
+        "validator_reasons": [
+          "auto_resolve:no_flags_fired"
+        ],
+        "risk_reasons": [
+          "base_risk:LOW"
+        ],
+        "retrieved_record_ids": [
+          "TKT-2022-03841",
+          "TKT-2024-00477",
+          "TKT-2022-00820",
+          "TKT-2023-09704",
+          "TKT-2024-08301",
+          "TKT-2022-09856",
+          "TKT-2022-02917",
+          "TKT-2022-01990"
+        ]
+      }
+    },
+    "transcript_id": "EVAL-0154"
+  },
+  {
+    "category": "JANITORIAL",
+    "subcategory": "restroom_supplies",
+    "risk_level": "LOW",
+    "needs_human_review": false,
+    "needs_clarification": false,
+    "building_name": "One Commerce Center",
+    "address": "1 Commerce Way",
+    "floor": "Floor 9",
+    "dispatched_vendor_id": "v_025",
+    "dispatched_emergency_services": false,
+    "call_summary": "Restroom supply issue reported at One Commerce Center, Floor 9. LOW risk. Dispatched ProClean Facility Services.",
+    "trainer_log": {
+      "full_transcript": "[AGENT] CBRE facilities, Marcus speaking. How can I help?\n[CALLER] Restroom is out of toilet paper and paper towels.\n[AGENT] Got it. Is the whole facility out?\n[CALLER] Just TP \u2014 the rest is fine.\n[AGENT] Can you tell me the building, floor, and suite?\n[CALLER] Uh, one Commerce Center, Floor 9, Suite 904.\n[AGENT] Okay, ticket's logged. Someone'll come out during business hours.\n[CALLER] Okay.",
+      "ai_prediction": {
+        "category": "JANITORIAL",
+        "subcategory": "restroom_supplies",
+        "risk_level": "LOW",
+        "dispatched_vendor_id": "v_025",
+        "dispatched_emergency_services": false,
+        "needs_human_review": false,
+        "needs_clarification": false,
+        "confidence_category": 0.95,
+        "confidence_subcategory": 0.95,
+        "validator_reasons": [
+          "auto_resolve:no_flags_fired"
+        ],
+        "risk_reasons": [
+          "base_risk:LOW"
+        ],
+        "retrieved_record_ids": [
+          "TKT-2022-08467",
+          "TKT-2022-04618",
+          "TKT-2023-03878",
+          "TKT-2022-05617",
+          "TKT-2023-08306",
+          "TKT-2024-02238",
+          "TKT-2024-00984",
+          "TKT-2022-05257"
+        ]
+      },
+      "human_override": null,
+      "final_decision": {
+        "category": "JANITORIAL",
+        "subcategory": "restroom_supplies",
+        "risk_level": "LOW",
+        "dispatched_vendor_id": "v_025",
+        "dispatched_emergency_services": false,
+        "needs_human_review": false,
+        "needs_clarification": false,
+        "confidence_category": 0.95,
+        "confidence_subcategory": 0.95,
+        "validator_reasons": [
+          "auto_resolve:no_flags_fired"
+        ],
+        "risk_reasons": [
+          "base_risk:LOW"
+        ],
+        "retrieved_record_ids": [
+          "TKT-2022-08467",
+          "TKT-2022-04618",
+          "TKT-2023-03878",
+          "TKT-2022-05617",
+          "TKT-2023-08306",
+          "TKT-2024-02238",
+          "TKT-2024-00984",
+          "TKT-2022-05257"
+        ]
+      }
+    },
+    "transcript_id": "EVAL-0156"
+  },
+  {
+    "category": "PEST_SPECIALTY",
+    "subcategory": "landscaping",
+    "risk_level": "LOW",
+    "needs_human_review": false,
+    "needs_clarification": false,
+    "building_name": null,
+    "address": null,
+    "floor": "Floor 6",
+    "dispatched_vendor_id": "v_031",
+    "dispatched_emergency_services": false,
+    "call_summary": "Landscaping issue reported at Floor 6. LOW risk. Dispatched Cal-Coast Grounds Care.",
+    "trainer_log": {
+      "full_transcript": "[AGENT] CBRE facilities, this is Sam. What's going on?\n[CALLER] Hi there, Sprinkler head on Floor 6 in Suite 604 is stuck on, water everywhere.\n[AGENT] Got it. Is water damaging anything?\n[CALLER] Not immediately, but wasteful.\n[AGENT] Alright, I'll send a vendor over. You'll get a text once they're rolling.\n[CALLER] Okay, please hurry.",
+      "ai_prediction": {
+        "category": "PEST_SPECIALTY",
+        "subcategory": "landscaping",
+        "risk_level": "LOW",
+        "dispatched_vendor_id": "v_031",
+        "dispatched_emergency_services": false,
+        "needs_human_review": false,
+        "needs_clarification": false,
+        "confidence_category": 0.9,
+        "confidence_subcategory": 0.9,
+        "validator_reasons": [
+          "auto_resolve:no_flags_fired"
+        ],
+        "risk_reasons": [
+          "base_risk:LOW"
+        ],
+        "retrieved_record_ids": [
+          "TKT-2024-07431",
+          "TKT-2024-05583",
+          "TKT-2024-01134",
+          "TKT-2024-03981",
+          "TKT-2023-00428",
+          "TKT-2022-08212",
+          "TKT-2024-08415",
+          "TKT-2024-07266"
+        ]
+      },
+      "human_override": null,
+      "final_decision": {
+        "category": "PEST_SPECIALTY",
+        "subcategory": "landscaping",
+        "risk_level": "LOW",
+        "dispatched_vendor_id": "v_031",
+        "dispatched_emergency_services": false,
+        "needs_human_review": false,
+        "needs_clarification": false,
+        "confidence_category": 0.9,
+        "confidence_subcategory": 0.9,
+        "validator_reasons": [
+          "auto_resolve:no_flags_fired"
+        ],
+        "risk_reasons": [
+          "base_risk:LOW"
+        ],
+        "retrieved_record_ids": [
+          "TKT-2024-07431",
+          "TKT-2024-05583",
+          "TKT-2024-01134",
+          "TKT-2024-03981",
+          "TKT-2023-00428",
+          "TKT-2022-08212",
+          "TKT-2024-08415",
+          "TKT-2024-07266"
+        ]
+      }
+    },
+    "transcript_id": "EVAL-0161"
+  },
+  {
+    "category": "GROUNDS_EXTERIOR",
+    "subcategory": "signage_fencing",
+    "risk_level": "LOW",
+    "needs_human_review": false,
+    "needs_clarification": false,
+    "building_name": "Crossroads Business Park",
+    "address": "3300 Crossroads Pkwy",
+    "floor": "Floor 4",
+    "dispatched_vendor_id": "v_029",
+    "dispatched_emergency_services": false,
+    "call_summary": "Signage/fencing issue reported at Crossroads Business Park, Floor 4. LOW risk. Dispatched Golden State Exterior Maintenance.",
+    "trainer_log": {
+      "full_transcript": "[AGENT] CBRE maintenance \u2014 what's going on?\n[CALLER] Fence is leaning bad, wind must have done it.\n[AGENT] Mhm. Is it blocking access?\n[CALLER] Not blocking anything but it looks bad.\n[AGENT] Which building, floor, and suite are you in?\n[CALLER] Crossroads Business Park, Floor 4, Suite 401.\n[AGENT] I'll send a vendor out and loop in the PM.\n[AGENT] Hmm, none of our vendors are quite the right fit \u2014 let me bump this up to the on-call PM so they can handle it directly.\n[CALLER] Okay, please hurry.",
+      "ai_prediction": {
+        "category": "GROUNDS_EXTERIOR",
+        "subcategory": "signage_fencing",
+        "risk_level": "LOW",
+        "dispatched_vendor_id": "v_029",
+        "dispatched_emergency_services": false,
+        "needs_human_review": false,
+        "needs_clarification": false,
+        "confidence_category": 0.95,
+        "confidence_subcategory": 0.95,
+        "validator_reasons": [
+          "auto_resolve:no_flags_fired"
+        ],
+        "risk_reasons": [
+          "base_risk:LOW"
+        ],
+        "retrieved_record_ids": [
+          "TKT-2024-03567",
+          "TKT-2023-03824",
+          "TKT-2023-00674",
+          "TKT-2024-08451",
+          "TKT-2022-01576",
+          "TKT-2024-00783",
+          "TKT-2022-02356",
+          "TKT-2024-06204"
+        ]
+      },
+      "human_override": null,
+      "final_decision": {
+        "category": "GROUNDS_EXTERIOR",
+        "subcategory": "signage_fencing",
+        "risk_level": "LOW",
+        "dispatched_vendor_id": "v_029",
+        "dispatched_emergency_services": false,
+        "needs_human_review": false,
+        "needs_clarification": false,
+        "confidence_category": 0.95,
+        "confidence_subcategory": 0.95,
+        "validator_reasons": [
+          "auto_resolve:no_flags_fired"
+        ],
+        "risk_reasons": [
+          "base_risk:LOW"
+        ],
+        "retrieved_record_ids": [
+          "TKT-2024-03567",
+          "TKT-2023-03824",
+          "TKT-2023-00674",
+          "TKT-2024-08451",
+          "TKT-2022-01576",
+          "TKT-2024-00783",
+          "TKT-2022-02356",
+          "TKT-2024-06204"
+        ]
+      }
+    },
+    "transcript_id": "EVAL-0162"
+  },
+  {
+    "category": "ELEVATOR",
+    "subcategory": "entrapment",
+    "risk_level": "EMERGENCY",
+    "needs_human_review": true,
+    "needs_clarification": false,
+    "building_name": null,
+    "address": null,
+    "floor": "Floor 9",
+    "dispatched_vendor_id": "v_016",
+    "dispatched_emergency_services": true,
+    "call_summary": "Person trapped reported at Floor 9. EMERGENCY risk. Emergency services dispatched.",
+    "trainer_log": {
+      "full_transcript": "[AGENT] Hi, CBRE facilities. What can I do for you?\n[CALLER] Hey, Elevator on Floor 9 jammed between floors, I can hear someone banging inside.\n[AGENT] Alright. Are they between floors?\n[CALLER] Two people in there, they're pressing the call button.\n[AGENT] Are they responding?\n[CALLER] [pa announcement in background] Two people in there, they're pressing the call button.\n[AGENT] Pulling in the supervisor and dispatching a vendor right now.\n[CALLER] Thanks, bye.",
+      "ai_prediction": {
+        "category": "ELEVATOR",
+        "subcategory": "entrapment",
+        "risk_level": "EMERGENCY",
+        "dispatched_vendor_id": "v_016",
+        "dispatched_emergency_services": true,
+        "needs_human_review": true,
+        "needs_clarification": false,
+        "confidence_category": 0.95,
+        "confidence_subcategory": 0.95,
+        "validator_reasons": [
+          "emergency_band:always_pause",
+          "emergency_dispatch:entrapment:hazard_cue_confirmed"
+        ],
+        "risk_reasons": [
+          "base_risk:EMERGENCY",
+          "hard_cue:people trapped",
+          "capped_at_EMERGENCY:historical_max for subcategory=entrapment"
+        ],
+        "retrieved_record_ids": [
+          "TKT-2022-00187",
+          "TKT-2022-09835",
+          "TKT-2023-03569",
+          "TKT-2023-06902",
+          "TKT-2022-02071",
+          "TKT-2024-05823",
+          "TKT-2022-01486",
+          "TKT-2023-02576"
+        ]
+      },
+      "human_override": null,
+      "final_decision": {
+        "category": "ELEVATOR",
+        "subcategory": "entrapment",
+        "risk_level": "EMERGENCY",
+        "dispatched_vendor_id": "v_016",
+        "dispatched_emergency_services": true,
+        "needs_human_review": true,
+        "needs_clarification": false,
+        "confidence_category": 0.95,
+        "confidence_subcategory": 0.95,
+        "validator_reasons": [
+          "emergency_band:always_pause",
+          "emergency_dispatch:entrapment:hazard_cue_confirmed"
+        ],
+        "risk_reasons": [
+          "base_risk:EMERGENCY",
+          "hard_cue:people trapped",
+          "capped_at_EMERGENCY:historical_max for subcategory=entrapment"
+        ],
+        "retrieved_record_ids": [
+          "TKT-2022-00187",
+          "TKT-2022-09835",
+          "TKT-2023-03569",
+          "TKT-2023-06902",
+          "TKT-2022-02071",
+          "TKT-2024-05823",
+          "TKT-2022-01486",
+          "TKT-2023-02576"
+        ]
+      }
+    },
+    "transcript_id": "EVAL-0170"
+  },
+  {
+    "category": "ELEVATOR",
+    "subcategory": "minor_issue",
+    "risk_level": "LOW",
+    "needs_human_review": false,
+    "needs_clarification": false,
+    "building_name": "Metro Center Offices",
+    "address": "650 Metro Center Way",
+    "floor": "Floor 2",
+    "dispatched_vendor_id": "v_016",
+    "dispatched_emergency_services": false,
+    "call_summary": "Minor maintenance issue reported at Metro Center Offices, Floor 2. LOW risk. Dispatched Skyline Elevator Co.",
+    "trainer_log": {
+      "full_transcript": "[AGENT] Maintenance, what's the situation?\n[CALLER] The elevator isn't leveling properly at our floor.\n[AGENT] Alright. Is it still safe to use?\n[CALLER] Probably fine but sounds awful.\n[AGENT] What's your building, floor, suite?\n[CALLER] Metro Center Offices, you know, Floor 2, Suite 204.\n[AGENT] Got the ticket open. Vendor should make it out during business hours.\n[CALLER] Got it, um, thanks.",
+      "ai_prediction": {
+        "category": "ELEVATOR",
+        "subcategory": "minor_issue",
+        "risk_level": "LOW",
+        "dispatched_vendor_id": "v_016",
+        "dispatched_emergency_services": false,
+        "needs_human_review": false,
+        "needs_clarification": false,
+        "confidence_category": 0.95,
+        "confidence_subcategory": 0.95,
+        "validator_reasons": [
+          "auto_resolve:no_flags_fired"
+        ],
+        "risk_reasons": [
+          "base_risk:LOW"
+        ],
+        "retrieved_record_ids": [
+          "TKT-2023-04187",
+          "TKT-2023-06341",
+          "TKT-2024-03555",
+          "TKT-2024-08505",
+          "TKT-2024-06666",
+          "TKT-2023-09815",
+          "TKT-2024-00024",
+          "TKT-2024-03744"
+        ]
+      },
+      "human_override": null,
+      "final_decision": {
+        "category": "ELEVATOR",
+        "subcategory": "minor_issue",
+        "risk_level": "LOW",
+        "dispatched_vendor_id": "v_016",
+        "dispatched_emergency_services": false,
+        "needs_human_review": false,
+        "needs_clarification": false,
+        "confidence_category": 0.95,
+        "confidence_subcategory": 0.95,
+        "validator_reasons": [
+          "auto_resolve:no_flags_fired"
+        ],
+        "risk_reasons": [
+          "base_risk:LOW"
+        ],
+        "retrieved_record_ids": [
+          "TKT-2023-04187",
+          "TKT-2023-06341",
+          "TKT-2024-03555",
+          "TKT-2024-08505",
+          "TKT-2024-06666",
+          "TKT-2023-09815",
+          "TKT-2024-00024",
+          "TKT-2024-03744"
+        ]
+      }
+    },
+    "transcript_id": "EVAL-0175"
+  },
+  {
+    "category": "HVAC",
+    "subcategory": "air_quality",
+    "risk_level": "MEDIUM",
+    "needs_human_review": true,
+    "needs_clarification": false,
+    "building_name": "La Jolla Professional Suites",
+    "address": "9400 La Jolla Village Dr",
+    "floor": "Floor 2",
+    "dispatched_vendor_id": "v_014",
+    "dispatched_emergency_services": false,
+    "call_summary": "Air quality concern reported at La Jolla Professional Suites, Floor 2. MEDIUM risk. Flagged for review. MediCool HVAC Systems dispatched pending approval.",
+    "trainer_log": {
+      "full_transcript": "[AGENT] CBRE dispatch, talk to me.\n[CALLER] Strong chemical smell in the hallway, like cleaning fluid \u2014 the janitor just mopped with bleach solution.\n[AGENT] Okay \u2014 can you confirm there's no actual fire or injury right now?\n[CALLER] [background: phone ringing] No, uh, just the smell \u2014 no one's hurt, just annoying.\n[AGENT] Which building and floor are you at?\n[CALLER] [door closing] La Jolla Professional Suites, Floor 2, Suite 206.\n[AGENT] I'll get a vendor rolling and let the property manager know.",
+      "ai_prediction": {
+        "category": "HVAC",
+        "subcategory": "air_quality",
+        "risk_level": "MEDIUM",
+        "dispatched_vendor_id": "v_014",
+        "dispatched_emergency_services": false,
+        "needs_human_review": true,
+        "needs_clarification": false,
+        "confidence_category": 0.95,
+        "confidence_subcategory": 0.95,
+        "validator_reasons": [
+          "trap_prone_subcategory:air_quality(over_escalation_rate=19%)"
+        ],
+        "risk_reasons": [
+          "base_risk:MEDIUM"
+        ],
+        "retrieved_record_ids": [
+          "TKT-2023-00554",
+          "TKT-2024-08193",
+          "TKT-2022-07963",
+          "TKT-2023-01883",
+          "TKT-2022-07075",
+          "TKT-2023-02927",
+          "TKT-2023-01952",
+          "TKT-2023-01151"
+        ]
+      },
+      "human_override": null,
+      "final_decision": {
+        "category": "HVAC",
+        "subcategory": "air_quality",
+        "risk_level": "MEDIUM",
+        "dispatched_vendor_id": "v_014",
+        "dispatched_emergency_services": false,
+        "needs_human_review": true,
+        "needs_clarification": false,
+        "confidence_category": 0.95,
+        "confidence_subcategory": 0.95,
+        "validator_reasons": [
+          "trap_prone_subcategory:air_quality(over_escalation_rate=19%)"
+        ],
+        "risk_reasons": [
+          "base_risk:MEDIUM"
+        ],
+        "retrieved_record_ids": [
+          "TKT-2023-00554",
+          "TKT-2024-08193",
+          "TKT-2022-07963",
+          "TKT-2023-01883",
+          "TKT-2022-07075",
+          "TKT-2023-02927",
+          "TKT-2023-01952",
+          "TKT-2023-01151"
+        ]
+      }
+    },
+    "transcript_id": "EVAL-0177"
+  },
+  {
+    "category": "PEST_SPECIALTY",
+    "subcategory": "landscaping",
+    "risk_level": "LOW",
+    "needs_human_review": false,
+    "needs_clarification": false,
+    "building_name": "Pacific Financial Tower",
+    "address": "555 Pacific Ave",
+    "floor": "Floor 15",
+    "dispatched_vendor_id": "v_031",
+    "dispatched_emergency_services": false,
+    "call_summary": "Landscaping issue reported at Pacific Financial Tower, Floor 15. LOW risk. Dispatched Cal-Coast Grounds Care.",
+    "trainer_log": {
+      "full_transcript": "[AGENT] CBRE maintenance line, this is Priya \u2014 what do you need?\n[CALLER] Hold on, irrigation sprinkler on Floor 15 is broken and flooding the lawn.\n[AGENT] Which building and floor are you at?\n[CALLER] Pacific Financial Tower, Floor 15.\n[AGENT] Okay, I'll line that up now. Confirmation text will come through shortly.",
+      "ai_prediction": {
+        "category": "PEST_SPECIALTY",
+        "subcategory": "landscaping",
+        "risk_level": "LOW",
+        "dispatched_vendor_id": "v_031",
+        "dispatched_emergency_services": false,
+        "needs_human_review": false,
+        "needs_clarification": false,
+        "confidence_category": 0.95,
+        "confidence_subcategory": 0.95,
+        "validator_reasons": [
+          "auto_resolve:no_flags_fired"
+        ],
+        "risk_reasons": [
+          "base_risk:LOW",
+          "soft_cue:flooding",
+          "capped_at_LOW:historical_max for subcategory=landscaping"
+        ],
+        "retrieved_record_ids": [
+          "TKT-2023-02270",
+          "TKT-2024-04068",
+          "TKT-2024-08523",
+          "TKT-2023-05066",
+          "TKT-2023-06503",
+          "TKT-2024-04671",
+          "TKT-2024-01227",
+          "TKT-2024-09378"
+        ]
+      },
+      "human_override": null,
+      "final_decision": {
+        "category": "PEST_SPECIALTY",
+        "subcategory": "landscaping",
+        "risk_level": "LOW",
+        "dispatched_vendor_id": "v_031",
+        "dispatched_emergency_services": false,
+        "needs_human_review": false,
+        "needs_clarification": false,
+        "confidence_category": 0.95,
+        "confidence_subcategory": 0.95,
+        "validator_reasons": [
+          "auto_resolve:no_flags_fired"
+        ],
+        "risk_reasons": [
+          "base_risk:LOW",
+          "soft_cue:flooding",
+          "capped_at_LOW:historical_max for subcategory=landscaping"
+        ],
+        "retrieved_record_ids": [
+          "TKT-2023-02270",
+          "TKT-2024-04068",
+          "TKT-2024-08523",
+          "TKT-2023-05066",
+          "TKT-2023-06503",
+          "TKT-2024-04671",
+          "TKT-2024-01227",
+          "TKT-2024-09378"
+        ]
+      }
+    },
+    "transcript_id": "EVAL-0181"
+  },
+  {
+    "category": "PLUMBING",
+    "subcategory": "pipe_leak",
+    "risk_level": "HIGH",
+    "needs_human_review": true,
+    "needs_clarification": false,
+    "building_name": "Wilshire Grand Offices",
+    "address": "1100 Wilshire Blvd",
+    "floor": "Floor 20",
+    "dispatched_vendor_id": "v_004",
+    "dispatched_emergency_services": false,
+    "call_summary": "Pipe leak reported at Wilshire Grand Offices, Floor 20. HIGH risk. Flagged for review. Regency Commercial Plumbing dispatched pending approval.",
+    "trainer_log": {
+      "full_transcript": "[AGENT] Maintenance, what's the situation?\n[CALLER] There's something leaking, I think it's water.\n[AGENT] Okay, can you describe what you're seeing or smelling?\n[CALLER] Just dripping for the last hour, not terrible yet.\n[AGENT] Is it near any electrical outlets?\n[CALLER] Water's pooling \u2014 maybe a foot across?\n[AGENT] What's your building, floor, suite?\n[CALLER] Wilshire Grand Offices, Floor 20, Suite 2005.\n[AGENT] Tech is on the way. You'll get a text once they're rolling.",
+      "ai_prediction": {
+        "category": "PLUMBING",
+        "subcategory": "pipe_leak",
+        "risk_level": "HIGH",
+        "dispatched_vendor_id": "v_004",
+        "dispatched_emergency_services": false,
+        "needs_human_review": true,
+        "needs_clarification": false,
+        "confidence_category": 0.95,
+        "confidence_subcategory": 0.95,
+        "validator_reasons": [
+          "high_band:always_pause"
+        ],
+        "risk_reasons": [
+          "base_risk:HIGH"
+        ],
+        "retrieved_record_ids": [
+          "TKT-2023-09839",
+          "TKT-2023-02333",
+          "TKT-2024-03597",
+          "TKT-2022-01243",
+          "TKT-2022-00526",
+          "TKT-2023-06353",
+          "TKT-2023-01511",
+          "TKT-2023-09572"
+        ]
+      },
+      "human_override": null,
+      "final_decision": {
+        "category": "PLUMBING",
+        "subcategory": "pipe_leak",
+        "risk_level": "HIGH",
+        "dispatched_vendor_id": "v_004",
+        "dispatched_emergency_services": false,
+        "needs_human_review": true,
+        "needs_clarification": false,
+        "confidence_category": 0.95,
+        "confidence_subcategory": 0.95,
+        "validator_reasons": [
+          "high_band:always_pause"
+        ],
+        "risk_reasons": [
+          "base_risk:HIGH"
+        ],
+        "retrieved_record_ids": [
+          "TKT-2023-09839",
+          "TKT-2023-02333",
+          "TKT-2024-03597",
+          "TKT-2022-01243",
+          "TKT-2022-00526",
+          "TKT-2023-06353",
+          "TKT-2023-01511",
+          "TKT-2023-09572"
+        ]
+      }
+    },
+    "transcript_id": "EVAL-0192"
+  },
+  {
+    "category": "JANITORIAL",
+    "subcategory": "restroom_supplies",
+    "risk_level": "LOW",
+    "needs_human_review": false,
+    "needs_clarification": false,
+    "building_name": "Sierra Vista Medical Office",
+    "address": "750 Sierra Vista Ave",
+    "floor": "Floor 2",
+    "dispatched_vendor_id": "v_025",
+    "dispatched_emergency_services": false,
+    "call_summary": "Restroom supply issue reported at Sierra Vista Medical Office, Floor 2. LOW risk. Dispatched ProClean Facility Services.",
+    "trainer_log": {
+      "full_transcript": "[AGENT] CBRE facilities, Marcus speaking. How can I help?\n[CALLER] Hello, Soap dispenser in the women's room is empty again.\n[AGENT] Understood. Is the whole facility out?\n[CALLER] Just TP \u2014 the rest is fine.\n[AGENT] Which building and floor are you at?\n[CALLER] Sierra Vista Medical Office, Floor 2, Suite 203.\n[AGENT] Alright, I'll send a vendor over. You'll get a text once they're rolling.",
+      "ai_prediction": {
+        "category": "JANITORIAL",
+        "subcategory": "restroom_supplies",
+        "risk_level": "LOW",
+        "dispatched_vendor_id": "v_025",
+        "dispatched_emergency_services": false,
+        "needs_human_review": false,
+        "needs_clarification": false,
+        "confidence_category": 0.95,
+        "confidence_subcategory": 0.95,
+        "validator_reasons": [
+          "auto_resolve:no_flags_fired"
+        ],
+        "risk_reasons": [
+          "base_risk:LOW",
+          "sensitive_building:medical",
+          "capped_at_LOW:historical_max for subcategory=restroom_supplies"
+        ],
+        "retrieved_record_ids": [
+          "TKT-2022-03352",
+          "TKT-2022-05032",
+          "TKT-2024-09666",
+          "TKT-2023-08510",
+          "TKT-2024-05607",
+          "TKT-2023-00128",
+          "TKT-2022-06385",
+          "TKT-2023-08564"
+        ]
+      },
+      "human_override": null,
+      "final_decision": {
+        "category": "JANITORIAL",
+        "subcategory": "restroom_supplies",
+        "risk_level": "LOW",
+        "dispatched_vendor_id": "v_025",
+        "dispatched_emergency_services": false,
+        "needs_human_review": false,
+        "needs_clarification": false,
+        "confidence_category": 0.95,
+        "confidence_subcategory": 0.95,
+        "validator_reasons": [
+          "auto_resolve:no_flags_fired"
+        ],
+        "risk_reasons": [
+          "base_risk:LOW",
+          "sensitive_building:medical",
+          "capped_at_LOW:historical_max for subcategory=restroom_supplies"
+        ],
+        "retrieved_record_ids": [
+          "TKT-2022-03352",
+          "TKT-2022-05032",
+          "TKT-2024-09666",
+          "TKT-2023-08510",
+          "TKT-2024-05607",
+          "TKT-2023-00128",
+          "TKT-2022-06385",
+          "TKT-2023-08564"
+        ]
+      }
+    },
+    "transcript_id": "EVAL-0193"
+  },
+  {
+    "category": "ELECTRICAL",
+    "subcategory": "lighting",
+    "risk_level": "LOW",
+    "needs_human_review": false,
+    "needs_clarification": false,
+    "building_name": "Mission Bay Technology Center",
+    "address": "1600 Mission Bay Dr",
+    "floor": "Floor 7",
+    "dispatched_vendor_id": "v_010",
+    "dispatched_emergency_services": false,
+    "call_summary": "Lighting failure reported at Mission Bay Technology Center, Floor 7. LOW risk. Dispatched All-Site Facilities Co.",
+    "trainer_log": {
+      "full_transcript": "[AGENT] Maintenance, what's the situation?\n[CALLER] Um, the hallway light is out - can't see the doorways.\n[AGENT] Mhm. Is it flickering or fully out?\n[CALLER] Flickering, kind of strobing.\n[AGENT] Which building and floor are you at?\n[CALLER] Mission Bay Technology Center, hold on, Floor 7, Suite 704.\n[AGENT] Okay, I'll line that up now. Confirmation text will come through shortly.\n[CALLER] Thanks, bye.",
+      "ai_prediction": {
+        "category": "ELECTRICAL",
+        "subcategory": "lighting",
+        "risk_level": "LOW",
+        "dispatched_vendor_id": "v_010",
+        "dispatched_emergency_services": false,
+        "needs_human_review": false,
+        "needs_clarification": false,
+        "confidence_category": 0.95,
+        "confidence_subcategory": 0.95,
+        "validator_reasons": [
+          "auto_resolve:no_flags_fired"
+        ],
+        "risk_reasons": [
+          "base_risk:LOW"
+        ],
+        "retrieved_record_ids": [
+          "TKT-2024-01584",
+          "TKT-2023-03671",
+          "TKT-2024-08577",
+          "TKT-2023-03776",
+          "TKT-2022-00850",
+          "TKT-2022-04063",
+          "TKT-2022-09973",
+          "TKT-2022-04819"
+        ]
+      },
+      "human_override": null,
+      "final_decision": {
+        "category": "ELECTRICAL",
+        "subcategory": "lighting",
+        "risk_level": "LOW",
+        "dispatched_vendor_id": "v_010",
+        "dispatched_emergency_services": false,
+        "needs_human_review": false,
+        "needs_clarification": false,
+        "confidence_category": 0.95,
+        "confidence_subcategory": 0.95,
+        "validator_reasons": [
+          "auto_resolve:no_flags_fired"
+        ],
+        "risk_reasons": [
+          "base_risk:LOW"
+        ],
+        "retrieved_record_ids": [
+          "TKT-2024-01584",
+          "TKT-2023-03671",
+          "TKT-2024-08577",
+          "TKT-2023-03776",
+          "TKT-2022-00850",
+          "TKT-2022-04063",
+          "TKT-2022-09973",
+          "TKT-2022-04819"
+        ]
+      }
+    },
+    "transcript_id": "EVAL-0195"
+  },
+  {
+    "category": "SECURITY",
+    "subcategory": "unauthorized_access",
+    "risk_level": "HIGH",
+    "needs_human_review": true,
+    "needs_clarification": false,
+    "building_name": "Oakwood Corporate Campus - Building A",
+    "address": "400 Oakwood Pkwy",
+    "floor": "Floor 6",
+    "dispatched_vendor_id": "v_027",
+    "dispatched_emergency_services": false,
+    "call_summary": "Unauthorized access reported at Oakwood Corporate Campus - Building A, Floor 6. HIGH risk. Flagged for review. Elite Protective Services dispatched pending approval.",
+    "trainer_log": {
+      "full_transcript": "[AGENT] CBRE facilities, this is Sam. What's going on?\n[CALLER] Hi, hold on, Breach alarm is going off - looks like someone entered without a badge.\n[AGENT] Mhm. Do you have a description?\n[CALLER] Wearing a tan uniform, looks like a delivery person but no tag.\n[AGENT] Which building and floor are you at?\n[CALLER] Oakwood Corporate Campus - Building A, hold on, Floor 6, Suite 605.\n[AGENT] I want a second pair of eyes on this. I'll bring the PM in and send a tech out.",
+      "ai_prediction": {
+        "category": "SECURITY",
+        "subcategory": "unauthorized_access",
+        "risk_level": "HIGH",
+        "dispatched_vendor_id": "v_027",
+        "dispatched_emergency_services": false,
+        "needs_human_review": true,
+        "needs_clarification": false,
+        "confidence_category": 0.95,
+        "confidence_subcategory": 0.95,
+        "validator_reasons": [
+          "high_band:always_pause"
+        ],
+        "risk_reasons": [
+          "base_risk:HIGH"
+        ],
+        "retrieved_record_ids": [
+          "TKT-2023-07427",
+          "TKT-2023-06473",
+          "TKT-2022-02461",
+          "TKT-2024-02748",
+          "TKT-2024-09882",
+          "TKT-2023-08723",
+          "TKT-2022-01288",
+          "TKT-2022-07258"
+        ]
+      },
+      "human_override": null,
+      "final_decision": {
+        "category": "SECURITY",
+        "subcategory": "unauthorized_access",
+        "risk_level": "HIGH",
+        "dispatched_vendor_id": "v_027",
+        "dispatched_emergency_services": false,
+        "needs_human_review": true,
+        "needs_clarification": false,
+        "confidence_category": 0.95,
+        "confidence_subcategory": 0.95,
+        "validator_reasons": [
+          "high_band:always_pause"
+        ],
+        "risk_reasons": [
+          "base_risk:HIGH"
+        ],
+        "retrieved_record_ids": [
+          "TKT-2023-07427",
+          "TKT-2023-06473",
+          "TKT-2022-02461",
+          "TKT-2024-02748",
+          "TKT-2024-09882",
+          "TKT-2023-08723",
+          "TKT-2022-01288",
+          "TKT-2022-07258"
+        ]
+      }
+    },
+    "transcript_id": "EVAL-0197"
+  },
+  {
+    "category": "PLUMBING",
+    "subcategory": "pipe_leak",
+    "risk_level": "HIGH",
+    "needs_human_review": true,
+    "needs_clarification": true,
+    "building_name": "La Jolla Professional Suites",
+    "address": "9400 La Jolla Village Dr",
+    "floor": "Basement",
+    "dispatched_vendor_id": "v_004",
+    "dispatched_emergency_services": false,
+    "call_summary": "Pipe leak reported at La Jolla Professional Suites, Basement. HIGH risk. Flagged for review. Regency Commercial Plumbing dispatched pending approval.",
+    "trainer_log": {
+      "full_transcript": "[AGENT] Hi, CBRE facilities. What can I do for you?\n[CALLER] There's an issue with pipe leak.\n[AGENT] How large is the leak \u2014 dripping or pouring?\n[CALLER] [muffled voices nearby] Water's pooling \u2014 maybe a foot across?\n[AGENT] Can you confirm the building and floor?\n[CALLER] La Jolla Professional Suites, Basement.\n[AGENT] Tech is on the way. You'll get a text once they're rolling.",
+      "ai_prediction": {
+        "category": "PLUMBING",
+        "subcategory": "pipe_leak",
+        "risk_level": "HIGH",
+        "dispatched_vendor_id": "v_004",
+        "dispatched_emergency_services": false,
+        "needs_human_review": true,
+        "needs_clarification": true,
+        "confidence_category": 0.95,
+        "confidence_subcategory": 0.95,
+        "validator_reasons": [
+          "high_band:always_pause"
+        ],
+        "risk_reasons": [
+          "base_risk:HIGH"
+        ],
+        "retrieved_record_ids": [
+          "TKT-2023-09572",
+          "TKT-2023-00605",
+          "TKT-2024-05304",
+          "TKT-2024-01443",
+          "TKT-2022-07591",
+          "TKT-2023-09221",
+          "TKT-2023-08651",
+          "TKT-2024-03834"
+        ]
+      },
+      "human_override": null,
+      "final_decision": {
+        "category": "PLUMBING",
+        "subcategory": "pipe_leak",
+        "risk_level": "HIGH",
+        "dispatched_vendor_id": "v_004",
+        "dispatched_emergency_services": false,
+        "needs_human_review": true,
+        "needs_clarification": true,
+        "confidence_category": 0.95,
+        "confidence_subcategory": 0.95,
+        "validator_reasons": [
+          "high_band:always_pause"
+        ],
+        "risk_reasons": [
+          "base_risk:HIGH"
+        ],
+        "retrieved_record_ids": [
+          "TKT-2023-09572",
+          "TKT-2023-00605",
+          "TKT-2024-05304",
+          "TKT-2024-01443",
+          "TKT-2022-07591",
+          "TKT-2023-09221",
+          "TKT-2023-08651",
+          "TKT-2024-03834"
+        ]
+      }
+    },
+    "transcript_id": "EVAL-0198"
+  },
+  {
+    "category": "HVAC",
+    "subcategory": "no_cooling",
+    "risk_level": "LOW",
+    "needs_human_review": false,
+    "needs_clarification": false,
+    "building_name": "Seaside Professional Center",
+    "address": "350 Ocean View Ave",
+    "floor": "Floor 4",
+    "dispatched_vendor_id": "v_012",
+    "dispatched_emergency_services": false,
+    "call_summary": "No cooling reported at Seaside Professional Center, Floor 4. LOW risk. Dispatched Pacific HVAC Services.",
+    "trainer_log": {
+      "full_transcript": "[AGENT] CBRE facilities, this is Sam. What's going on?\n[CALLER] It's really hot in here, not sure what's going on.\n[AGENT] Okay, can you describe what you're seeing or smelling?\n[CALLER] Everyone on the floor is complaining.\n[AGENT] What's the current temperature?\n[CALLER] Hold on, everyone on the floor is complaining.\n[AGENT] Which building and floor are you at?\n[CALLER] Seaside Professional Center, Floor 4, Suite 403.\n[AGENT] Okay, ticket's logged. Someone'll come out during business hours.",
+      "ai_prediction": {
+        "category": "HVAC",
+        "subcategory": "no_cooling",
+        "risk_level": "LOW",
+        "dispatched_vendor_id": "v_012",
+        "dispatched_emergency_services": false,
+        "needs_human_review": false,
+        "needs_clarification": false,
+        "confidence_category": 0.9,
+        "confidence_subcategory": 0.9,
+        "validator_reasons": [
+          "auto_resolve:no_flags_fired"
+        ],
+        "risk_reasons": [
+          "base_risk:LOW"
+        ],
+        "retrieved_record_ids": [
+          "TKT-2024-05121",
+          "TKT-2022-00775",
+          "TKT-2023-05909",
+          "TKT-2022-06763",
+          "TKT-2022-04249",
+          "TKT-2022-02188",
+          "TKT-2024-07581",
+          "TKT-2023-00308"
+        ]
+      },
+      "human_override": null,
+      "final_decision": {
+        "category": "HVAC",
+        "subcategory": "no_cooling",
+        "risk_level": "LOW",
+        "dispatched_vendor_id": "v_012",
+        "dispatched_emergency_services": false,
+        "needs_human_review": false,
+        "needs_clarification": false,
+        "confidence_category": 0.9,
+        "confidence_subcategory": 0.9,
+        "validator_reasons": [
+          "auto_resolve:no_flags_fired"
+        ],
+        "risk_reasons": [
+          "base_risk:LOW"
+        ],
+        "retrieved_record_ids": [
+          "TKT-2024-05121",
+          "TKT-2022-00775",
+          "TKT-2023-05909",
+          "TKT-2022-06763",
+          "TKT-2022-04249",
+          "TKT-2022-02188",
+          "TKT-2024-07581",
+          "TKT-2023-00308"
+        ]
+      }
+    },
+    "transcript_id": "EVAL-0207"
+  },
+  {
+    "category": "HVAC",
+    "subcategory": "no_heating",
+    "risk_level": "LOW",
+    "needs_human_review": false,
+    "needs_clarification": false,
+    "building_name": "The Atrium at South Coast",
+    "address": "3100 Bristol St",
+    "floor": "Floor 3",
+    "dispatched_vendor_id": "v_012",
+    "dispatched_emergency_services": false,
+    "call_summary": "No heating reported at The Atrium at South Coast, Floor 3. LOW risk. Dispatched Pacific HVAC Services.",
+    "trainer_log": {
+      "full_transcript": "[AGENT] CBRE maintenance \u2014 what's going on?\n[CALLER] Good morning, HVAC is blowing cold air even though it's set to heat on Floor 3 in Suite 306.\n[AGENT] Alright. How cold is it in there?\n[CALLER] Got a client meeting coming in, this is bad.\n[AGENT] This one's a bit tricky \u2014 let me loop in the PM and get a tech rolling.\n[AGENT] Hmm, none of our vendors are quite the right fit \u2014 let me bump this up to the on-call PM so they can handle it directly.\n[CALLER] Okay, please hurry.",
+      "ai_prediction": {
+        "category": "HVAC",
+        "subcategory": "no_heating",
+        "risk_level": "LOW",
+        "dispatched_vendor_id": "v_012",
+        "dispatched_emergency_services": false,
+        "needs_human_review": false,
+        "needs_clarification": false,
+        "confidence_category": 0.9,
+        "confidence_subcategory": 0.9,
+        "validator_reasons": [
+          "auto_resolve:no_flags_fired"
+        ],
+        "risk_reasons": [
+          "base_risk:LOW"
+        ],
+        "retrieved_record_ids": [
+          "TKT-2024-04761",
+          "TKT-2024-06534",
+          "TKT-2023-01775",
+          "TKT-2023-07613",
+          "TKT-2022-08812",
+          "TKT-2024-09456",
+          "TKT-2022-05053",
+          "TKT-2024-02844"
+        ]
+      },
+      "human_override": null,
+      "final_decision": {
+        "category": "HVAC",
+        "subcategory": "no_heating",
+        "risk_level": "LOW",
+        "dispatched_vendor_id": "v_012",
+        "dispatched_emergency_services": false,
+        "needs_human_review": false,
+        "needs_clarification": false,
+        "confidence_category": 0.9,
+        "confidence_subcategory": 0.9,
+        "validator_reasons": [
+          "auto_resolve:no_flags_fired"
+        ],
+        "risk_reasons": [
+          "base_risk:LOW"
+        ],
+        "retrieved_record_ids": [
+          "TKT-2024-04761",
+          "TKT-2024-06534",
+          "TKT-2023-01775",
+          "TKT-2023-07613",
+          "TKT-2022-08812",
+          "TKT-2024-09456",
+          "TKT-2022-05053",
+          "TKT-2024-02844"
+        ]
+      }
+    },
+    "transcript_id": "EVAL-0210"
+  },
+  {
+    "category": "PEST_SPECIALTY",
+    "subcategory": "landscaping",
+    "risk_level": "LOW",
+    "needs_human_review": false,
+    "needs_clarification": false,
+    "building_name": "Palm Court Offices",
+    "address": "420 Palm Ave",
+    "floor": "Floor 2",
+    "dispatched_vendor_id": "v_031",
+    "dispatched_emergency_services": false,
+    "call_summary": "Landscaping issue reported at Palm Court Offices, Floor 2. LOW risk. Dispatched Cal-Coast Grounds Care.",
+    "trainer_log": {
+      "full_transcript": "[AGENT] Maintenance, what's the situation?\n[CALLER] Irrigation sprinkler at Palm Court Offices on Floor 2 in Suite 205 is broken and flooding the lawn.\n[AGENT] Alright. Is water damaging anything?\n[CALLER] Not immediately, but wasteful.\n[AGENT] Okay, I'll line that up now. Confirmation text will come through shortly.\n[CALLER] Okay.",
+      "ai_prediction": {
+        "category": "PEST_SPECIALTY",
+        "subcategory": "landscaping",
+        "risk_level": "LOW",
+        "dispatched_vendor_id": "v_031",
+        "dispatched_emergency_services": false,
+        "needs_human_review": false,
+        "needs_clarification": false,
+        "confidence_category": 0.9,
+        "confidence_subcategory": 0.9,
+        "validator_reasons": [
+          "auto_resolve:no_flags_fired"
+        ],
+        "risk_reasons": [
+          "base_risk:LOW",
+          "soft_cue:flooding",
+          "capped_at_LOW:historical_max for subcategory=landscaping"
+        ],
+        "retrieved_record_ids": [
+          "TKT-2023-06218",
+          "TKT-2024-01227",
+          "TKT-2023-05066",
+          "TKT-2023-06503",
+          "TKT-2024-09651",
+          "TKT-2023-02270",
+          "TKT-2024-04068",
+          "TKT-2024-09378"
+        ]
+      },
+      "human_override": null,
+      "final_decision": {
+        "category": "PEST_SPECIALTY",
+        "subcategory": "landscaping",
+        "risk_level": "LOW",
+        "dispatched_vendor_id": "v_031",
+        "dispatched_emergency_services": false,
+        "needs_human_review": false,
+        "needs_clarification": false,
+        "confidence_category": 0.9,
+        "confidence_subcategory": 0.9,
+        "validator_reasons": [
+          "auto_resolve:no_flags_fired"
+        ],
+        "risk_reasons": [
+          "base_risk:LOW",
+          "soft_cue:flooding",
+          "capped_at_LOW:historical_max for subcategory=landscaping"
+        ],
+        "retrieved_record_ids": [
+          "TKT-2023-06218",
+          "TKT-2024-01227",
+          "TKT-2023-05066",
+          "TKT-2023-06503",
+          "TKT-2024-09651",
+          "TKT-2023-02270",
+          "TKT-2024-04068",
+          "TKT-2024-09378"
+        ]
+      }
+    },
+    "transcript_id": "EVAL-0217"
+  },
+  {
+    "category": "JANITORIAL",
+    "subcategory": "restroom_supplies",
+    "risk_level": "LOW",
+    "needs_human_review": false,
+    "needs_clarification": false,
+    "building_name": "Pacific Ridge Medical Plaza",
+    "address": "3200 Pacific Coast Hwy",
+    "floor": "Floor 6",
+    "dispatched_vendor_id": "v_025",
+    "dispatched_emergency_services": false,
+    "call_summary": "Restroom supply issue reported at Pacific Ridge Medical Plaza, Floor 6. LOW risk. Dispatched ProClean Facility Services.",
+    "trainer_log": {
+      "full_transcript": "[AGENT] CBRE dispatch, talk to me.\n[CALLER] Like, the restroom's out of stuff.\n[AGENT] Okay, can you describe what you're seeing or smelling?\n[CALLER] You know, women's room on three.\n[AGENT] Is the whole facility out?\n[CALLER] Just TP \u2014 the rest is fine.\n[AGENT] Which building and floor are you at?\n[CALLER] Pacific Ridge Medical Plaza, Floor 6, Suite 602.\n[AGENT] Okay, I'll line that up now. Confirmation text will come through shortly.",
+      "ai_prediction": {
+        "category": "JANITORIAL",
+        "subcategory": "restroom_supplies",
+        "risk_level": "LOW",
+        "dispatched_vendor_id": "v_025",
+        "dispatched_emergency_services": false,
+        "needs_human_review": false,
+        "needs_clarification": false,
+        "confidence_category": 0.9,
+        "confidence_subcategory": 0.9,
+        "validator_reasons": [
+          "auto_resolve:no_flags_fired"
+        ],
+        "risk_reasons": [
+          "base_risk:LOW",
+          "sensitive_building:medical",
+          "capped_at_LOW:historical_max for subcategory=restroom_supplies"
+        ],
+        "retrieved_record_ids": [
+          "TKT-2024-01335",
+          "TKT-2023-07574",
+          "TKT-2022-03946",
+          "TKT-2022-04618",
+          "TKT-2023-08306",
+          "TKT-2022-01720",
+          "TKT-2023-09617",
+          "TKT-2024-01533"
+        ]
+      },
+      "human_override": null,
+      "final_decision": {
+        "category": "JANITORIAL",
+        "subcategory": "restroom_supplies",
+        "risk_level": "LOW",
+        "dispatched_vendor_id": "v_025",
+        "dispatched_emergency_services": false,
+        "needs_human_review": false,
+        "needs_clarification": false,
+        "confidence_category": 0.9,
+        "confidence_subcategory": 0.9,
+        "validator_reasons": [
+          "auto_resolve:no_flags_fired"
+        ],
+        "risk_reasons": [
+          "base_risk:LOW",
+          "sensitive_building:medical",
+          "capped_at_LOW:historical_max for subcategory=restroom_supplies"
+        ],
+        "retrieved_record_ids": [
+          "TKT-2024-01335",
+          "TKT-2023-07574",
+          "TKT-2022-03946",
+          "TKT-2022-04618",
+          "TKT-2023-08306",
+          "TKT-2022-01720",
+          "TKT-2023-09617",
+          "TKT-2024-01533"
+        ]
+      }
+    },
+    "transcript_id": "EVAL-0218"
+  },
+  {
+    "category": "HVAC",
+    "subcategory": "air_quality",
+    "risk_level": "MEDIUM",
+    "needs_human_review": true,
+    "needs_clarification": false,
+    "building_name": "The Atrium at South Coast",
+    "address": "3100 Bristol St",
+    "floor": "Floor 3",
+    "dispatched_vendor_id": "v_012",
+    "dispatched_emergency_services": false,
+    "call_summary": "Air quality concern reported at The Atrium at South Coast, Floor 3. MEDIUM risk. Flagged for review. Pacific HVAC Services dispatched pending approval.",
+    "trainer_log": {
+      "full_transcript": "[AGENT] CBRE maintenance \u2014 what's going on?\n[CALLER] Hello, uh, Two people on our floor got headaches from a weird smell in the air.\n[AGENT] Got it. Can you describe the smell?\n[CALLER] No, not sulfur \u2014 more like a cleaning solvent.\n[AGENT] Where exactly \u2014 which suite?\n[CALLER] The Atrium at South Coast, Floor 3, Suite 306.\n[AGENT] I'll get a tech out \u2014 they'll text you when they're heading over.\n[AGENT] Hmm, none of our vendors are quite the right fit \u2014 let me bump this up to the on-call PM so they can handle it directly.\n[CALLER] Okay, please hurry.",
+      "ai_prediction": {
+        "category": "HVAC",
+        "subcategory": "air_quality",
+        "risk_level": "MEDIUM",
+        "dispatched_vendor_id": "v_012",
+        "dispatched_emergency_services": false,
+        "needs_human_review": true,
+        "needs_clarification": false,
+        "confidence_category": 0.95,
+        "confidence_subcategory": 0.95,
+        "validator_reasons": [
+          "trap_prone_subcategory:air_quality(over_escalation_rate=19%)"
+        ],
+        "risk_reasons": [
+          "base_risk:MEDIUM"
+        ],
+        "retrieved_record_ids": [
+          "TKT-2022-09628",
+          "TKT-2023-02228",
+          "TKT-2023-07133",
+          "TKT-2023-07025",
+          "TKT-2023-00854",
+          "TKT-2022-04507",
+          "TKT-2023-09923",
+          "TKT-2022-07066"
+        ]
+      },
+      "human_override": null,
+      "final_decision": {
+        "category": "HVAC",
+        "subcategory": "air_quality",
+        "risk_level": "MEDIUM",
+        "dispatched_vendor_id": "v_012",
+        "dispatched_emergency_services": false,
+        "needs_human_review": true,
+        "needs_clarification": false,
+        "confidence_category": 0.95,
+        "confidence_subcategory": 0.95,
+        "validator_reasons": [
+          "trap_prone_subcategory:air_quality(over_escalation_rate=19%)"
+        ],
+        "risk_reasons": [
+          "base_risk:MEDIUM"
+        ],
+        "retrieved_record_ids": [
+          "TKT-2022-09628",
+          "TKT-2023-02228",
+          "TKT-2023-07133",
+          "TKT-2023-07025",
+          "TKT-2023-00854",
+          "TKT-2022-04507",
+          "TKT-2023-09923",
+          "TKT-2022-07066"
+        ]
+      }
+    },
+    "transcript_id": "EVAL-0224"
+  },
+  {
+    "category": "JANITORIAL",
+    "subcategory": "carpet_floor",
+    "risk_level": "LOW",
+    "needs_human_review": false,
+    "needs_clarification": false,
+    "building_name": null,
+    "address": null,
+    "floor": "Floor 4",
+    "dispatched_vendor_id": "v_023",
+    "dispatched_emergency_services": false,
+    "call_summary": "Carpet/flooring damage reported at Floor 4. LOW risk. Dispatched Sparkle Commercial Cleaning.",
+    "trainer_log": {
+      "full_transcript": "[AGENT] CBRE facilities \u2014 how can I help?\n[CALLER] Hi there, Someone spilled coffee all over the carpet on Floor 4 in Suite 404, need it cleaned.\n[AGENT] Mhm. What was spilled?\n[CALLER] Just spilled, coffee.\n[AGENT] Alright, I've put a ticket in \u2014 vendor will swing by during business hours.",
+      "ai_prediction": {
+        "category": "JANITORIAL",
+        "subcategory": "carpet_floor",
+        "risk_level": "LOW",
+        "dispatched_vendor_id": "v_023",
+        "dispatched_emergency_services": false,
+        "needs_human_review": false,
+        "needs_clarification": false,
+        "confidence_category": 0.95,
+        "confidence_subcategory": 0.95,
+        "validator_reasons": [
+          "auto_resolve:no_flags_fired"
+        ],
+        "risk_reasons": [
+          "base_risk:LOW"
+        ],
+        "retrieved_record_ids": [
+          "TKT-2022-00415",
+          "TKT-2024-02595",
+          "TKT-2022-05242",
+          "TKT-2023-08174",
+          "TKT-2022-06649",
+          "TKT-2022-08554",
+          "TKT-2022-05113",
+          "TKT-2023-07043"
+        ]
+      },
+      "human_override": null,
+      "final_decision": {
+        "category": "JANITORIAL",
+        "subcategory": "carpet_floor",
+        "risk_level": "LOW",
+        "dispatched_vendor_id": "v_023",
+        "dispatched_emergency_services": false,
+        "needs_human_review": false,
+        "needs_clarification": false,
+        "confidence_category": 0.95,
+        "confidence_subcategory": 0.95,
+        "validator_reasons": [
+          "auto_resolve:no_flags_fired"
+        ],
+        "risk_reasons": [
+          "base_risk:LOW"
+        ],
+        "retrieved_record_ids": [
+          "TKT-2022-00415",
+          "TKT-2024-02595",
+          "TKT-2022-05242",
+          "TKT-2023-08174",
+          "TKT-2022-06649",
+          "TKT-2022-08554",
+          "TKT-2022-05113",
+          "TKT-2023-07043"
+        ]
+      }
+    },
+    "transcript_id": "EVAL-0227"
+  },
+  {
+    "category": "PLUMBING",
+    "subcategory": "roof_leak",
+    "risk_level": "MEDIUM",
+    "needs_human_review": true,
+    "needs_clarification": false,
+    "building_name": "Mission Bay Technology Center",
+    "address": "1600 Mission Bay Dr",
+    "floor": "Floor 7",
+    "dispatched_vendor_id": "v_005",
+    "dispatched_emergency_services": false,
+    "call_summary": "Roof leak reported at Mission Bay Technology Center, Floor 7. MEDIUM risk. Flagged for review. Bayside Roofing Co dispatched pending approval.",
+    "trainer_log": {
+      "full_transcript": "[AGENT] CBRE facilities, this is Sam. What's going on?\n[CALLER] We've got a pipe leak \u2014 water is dripping from the ceiling tile steadily.\n[AGENT] Understood. Is it near any electrical outlets?\n[CALLER] Hold on \u2014 my mistake. It only happens when it rains, so this has to be a roof leak, not a pipe.\n[AGENT] Got it \u2014 updating the ticket. Is the ceiling sagging?\n[CALLER] Yeah, it's been pouring for like an hour.\n[AGENT] Which building and floor are you at?\n[CALLER] Mission Bay Technology Center, Floor 7, Suite 704.\n[AGENT] Sending a tech your way now. You'll hear from them en route.",
+      "ai_prediction": {
+        "category": "PLUMBING",
+        "subcategory": "roof_leak",
+        "risk_level": "MEDIUM",
+        "dispatched_vendor_id": "v_005",
+        "dispatched_emergency_services": false,
+        "needs_human_review": true,
+        "needs_clarification": false,
+        "confidence_category": 0.95,
+        "confidence_subcategory": 0.95,
+        "validator_reasons": [
+          "trap_cascade_subcategory:roof_leak(high-audit cell at HIGH/EMERGENCY \u2014 possible under-classification)"
+        ],
+        "risk_reasons": [
+          "base_risk:MEDIUM"
+        ],
+        "retrieved_record_ids": [
+          "TKT-2024-07929",
+          "TKT-2023-07562",
+          "TKT-2024-08340",
+          "TKT-2022-05638",
+          "TKT-2023-04388",
+          "TKT-2024-05037",
+          "TKT-2023-01490",
+          "TKT-2024-08469"
+        ]
+      },
+      "human_override": null,
+      "final_decision": {
+        "category": "PLUMBING",
+        "subcategory": "roof_leak",
+        "risk_level": "MEDIUM",
+        "dispatched_vendor_id": "v_005",
+        "dispatched_emergency_services": false,
+        "needs_human_review": true,
+        "needs_clarification": false,
+        "confidence_category": 0.95,
+        "confidence_subcategory": 0.95,
+        "validator_reasons": [
+          "trap_cascade_subcategory:roof_leak(high-audit cell at HIGH/EMERGENCY \u2014 possible under-classification)"
+        ],
+        "risk_reasons": [
+          "base_risk:MEDIUM"
+        ],
+        "retrieved_record_ids": [
+          "TKT-2024-07929",
+          "TKT-2023-07562",
+          "TKT-2024-08340",
+          "TKT-2022-05638",
+          "TKT-2023-04388",
+          "TKT-2024-05037",
+          "TKT-2023-01490",
+          "TKT-2024-08469"
+        ]
+      }
+    },
+    "transcript_id": "EVAL-0228"
+  },
+  {
+    "category": "HVAC",
+    "subcategory": "no_heating",
+    "risk_level": "LOW",
+    "needs_human_review": false,
+    "needs_clarification": true,
+    "building_name": "Riverside Corporate Campus",
+    "address": "2000 Riverside Dr",
+    "floor": "Floor 1",
+    "dispatched_vendor_id": "v_015",
+    "dispatched_emergency_services": false,
+    "call_summary": "No heating reported at Riverside Corporate Campus, Floor 1. LOW risk. Dispatched Budget Air Climate.",
+    "trainer_log": {
+      "full_transcript": "[AGENT] Maintenance, what's the situation?\n[CALLER] There's an issue with no heating.\n[AGENT] Are any vulnerable people \u2014 elderly or infants?\n[CALLER] I mean, it's like 58 in here.\n[AGENT] Can you confirm the building and floor?\n[CALLER] Riverside Corporate Campus, Floor 1.\n[AGENT] Got the ticket open. Vendor should make it out during business hours.",
+      "ai_prediction": {
+        "category": "HVAC",
+        "subcategory": "no_heating",
+        "risk_level": "LOW",
+        "dispatched_vendor_id": "v_015",
+        "dispatched_emergency_services": false,
+        "needs_human_review": false,
+        "needs_clarification": true,
+        "confidence_category": 0.95,
+        "confidence_subcategory": 0.95,
+        "validator_reasons": [
+          "auto_resolve:no_flags_fired"
+        ],
+        "risk_reasons": [
+          "base_risk:LOW"
+        ],
+        "retrieved_record_ids": [
+          "TKT-2024-01821",
+          "TKT-2023-09539",
+          "TKT-2023-08456",
+          "TKT-2024-04323",
+          "TKT-2022-08185",
+          "TKT-2022-08740",
+          "TKT-2022-08947",
+          "TKT-2024-04488"
+        ]
+      },
+      "human_override": null,
+      "final_decision": {
+        "category": "HVAC",
+        "subcategory": "no_heating",
+        "risk_level": "LOW",
+        "dispatched_vendor_id": "v_015",
+        "dispatched_emergency_services": false,
+        "needs_human_review": false,
+        "needs_clarification": true,
+        "confidence_category": 0.95,
+        "confidence_subcategory": 0.95,
+        "validator_reasons": [
+          "auto_resolve:no_flags_fired"
+        ],
+        "risk_reasons": [
+          "base_risk:LOW"
+        ],
+        "retrieved_record_ids": [
+          "TKT-2024-01821",
+          "TKT-2023-09539",
+          "TKT-2023-08456",
+          "TKT-2024-04323",
+          "TKT-2022-08185",
+          "TKT-2022-08740",
+          "TKT-2022-08947",
+          "TKT-2024-04488"
+        ]
+      }
+    },
+    "transcript_id": "EVAL-0231"
+  },
+  {
+    "category": "HVAC",
+    "subcategory": "no_cooling",
+    "risk_level": "LOW",
+    "needs_human_review": false,
+    "needs_clarification": false,
+    "building_name": "Baxter Building",
+    "address": "900 Harbor Dr",
+    "floor": "Floor 9",
+    "dispatched_vendor_id": "v_014",
+    "dispatched_emergency_services": false,
+    "call_summary": "No cooling reported at Baxter Building, Floor 9. LOW risk. Dispatched MediCool HVAC Systems.",
+    "trainer_log": {
+      "full_transcript": "[AGENT] Dispatch, what do you need?\n[CALLER] [door closing] I mean, it's really hot in here, not sure what's going on.\n[AGENT] Okay, can you describe what you're seeing or smelling?\n[CALLER] Everyone on the floor is complaining.\n[AGENT] What's the current temperature?\n[CALLER] It's 79 and climbing in here.\n[AGENT] Which building and floor are you at?\n[CALLER] Sorry, baxter Building, Floor 9.\n[AGENT] Okay, ticket's logged. Someone'll come out during business hours.",
+      "ai_prediction": {
+        "category": "HVAC",
+        "subcategory": "no_cooling",
+        "risk_level": "LOW",
+        "dispatched_vendor_id": "v_014",
+        "dispatched_emergency_services": false,
+        "needs_human_review": false,
+        "needs_clarification": false,
+        "confidence_category": 0.9,
+        "confidence_subcategory": 0.9,
+        "validator_reasons": [
+          "auto_resolve:no_flags_fired"
+        ],
+        "risk_reasons": [
+          "base_risk:LOW"
+        ],
+        "retrieved_record_ids": [
+          "TKT-2024-03906",
+          "TKT-2022-02176",
+          "TKT-2022-00742",
+          "TKT-2023-04244",
+          "TKT-2024-06996",
+          "TKT-2022-04789",
+          "TKT-2022-06763",
+          "TKT-2022-03127"
+        ]
+      },
+      "human_override": null,
+      "final_decision": {
+        "category": "HVAC",
+        "subcategory": "no_cooling",
+        "risk_level": "LOW",
+        "dispatched_vendor_id": "v_014",
+        "dispatched_emergency_services": false,
+        "needs_human_review": false,
+        "needs_clarification": false,
+        "confidence_category": 0.9,
+        "confidence_subcategory": 0.9,
+        "validator_reasons": [
+          "auto_resolve:no_flags_fired"
+        ],
+        "risk_reasons": [
+          "base_risk:LOW"
+        ],
+        "retrieved_record_ids": [
+          "TKT-2024-03906",
+          "TKT-2022-02176",
+          "TKT-2022-00742",
+          "TKT-2023-04244",
+          "TKT-2024-06996",
+          "TKT-2022-04789",
+          "TKT-2022-06763",
+          "TKT-2022-03127"
+        ]
+      }
+    },
+    "transcript_id": "EVAL-0257"
+  },
+  {
+    "category": "HVAC",
+    "subcategory": "controls_bms",
+    "risk_level": "LOW",
+    "needs_human_review": false,
+    "needs_clarification": false,
+    "building_name": "Airport Business Center",
+    "address": "9200 Airport Blvd",
+    "floor": "Floor 4",
+    "dispatched_vendor_id": "v_014",
+    "dispatched_emergency_services": false,
+    "call_summary": "Building controls issue reported at Airport Business Center, Floor 4. LOW risk. Dispatched MediCool HVAC Systems.",
+    "trainer_log": {
+      "full_transcript": "[AGENT] CBRE dispatch, talk to me.\n[CALLER] Can't change the temp on Floor 4, thermostat screen is frozen.\n[AGENT] Which building and floor are you at?\n[CALLER] Airport Business Center, uh, Floor 4.\n[AGENT] Got the ticket open. Vendor should make it out during business hours.",
+      "ai_prediction": {
+        "category": "HVAC",
+        "subcategory": "controls_bms",
+        "risk_level": "LOW",
+        "dispatched_vendor_id": "v_014",
+        "dispatched_emergency_services": false,
+        "needs_human_review": false,
+        "needs_clarification": false,
+        "confidence_category": 0.9,
+        "confidence_subcategory": 0.9,
+        "validator_reasons": [
+          "auto_resolve:no_flags_fired"
+        ],
+        "risk_reasons": [
+          "base_risk:LOW"
+        ],
+        "retrieved_record_ids": [
+          "TKT-2022-03970",
+          "TKT-2024-04464",
+          "TKT-2024-01902",
+          "TKT-2023-05918",
+          "TKT-2023-03287",
+          "TKT-2022-02137",
+          "TKT-2024-07401",
+          "TKT-2022-07753"
+        ]
+      },
+      "human_override": null,
+      "final_decision": {
+        "category": "HVAC",
+        "subcategory": "controls_bms",
+        "risk_level": "LOW",
+        "dispatched_vendor_id": "v_014",
+        "dispatched_emergency_services": false,
+        "needs_human_review": false,
+        "needs_clarification": false,
+        "confidence_category": 0.9,
+        "confidence_subcategory": 0.9,
+        "validator_reasons": [
+          "auto_resolve:no_flags_fired"
+        ],
+        "risk_reasons": [
+          "base_risk:LOW"
+        ],
+        "retrieved_record_ids": [
+          "TKT-2022-03970",
+          "TKT-2024-04464",
+          "TKT-2024-01902",
+          "TKT-2023-05918",
+          "TKT-2023-03287",
+          "TKT-2022-02137",
+          "TKT-2024-07401",
+          "TKT-2022-07753"
+        ]
+      }
+    },
+    "transcript_id": "EVAL-0267"
+  },
+  {
+    "category": "JANITORIAL",
+    "subcategory": "carpet_floor",
+    "risk_level": "LOW",
+    "needs_human_review": false,
+    "needs_clarification": false,
+    "building_name": "One Commerce Center",
+    "address": "1 Commerce Way",
+    "floor": "Floor 9",
+    "dispatched_vendor_id": "v_025",
+    "dispatched_emergency_services": false,
+    "call_summary": "Carpet/flooring damage reported at One Commerce Center, Floor 9. LOW risk. Dispatched ProClean Facility Services.",
+    "trainer_log": {
+      "full_transcript": "[AGENT] CBRE maintenance, this is Dana. What's going on?\n[CALLER] Good morning, Big dark stain on the carpet outside the elevators.\n[AGENT] Got it. Is the stain fresh?\n[CALLER] Yeah, like a large iced coffee.\n[AGENT] Which building and floor are you at?\n[CALLER] One Commerce Center, Floor 9, Suite 903.\n[AGENT] Alright, I've put a ticket in \u2014 vendor will swing by during business hours.\n[CALLER] Okay, thanks.",
+      "ai_prediction": {
+        "category": "JANITORIAL",
+        "subcategory": "carpet_floor",
+        "risk_level": "LOW",
+        "dispatched_vendor_id": "v_025",
+        "dispatched_emergency_services": false,
+        "needs_human_review": false,
+        "needs_clarification": false,
+        "confidence_category": 0.95,
+        "confidence_subcategory": 0.95,
+        "validator_reasons": [
+          "auto_resolve:no_flags_fired"
+        ],
+        "risk_reasons": [
+          "base_risk:LOW"
+        ],
+        "retrieved_record_ids": [
+          "TKT-2022-08044",
+          "TKT-2023-08411",
+          "TKT-2024-03984",
+          "TKT-2022-08674",
+          "TKT-2023-01106",
+          "TKT-2023-06221",
+          "TKT-2024-00879",
+          "TKT-2022-06658"
+        ]
+      },
+      "human_override": null,
+      "final_decision": {
+        "category": "JANITORIAL",
+        "subcategory": "carpet_floor",
+        "risk_level": "LOW",
+        "dispatched_vendor_id": "v_025",
+        "dispatched_emergency_services": false,
+        "needs_human_review": false,
+        "needs_clarification": false,
+        "confidence_category": 0.95,
+        "confidence_subcategory": 0.95,
+        "validator_reasons": [
+          "auto_resolve:no_flags_fired"
+        ],
+        "risk_reasons": [
+          "base_risk:LOW"
+        ],
+        "retrieved_record_ids": [
+          "TKT-2022-08044",
+          "TKT-2023-08411",
+          "TKT-2024-03984",
+          "TKT-2022-08674",
+          "TKT-2023-01106",
+          "TKT-2023-06221",
+          "TKT-2024-00879",
+          "TKT-2022-06658"
+        ]
+      }
+    },
+    "transcript_id": "EVAL-0269"
+  },
+  {
+    "category": "ELECTRICAL",
+    "subcategory": "lighting",
+    "risk_level": "LOW",
+    "needs_human_review": false,
+    "needs_clarification": true,
+    "building_name": "Metro Center Offices",
+    "address": "650 Metro Center Way",
+    "floor": "Floor 8",
+    "dispatched_vendor_id": "v_010",
+    "dispatched_emergency_services": false,
+    "call_summary": "Lighting failure reported at Metro Center Offices, Floor 8. LOW risk. Dispatched All-Site Facilities Co.",
+    "trainer_log": {
+      "full_transcript": "[AGENT] CBRE facilities, Marcus speaking. How can I help?\n[CALLER] Lights are off.\n[AGENT] Are the emergency lights on?\n[CALLER] Emergency lights came on, um, yeah.\n[AGENT] Which building and floor are you at?\n[CALLER] [door closing] Metro Center Offices, Floor 8, Suite 803.\n[AGENT] Alright \u2014 sending a vendor over and giving the PM a heads-up.",
+      "ai_prediction": {
+        "category": "ELECTRICAL",
+        "subcategory": "lighting",
+        "risk_level": "LOW",
+        "dispatched_vendor_id": "v_010",
+        "dispatched_emergency_services": false,
+        "needs_human_review": false,
+        "needs_clarification": true,
+        "confidence_category": 0.9,
+        "confidence_subcategory": 0.9,
+        "validator_reasons": [
+          "auto_resolve:no_flags_fired"
+        ],
+        "risk_reasons": [
+          "base_risk:LOW"
+        ],
+        "retrieved_record_ids": [
+          "TKT-2023-00701",
+          "TKT-2022-01171",
+          "TKT-2023-09686",
+          "TKT-2023-05675",
+          "TKT-2022-02446",
+          "TKT-2024-03603",
+          "TKT-2023-07139",
+          "TKT-2023-09089"
+        ]
+      },
+      "human_override": null,
+      "final_decision": {
+        "category": "ELECTRICAL",
+        "subcategory": "lighting",
+        "risk_level": "LOW",
+        "dispatched_vendor_id": "v_010",
+        "dispatched_emergency_services": false,
+        "needs_human_review": false,
+        "needs_clarification": true,
+        "confidence_category": 0.9,
+        "confidence_subcategory": 0.9,
+        "validator_reasons": [
+          "auto_resolve:no_flags_fired"
+        ],
+        "risk_reasons": [
+          "base_risk:LOW"
+        ],
+        "retrieved_record_ids": [
+          "TKT-2023-00701",
+          "TKT-2022-01171",
+          "TKT-2023-09686",
+          "TKT-2023-05675",
+          "TKT-2022-02446",
+          "TKT-2024-03603",
+          "TKT-2023-07139",
+          "TKT-2023-09089"
+        ]
+      }
+    },
+    "transcript_id": "EVAL-0274"
+  },
+  {
+    "category": "DOORS_ACCESS",
+    "subcategory": "door_mechanical",
+    "risk_level": "LOW",
+    "needs_human_review": false,
+    "needs_clarification": false,
+    "building_name": "Bayshore Commons",
+    "address": "1900 Bayshore Blvd",
+    "floor": "Floor 2",
+    "dispatched_vendor_id": "v_010",
+    "dispatched_emergency_services": false,
+    "call_summary": "Mechanical door issue reported at Bayshore Commons, Floor 2. LOW risk. Dispatched All-Site Facilities Co.",
+    "trainer_log": {
+      "full_transcript": "[AGENT] CBRE facilities \u2014 how can I help?\n[CALLER] Hey, The main door won't latch properly.\n[AGENT] Understood. Can the door be secured?\n[CALLER] It's an interior door to the suite.\n[AGENT] Where exactly \u2014 which suite?\n[CALLER] Bayshore Commons, Floor 2, Suite 307.\n[AGENT] Got it. I'll get someone out as soon as I can \u2014 should hear back within the hour.\n[CALLER] Alright, appreciate it.",
+      "ai_prediction": {
+        "category": "DOORS_ACCESS",
+        "subcategory": "door_mechanical",
+        "risk_level": "LOW",
+        "dispatched_vendor_id": "v_010",
+        "dispatched_emergency_services": false,
+        "needs_human_review": false,
+        "needs_clarification": false,
+        "confidence_category": 0.95,
+        "confidence_subcategory": 0.95,
+        "validator_reasons": [
+          "auto_resolve:no_flags_fired"
+        ],
+        "risk_reasons": [
+          "base_risk:LOW"
+        ],
+        "retrieved_record_ids": [
+          "TKT-2023-00809",
+          "TKT-2022-05746",
+          "TKT-2023-08576",
+          "TKT-2024-00876",
+          "TKT-2024-08961",
+          "TKT-2023-08816",
+          "TKT-2024-05319",
+          "TKT-2023-07550"
+        ]
+      },
+      "human_override": null,
+      "final_decision": {
+        "category": "DOORS_ACCESS",
+        "subcategory": "door_mechanical",
+        "risk_level": "LOW",
+        "dispatched_vendor_id": "v_010",
+        "dispatched_emergency_services": false,
+        "needs_human_review": false,
+        "needs_clarification": false,
+        "confidence_category": 0.95,
+        "confidence_subcategory": 0.95,
+        "validator_reasons": [
+          "auto_resolve:no_flags_fired"
+        ],
+        "risk_reasons": [
+          "base_risk:LOW"
+        ],
+        "retrieved_record_ids": [
+          "TKT-2023-00809",
+          "TKT-2022-05746",
+          "TKT-2023-08576",
+          "TKT-2024-00876",
+          "TKT-2024-08961",
+          "TKT-2023-08816",
+          "TKT-2024-05319",
+          "TKT-2023-07550"
+        ]
+      }
+    },
+    "transcript_id": "EVAL-0275"
+  },
+  {
+    "category": "GROUNDS_EXTERIOR",
+    "subcategory": "signage_fencing",
+    "risk_level": "LOW",
+    "needs_human_review": false,
+    "needs_clarification": false,
+    "building_name": "Brookfield Retail Center",
+    "address": "2200 Brookfield Rd",
+    "floor": "Floor 2",
+    "dispatched_vendor_id": "v_029",
+    "dispatched_emergency_services": false,
+    "call_summary": "Signage/fencing issue reported at Brookfield Retail Center, Floor 2. LOW risk. Dispatched Golden State Exterior Maintenance.",
+    "trainer_log": {
+      "full_transcript": "[AGENT] CBRE maintenance line, what do you need?\n[CALLER] Uh, hello, Property sign on Floor 2 in Suite 208 is laying on the ground, letters broken off.\n[AGENT] Mhm. Is it blocking access?\n[CALLER] Not blocking anything but it looks bad.\n[AGENT] Okay, ticket's logged. Someone'll come out during business hours.\n[CALLER] Okay, sorry, thanks.",
+      "ai_prediction": {
+        "category": "GROUNDS_EXTERIOR",
+        "subcategory": "signage_fencing",
+        "risk_level": "LOW",
+        "dispatched_vendor_id": "v_029",
+        "dispatched_emergency_services": false,
+        "needs_human_review": false,
+        "needs_clarification": false,
+        "confidence_category": 0.95,
+        "confidence_subcategory": 0.95,
+        "validator_reasons": [
+          "auto_resolve:no_flags_fired"
+        ],
+        "risk_reasons": [
+          "base_risk:LOW"
+        ],
+        "retrieved_record_ids": [
+          "TKT-2024-02691",
+          "TKT-2023-08963",
+          "TKT-2022-06922",
+          "TKT-2024-03660",
+          "TKT-2024-06747",
+          "TKT-2023-03908",
+          "TKT-2023-09098",
+          "TKT-2022-04564"
+        ]
+      },
+      "human_override": null,
+      "final_decision": {
+        "category": "GROUNDS_EXTERIOR",
+        "subcategory": "signage_fencing",
+        "risk_level": "LOW",
+        "dispatched_vendor_id": "v_029",
+        "dispatched_emergency_services": false,
+        "needs_human_review": false,
+        "needs_clarification": false,
+        "confidence_category": 0.95,
+        "confidence_subcategory": 0.95,
+        "validator_reasons": [
+          "auto_resolve:no_flags_fired"
+        ],
+        "risk_reasons": [
+          "base_risk:LOW"
+        ],
+        "retrieved_record_ids": [
+          "TKT-2024-02691",
+          "TKT-2023-08963",
+          "TKT-2022-06922",
+          "TKT-2024-03660",
+          "TKT-2024-06747",
+          "TKT-2023-03908",
+          "TKT-2023-09098",
+          "TKT-2022-04564"
+        ]
+      }
+    },
+    "transcript_id": "EVAL-0276"
+  },
+  {
+    "category": "LIFE_SAFETY",
+    "subcategory": "gas_chemical",
+    "risk_level": "EMERGENCY",
+    "needs_human_review": true,
+    "needs_clarification": false,
+    "building_name": "Shoreline Tech Campus",
+    "address": "2500 Shoreline Blvd",
+    "floor": "Floor 4",
+    "dispatched_vendor_id": null,
+    "dispatched_emergency_services": true,
+    "call_summary": "Gas or chemical hazard reported at Shoreline Tech Campus, Floor 4. EMERGENCY risk. Emergency services dispatched.",
+    "trainer_log": {
+      "full_transcript": "[AGENT] Hi, CBRE facilities. What can I do for you?\n[CALLER] Hey, Something smells like rotten eggs, people are feeling sick.\n[AGENT] Mhm. Can you describe the smell?\n[CALLER] Smells like rotten eggs \u2014 pretty strong.\n[AGENT] Which building and floor are you at?\n[CALLER] Shoreline Tech Campus, like, Floor 4, Suite 405.\n[AGENT] Dialing 911 now. Please leave the area if it's safe.",
+      "ai_prediction": {
+        "category": "LIFE_SAFETY",
+        "subcategory": "gas_chemical",
+        "risk_level": "EMERGENCY",
+        "dispatched_vendor_id": null,
+        "dispatched_emergency_services": true,
+        "needs_human_review": true,
+        "needs_clarification": false,
+        "confidence_category": 0.95,
+        "confidence_subcategory": 0.95,
+        "validator_reasons": [
+          "emergency_band:always_pause",
+          "emergency_dispatch:gas_chemical:hazard_cue_confirmed"
+        ],
+        "risk_reasons": [
+          "base_risk:EMERGENCY",
+          "hard_cue:gas leak",
+          "capped_at_EMERGENCY:historical_max for subcategory=gas_chemical"
+        ],
+        "retrieved_record_ids": [
+          "TKT-2024-04020",
+          "TKT-2022-05917",
+          "TKT-2024-00930",
+          "TKT-2022-02596",
+          "TKT-2024-03792",
+          "TKT-2022-01117",
+          "TKT-2022-02779",
+          "TKT-2023-03950"
+        ]
+      },
+      "human_override": null,
+      "final_decision": {
+        "category": "LIFE_SAFETY",
+        "subcategory": "gas_chemical",
+        "risk_level": "EMERGENCY",
+        "dispatched_vendor_id": null,
+        "dispatched_emergency_services": true,
+        "needs_human_review": true,
+        "needs_clarification": false,
+        "confidence_category": 0.95,
+        "confidence_subcategory": 0.95,
+        "validator_reasons": [
+          "emergency_band:always_pause",
+          "emergency_dispatch:gas_chemical:hazard_cue_confirmed"
+        ],
+        "risk_reasons": [
+          "base_risk:EMERGENCY",
+          "hard_cue:gas leak",
+          "capped_at_EMERGENCY:historical_max for subcategory=gas_chemical"
+        ],
+        "retrieved_record_ids": [
+          "TKT-2024-04020",
+          "TKT-2022-05917",
+          "TKT-2024-00930",
+          "TKT-2022-02596",
+          "TKT-2024-03792",
+          "TKT-2022-01117",
+          "TKT-2022-02779",
+          "TKT-2023-03950"
+        ]
+      }
+    },
+    "transcript_id": "EVAL-0280"
+  },
+  {
+    "category": "LIFE_SAFETY",
+    "subcategory": "fire_smoke",
+    "risk_level": "EMERGENCY",
+    "needs_human_review": true,
+    "needs_clarification": false,
+    "building_name": null,
+    "address": null,
+    "floor": "Floor 3",
+    "dispatched_vendor_id": null,
+    "dispatched_emergency_services": true,
+    "call_summary": "Fire/smoke detected reported at Floor 3. EMERGENCY risk. Emergency services dispatched.",
+    "trainer_log": {
+      "full_transcript": "[AGENT] Maintenance, what's the situation?\n[CALLER] Good afternoon, Flames coming from the kitchen on Floor 3 in Suite 308, we evacuated the floor.\n[AGENT] Okay. Can you describe what you're seeing \u2014 flames or just smoke?\n[CALLER] Yes, like, people are out.\n[AGENT] Have you pulled the fire alarm?\n[CALLER] Yes I pulled the alarm, it's going off.\n[AGENT] 911 is going out now and I'm alerting building ops \u2014 stay with me on the line if you can.\n[CALLER] Got it, thanks.",
+      "ai_prediction": {
+        "category": "LIFE_SAFETY",
+        "subcategory": "fire_smoke",
+        "risk_level": "EMERGENCY",
+        "dispatched_vendor_id": null,
+        "dispatched_emergency_services": true,
+        "needs_human_review": true,
+        "needs_clarification": false,
+        "confidence_category": 0.95,
+        "confidence_subcategory": 0.95,
+        "validator_reasons": [
+          "emergency_band:always_pause",
+          "emergency_dispatch:fire_smoke:hazard_cue_confirmed"
+        ],
+        "risk_reasons": [
+          "base_risk:EMERGENCY",
+          "hard_cue:flames",
+          "hard_cue:fire",
+          "capped_at_EMERGENCY:historical_max for subcategory=fire_smoke"
+        ],
+        "retrieved_record_ids": [
+          "TKT-2023-03740",
+          "TKT-2024-09834",
+          "TKT-2023-08369",
+          "TKT-2023-02687",
+          "TKT-2024-06567",
+          "TKT-2023-02507",
+          "TKT-2023-02495",
+          "TKT-2023-02720"
+        ]
+      },
+      "human_override": null,
+      "final_decision": {
+        "category": "LIFE_SAFETY",
+        "subcategory": "fire_smoke",
+        "risk_level": "EMERGENCY",
+        "dispatched_vendor_id": null,
+        "dispatched_emergency_services": true,
+        "needs_human_review": true,
+        "needs_clarification": false,
+        "confidence_category": 0.95,
+        "confidence_subcategory": 0.95,
+        "validator_reasons": [
+          "emergency_band:always_pause",
+          "emergency_dispatch:fire_smoke:hazard_cue_confirmed"
+        ],
+        "risk_reasons": [
+          "base_risk:EMERGENCY",
+          "hard_cue:flames",
+          "hard_cue:fire",
+          "capped_at_EMERGENCY:historical_max for subcategory=fire_smoke"
+        ],
+        "retrieved_record_ids": [
+          "TKT-2023-03740",
+          "TKT-2024-09834",
+          "TKT-2023-08369",
+          "TKT-2023-02687",
+          "TKT-2024-06567",
+          "TKT-2023-02507",
+          "TKT-2023-02495",
+          "TKT-2023-02720"
+        ]
+      }
+    },
+    "transcript_id": "EVAL-0283"
+  },
+  {
+    "category": "HVAC",
+    "subcategory": "controls_bms",
+    "risk_level": "LOW",
+    "needs_human_review": false,
+    "needs_clarification": false,
+    "building_name": "Northgate Logistics Hub",
+    "address": "7500 Northgate Way",
+    "floor": "Ground Floor",
+    "dispatched_vendor_id": "v_013",
+    "dispatched_emergency_services": false,
+    "call_summary": "Building controls issue reported at Northgate Logistics Hub, Ground Floor. LOW risk. Dispatched CoolZone HVAC.",
+    "trainer_log": {
+      "full_transcript": "[AGENT] CBRE facilities, Marcus speaking. How can I help?\n[CALLER] Hi, BMS is showing alarms for our zone at Northgate Logistics Hub on Ground Floor.\n[AGENT] Okay, I see. Is the thermostat display blank or showing something?\n[CALLER] Display is completely dark.\n[AGENT] Okay, ticket's logged. Someone'll come out during business hours.\n[CALLER] Okay.",
+      "ai_prediction": {
+        "category": "HVAC",
+        "subcategory": "controls_bms",
+        "risk_level": "LOW",
+        "dispatched_vendor_id": "v_013",
+        "dispatched_emergency_services": false,
+        "needs_human_review": false,
+        "needs_clarification": false,
+        "confidence_category": 0.9,
+        "confidence_subcategory": 0.9,
+        "validator_reasons": [
+          "auto_resolve:no_flags_fired"
+        ],
+        "risk_reasons": [
+          "base_risk:LOW"
+        ],
+        "retrieved_record_ids": [
+          "TKT-2024-06054",
+          "TKT-2023-04166",
+          "TKT-2022-09187",
+          "TKT-2022-04261",
+          "TKT-2024-07119",
+          "TKT-2022-01981",
+          "TKT-2024-00036",
+          "TKT-2023-07784"
+        ]
+      },
+      "human_override": null,
+      "final_decision": {
+        "category": "HVAC",
+        "subcategory": "controls_bms",
+        "risk_level": "LOW",
+        "dispatched_vendor_id": "v_013",
+        "dispatched_emergency_services": false,
+        "needs_human_review": false,
+        "needs_clarification": false,
+        "confidence_category": 0.9,
+        "confidence_subcategory": 0.9,
+        "validator_reasons": [
+          "auto_resolve:no_flags_fired"
+        ],
+        "risk_reasons": [
+          "base_risk:LOW"
+        ],
+        "retrieved_record_ids": [
+          "TKT-2024-06054",
+          "TKT-2023-04166",
+          "TKT-2022-09187",
+          "TKT-2022-04261",
+          "TKT-2024-07119",
+          "TKT-2022-01981",
+          "TKT-2024-00036",
+          "TKT-2023-07784"
+        ]
+      }
+    },
+    "transcript_id": "EVAL-0285"
+  },
+  {
+    "category": "ELEVATOR",
+    "subcategory": "entrapment",
+    "risk_level": "EMERGENCY",
+    "needs_human_review": true,
+    "needs_clarification": false,
+    "building_name": "Ventura Harbor Center",
+    "address": "1550 Spinnaker Dr",
+    "floor": "Floor 1",
+    "dispatched_vendor_id": "v_016",
+    "dispatched_emergency_services": true,
+    "call_summary": "Person trapped reported at Ventura Harbor Center, Floor 1. EMERGENCY risk. Emergency services dispatched.",
+    "trainer_log": {
+      "full_transcript": "[AGENT] CBRE dispatch, talk to me.\n[CALLER] The elevator's acting weird with someone in it.\n[AGENT] Okay, can you describe what you're seeing or smelling?\n[CALLER] [dog barking faintly] They're responding \u2014 just scared.\n[AGENT] Are they between floors?\n[CALLER] They're responding \u2014 just scared.\n[AGENT] Which building and floor are you at?\n[CALLER] Ventura Harbor Center, Floor 1, Suite 107.\n[AGENT] 911 is going out now and I'm alerting building ops \u2014 stay with me on the line if you can.",
+      "ai_prediction": {
+        "category": "ELEVATOR",
+        "subcategory": "entrapment",
+        "risk_level": "EMERGENCY",
+        "dispatched_vendor_id": "v_016",
+        "dispatched_emergency_services": true,
+        "needs_human_review": true,
+        "needs_clarification": false,
+        "confidence_category": 0.95,
+        "confidence_subcategory": 0.95,
+        "validator_reasons": [
+          "emergency_band:always_pause",
+          "emergency_dispatch:entrapment:hazard_cue_confirmed"
+        ],
+        "risk_reasons": [
+          "base_risk:EMERGENCY",
+          "hard_cue:trapped",
+          "capped_at_EMERGENCY:historical_max for subcategory=entrapment"
+        ],
+        "retrieved_record_ids": [
+          "TKT-2023-05009",
+          "TKT-2023-09029",
+          "TKT-2022-05575",
+          "TKT-2023-09077",
+          "TKT-2022-07741",
+          "TKT-2022-02071",
+          "TKT-2024-06030",
+          "TKT-2022-09388"
+        ]
+      },
+      "human_override": null,
+      "final_decision": {
+        "category": "ELEVATOR",
+        "subcategory": "entrapment",
+        "risk_level": "EMERGENCY",
+        "dispatched_vendor_id": "v_016",
+        "dispatched_emergency_services": true,
+        "needs_human_review": true,
+        "needs_clarification": false,
+        "confidence_category": 0.95,
+        "confidence_subcategory": 0.95,
+        "validator_reasons": [
+          "emergency_band:always_pause",
+          "emergency_dispatch:entrapment:hazard_cue_confirmed"
+        ],
+        "risk_reasons": [
+          "base_risk:EMERGENCY",
+          "hard_cue:trapped",
+          "capped_at_EMERGENCY:historical_max for subcategory=entrapment"
+        ],
+        "retrieved_record_ids": [
+          "TKT-2023-05009",
+          "TKT-2023-09029",
+          "TKT-2022-05575",
+          "TKT-2023-09077",
+          "TKT-2022-07741",
+          "TKT-2022-02071",
+          "TKT-2024-06030",
+          "TKT-2022-09388"
+        ]
+      }
+    },
+    "transcript_id": "EVAL-0295"
+  },
+  {
+    "category": "HVAC",
+    "subcategory": "controls_bms",
+    "risk_level": "LOW",
+    "needs_human_review": false,
+    "needs_clarification": false,
+    "building_name": "Pinnacle Financial Center",
+    "address": "600 Financial Dr",
+    "floor": "Floor 19",
+    "dispatched_vendor_id": "v_014",
+    "dispatched_emergency_services": false,
+    "call_summary": "Building controls issue reported at Pinnacle Financial Center, Floor 19. LOW risk. Dispatched MediCool HVAC Systems.",
+    "trainer_log": {
+      "full_transcript": "[AGENT] CBRE dispatch \u2014 go ahead.\n[CALLER] Good afternoon, BMS is showing alarms for our zone at Pinnacle Financial Center on Floor 19 in Suite 1904.\n[AGENT] Understood. Is the thermostat display blank or showing something?\n[CALLER] Display is completely dark.\n[AGENT] Got it. I'll get someone out as soon as I can \u2014 should hear back within the hour.\n[CALLER] Thanks, bye.",
+      "ai_prediction": {
+        "category": "HVAC",
+        "subcategory": "controls_bms",
+        "risk_level": "LOW",
+        "dispatched_vendor_id": "v_014",
+        "dispatched_emergency_services": false,
+        "needs_human_review": false,
+        "needs_clarification": false,
+        "confidence_category": 0.9,
+        "confidence_subcategory": 0.9,
+        "validator_reasons": [
+          "auto_resolve:no_flags_fired"
+        ],
+        "risk_reasons": [
+          "base_risk:LOW"
+        ],
+        "retrieved_record_ids": [
+          "TKT-2024-06663",
+          "TKT-2024-06054",
+          "TKT-2022-09187",
+          "TKT-2023-04166",
+          "TKT-2023-08498",
+          "TKT-2022-04261",
+          "TKT-2023-06608",
+          "TKT-2024-04326"
+        ]
+      },
+      "human_override": null,
+      "final_decision": {
+        "category": "HVAC",
+        "subcategory": "controls_bms",
+        "risk_level": "LOW",
+        "dispatched_vendor_id": "v_014",
+        "dispatched_emergency_services": false,
+        "needs_human_review": false,
+        "needs_clarification": false,
+        "confidence_category": 0.9,
+        "confidence_subcategory": 0.9,
+        "validator_reasons": [
+          "auto_resolve:no_flags_fired"
+        ],
+        "risk_reasons": [
+          "base_risk:LOW"
+        ],
+        "retrieved_record_ids": [
+          "TKT-2024-06663",
+          "TKT-2024-06054",
+          "TKT-2022-09187",
+          "TKT-2023-04166",
+          "TKT-2023-08498",
+          "TKT-2022-04261",
+          "TKT-2023-06608",
+          "TKT-2024-04326"
+        ]
+      }
+    },
+    "transcript_id": "EVAL-0300"
+  },
+  {
+    "category": "HVAC",
+    "subcategory": "controls_bms",
+    "risk_level": "LOW",
+    "needs_human_review": false,
+    "needs_clarification": false,
+    "building_name": "Metro Center Offices",
+    "address": "650 Metro Center Way",
+    "floor": "Floor 12",
+    "dispatched_vendor_id": "v_012",
+    "dispatched_emergency_services": false,
+    "call_summary": "Building controls issue reported at Metro Center Offices, Floor 12. LOW risk. Dispatched Pacific HVAC Services.",
+    "trainer_log": {
+      "full_transcript": "[AGENT] CBRE dispatch, talk to me.\n[CALLER] Hello, Can't change the temp, thermostat screen is frozen.\n[AGENT] Okay. What does the BMS alarm say?\n[CALLER] Says 'zone 4 comm loss' or something.\n[AGENT] Where exactly \u2014 which suite?\n[CALLER] Metro Center Offices, Floor 12, Suite 1203.\n[AGENT] Tech is on the way. You'll get a text once they're rolling.\n[AGENT] Nobody in our vendor list matches everything you need. Let me kick this over to the on-call PM.\n[CALLER] Okay, please hurry.",
+      "ai_prediction": {
+        "category": "HVAC",
+        "subcategory": "controls_bms",
+        "risk_level": "LOW",
+        "dispatched_vendor_id": "v_012",
+        "dispatched_emergency_services": false,
+        "needs_human_review": false,
+        "needs_clarification": false,
+        "confidence_category": 0.95,
+        "confidence_subcategory": 0.95,
+        "validator_reasons": [
+          "auto_resolve:no_flags_fired"
+        ],
+        "risk_reasons": [
+          "base_risk:LOW"
+        ],
+        "retrieved_record_ids": [
+          "TKT-2024-05049",
+          "TKT-2024-04464",
+          "TKT-2024-02217",
+          "TKT-2022-09271",
+          "TKT-2024-06840",
+          "TKT-2023-01295",
+          "TKT-2024-01026",
+          "TKT-2023-08753"
+        ]
+      },
+      "human_override": null,
+      "final_decision": {
+        "category": "HVAC",
+        "subcategory": "controls_bms",
+        "risk_level": "LOW",
+        "dispatched_vendor_id": "v_012",
+        "dispatched_emergency_services": false,
+        "needs_human_review": false,
+        "needs_clarification": false,
+        "confidence_category": 0.95,
+        "confidence_subcategory": 0.95,
+        "validator_reasons": [
+          "auto_resolve:no_flags_fired"
+        ],
+        "risk_reasons": [
+          "base_risk:LOW"
+        ],
+        "retrieved_record_ids": [
+          "TKT-2024-05049",
+          "TKT-2024-04464",
+          "TKT-2024-02217",
+          "TKT-2022-09271",
+          "TKT-2024-06840",
+          "TKT-2023-01295",
+          "TKT-2024-01026",
+          "TKT-2023-08753"
+        ]
+      }
+    },
+    "transcript_id": "EVAL-0301"
+  },
+  {
+    "category": "PLUMBING",
+    "subcategory": "drainage_backup",
+    "risk_level": "LOW",
+    "needs_human_review": false,
+    "needs_clarification": false,
+    "building_name": "La Jolla Professional Suites",
+    "address": "9400 La Jolla Village Dr",
+    "floor": "Floor 7",
+    "dispatched_vendor_id": "v_004",
+    "dispatched_emergency_services": false,
+    "call_summary": "Drainage backup reported at La Jolla Professional Suites, Floor 7. LOW risk. Dispatched Regency Commercial Plumbing.",
+    "trainer_log": {
+      "full_transcript": "[AGENT] CBRE maintenance line, this is Priya \u2014 what do you need?\n[CALLER] Good afternoon, Floor drain in the janitor closet at La Jolla Professional Suites on Floor 7 is backing up with gray water.\n[AGENT] Alright. Is there a strong sewer smell?\n[CALLER] Yeah, I mean, there's definitely a smell.\n[AGENT] Okay, I'll line that up now. Confirmation text will come through shortly.\n[CALLER] Okay, please hurry.",
+      "ai_prediction": {
+        "category": "PLUMBING",
+        "subcategory": "drainage_backup",
+        "risk_level": "LOW",
+        "dispatched_vendor_id": "v_004",
+        "dispatched_emergency_services": false,
+        "needs_human_review": false,
+        "needs_clarification": false,
+        "confidence_category": 0.95,
+        "confidence_subcategory": 0.95,
+        "validator_reasons": [
+          "auto_resolve:no_flags_fired"
+        ],
+        "risk_reasons": [
+          "base_risk:LOW"
+        ],
+        "retrieved_record_ids": [
+          "TKT-2022-06937",
+          "TKT-2024-07881",
+          "TKT-2022-00895",
+          "TKT-2023-05489",
+          "TKT-2024-06177",
+          "TKT-2022-07528",
+          "TKT-2022-04690",
+          "TKT-2023-05426"
+        ]
+      },
+      "human_override": null,
+      "final_decision": {
+        "category": "PLUMBING",
+        "subcategory": "drainage_backup",
+        "risk_level": "LOW",
+        "dispatched_vendor_id": "v_004",
+        "dispatched_emergency_services": false,
+        "needs_human_review": false,
+        "needs_clarification": false,
+        "confidence_category": 0.95,
+        "confidence_subcategory": 0.95,
+        "validator_reasons": [
+          "auto_resolve:no_flags_fired"
+        ],
+        "risk_reasons": [
+          "base_risk:LOW"
+        ],
+        "retrieved_record_ids": [
+          "TKT-2022-06937",
+          "TKT-2024-07881",
+          "TKT-2022-00895",
+          "TKT-2023-05489",
+          "TKT-2024-06177",
+          "TKT-2022-07528",
+          "TKT-2022-04690",
+          "TKT-2023-05426"
+        ]
+      }
+    },
+    "transcript_id": "EVAL-0309"
+  },
+  {
+    "category": "LIFE_SAFETY",
+    "subcategory": "slip_trip",
+    "risk_level": "LOW",
+    "needs_human_review": false,
+    "needs_clarification": false,
+    "building_name": "Airport Business Center",
+    "address": "9200 Airport Blvd",
+    "floor": "Floor 7",
+    "dispatched_vendor_id": "v_023",
+    "dispatched_emergency_services": false,
+    "call_summary": "Slip/trip hazard reported at Airport Business Center, Floor 7. LOW risk. Dispatched Sparkle Commercial Cleaning.",
+    "trainer_log": {
+      "full_transcript": "[AGENT] CBRE maintenance line, this is Priya \u2014 what do you need?\n[CALLER] Sorry, hello, There's a puddle at Airport Business Center on Floor 7 in Suite 709 in the main walkway, pretty big.\n[AGENT] Got it. Has anyone fallen?\n[CALLER] No one's fallen yet.\n[AGENT] Nobody in our vendor list matches everything you need. Let me kick this over to the on-call PM.\n[CALLER] Okay, please hurry.",
+      "ai_prediction": {
+        "category": "LIFE_SAFETY",
+        "subcategory": "slip_trip",
+        "risk_level": "LOW",
+        "dispatched_vendor_id": "v_023",
+        "dispatched_emergency_services": false,
+        "needs_human_review": false,
+        "needs_clarification": false,
+        "confidence_category": 0.95,
+        "confidence_subcategory": 0.95,
+        "validator_reasons": [
+          "auto_resolve:no_flags_fired"
+        ],
+        "risk_reasons": [
+          "base_risk:LOW"
+        ],
+        "retrieved_record_ids": [
+          "TKT-2022-04876",
+          "TKT-2022-05287",
+          "TKT-2022-07813",
+          "TKT-2023-08288",
+          "TKT-2024-04125",
+          "TKT-2022-02047",
+          "TKT-2022-00943",
+          "TKT-2023-09716"
+        ]
+      },
+      "human_override": null,
+      "final_decision": {
+        "category": "LIFE_SAFETY",
+        "subcategory": "slip_trip",
+        "risk_level": "LOW",
+        "dispatched_vendor_id": "v_023",
+        "dispatched_emergency_services": false,
+        "needs_human_review": false,
+        "needs_clarification": false,
+        "confidence_category": 0.95,
+        "confidence_subcategory": 0.95,
+        "validator_reasons": [
+          "auto_resolve:no_flags_fired"
+        ],
+        "risk_reasons": [
+          "base_risk:LOW"
+        ],
+        "retrieved_record_ids": [
+          "TKT-2022-04876",
+          "TKT-2022-05287",
+          "TKT-2022-07813",
+          "TKT-2023-08288",
+          "TKT-2024-04125",
+          "TKT-2022-02047",
+          "TKT-2022-00943",
+          "TKT-2023-09716"
+        ]
+      }
+    },
+    "transcript_id": "EVAL-0313"
+  },
+  {
+    "category": "SECURITY",
+    "subcategory": "unauthorized_access",
+    "risk_level": "HIGH",
+    "needs_human_review": true,
+    "needs_clarification": false,
+    "building_name": "Central Tower",
+    "address": "700 S Grand Ave",
+    "floor": "Rooftop",
+    "dispatched_vendor_id": "v_027",
+    "dispatched_emergency_services": false,
+    "call_summary": "Unauthorized access reported at Central Tower, Rooftop. HIGH risk. Flagged for review. Elite Protective Services dispatched pending approval.",
+    "trainer_log": {
+      "full_transcript": "[AGENT] CBRE maintenance line, what do you need?\n[CALLER] Like, good morning, Breach alarm is going off - looks like someone entered without a badge.\n[AGENT] Alright. Do you have a description?\n[CALLER] Wearing a tan uniform, I mean, looks like a delivery person but no tag.\n[AGENT] Can you tell me the building, floor, and suite?\n[CALLER] I mean, central Tower, Rooftop.\n[AGENT] Are they still on-site?\n[CALLER] I mean, he's still in the back corridor.\n[AGENT] I want a second pair of eyes on this. I'll bring the PM in and send a tech out.\n[CALLER] Thank you.",
+      "ai_prediction": {
+        "category": "SECURITY",
+        "subcategory": "unauthorized_access",
+        "risk_level": "HIGH",
+        "dispatched_vendor_id": "v_027",
+        "dispatched_emergency_services": false,
+        "needs_human_review": true,
+        "needs_clarification": false,
+        "confidence_category": 0.95,
+        "confidence_subcategory": 0.95,
+        "validator_reasons": [
+          "high_band:always_pause"
+        ],
+        "risk_reasons": [
+          "base_risk:HIGH"
+        ],
+        "retrieved_record_ids": [
+          "TKT-2022-02590",
+          "TKT-2022-01288",
+          "TKT-2023-08723",
+          "TKT-2023-07427",
+          "TKT-2024-09882",
+          "TKT-2022-07258",
+          "TKT-2022-02461",
+          "TKT-2024-06651"
+        ]
+      },
+      "human_override": null,
+      "final_decision": {
+        "category": "SECURITY",
+        "subcategory": "unauthorized_access",
+        "risk_level": "HIGH",
+        "dispatched_vendor_id": "v_027",
+        "dispatched_emergency_services": false,
+        "needs_human_review": true,
+        "needs_clarification": false,
+        "confidence_category": 0.95,
+        "confidence_subcategory": 0.95,
+        "validator_reasons": [
+          "high_band:always_pause"
+        ],
+        "risk_reasons": [
+          "base_risk:HIGH"
+        ],
+        "retrieved_record_ids": [
+          "TKT-2022-02590",
+          "TKT-2022-01288",
+          "TKT-2023-08723",
+          "TKT-2023-07427",
+          "TKT-2024-09882",
+          "TKT-2022-07258",
+          "TKT-2022-02461",
+          "TKT-2024-06651"
+        ]
+      }
+    },
+    "transcript_id": "EVAL-0316"
+  },
+  {
+    "category": "PLUMBING",
+    "subcategory": "roof_leak",
+    "risk_level": "MEDIUM",
+    "needs_human_review": true,
+    "needs_clarification": false,
+    "building_name": "Pacific Ridge Medical Plaza",
+    "address": "3200 Pacific Coast Hwy",
+    "floor": "Floor 4",
+    "dispatched_vendor_id": "v_005",
+    "dispatched_emergency_services": false,
+    "call_summary": "Roof leak reported at Pacific Ridge Medical Plaza, Floor 4. MEDIUM risk. Flagged for review. Bayside Roofing Co dispatched pending approval.",
+    "trainer_log": {
+      "full_transcript": "[AGENT] CBRE dispatch, talk to me.\n[CALLER] A piece of the ceiling fell \u2014 it's just one drop-ceiling tile, water-damaged, nothing structural, nobody hurt.\n[AGENT] Okay \u2014 can you confirm there's no actual fire or injury right now?\n[CALLER] It was one tile from a water leak \u2014 nobody hurt, just a mess.\n[AGENT] Where exactly \u2014 which suite?\n[CALLER] Pacific Ridge Medical Plaza, um, Floor 4, Suite 410.\n[AGENT] Tech is on the way. You'll get a text once they're rolling.",
+      "ai_prediction": {
+        "category": "PLUMBING",
+        "subcategory": "roof_leak",
+        "risk_level": "MEDIUM",
+        "dispatched_vendor_id": "v_005",
+        "dispatched_emergency_services": false,
+        "needs_human_review": true,
+        "needs_clarification": false,
+        "confidence_category": 0.9,
+        "confidence_subcategory": 0.9,
+        "validator_reasons": [
+          "trap_cascade_subcategory:roof_leak(high-audit cell at HIGH/EMERGENCY \u2014 possible under-classification)"
+        ],
+        "risk_reasons": [
+          "base_risk:MEDIUM",
+          "sensitive_building:medical",
+          "capped_at_MEDIUM:historical_max for subcategory=roof_leak"
+        ],
+        "retrieved_record_ids": [
+          "TKT-2022-08896",
+          "TKT-2024-02022",
+          "TKT-2023-03854",
+          "TKT-2024-02634",
+          "TKT-2023-03725",
+          "TKT-2022-04243",
+          "TKT-2022-07093",
+          "TKT-2023-05153"
+        ]
+      },
+      "human_override": null,
+      "final_decision": {
+        "category": "PLUMBING",
+        "subcategory": "roof_leak",
+        "risk_level": "MEDIUM",
+        "dispatched_vendor_id": "v_005",
+        "dispatched_emergency_services": false,
+        "needs_human_review": true,
+        "needs_clarification": false,
+        "confidence_category": 0.9,
+        "confidence_subcategory": 0.9,
+        "validator_reasons": [
+          "trap_cascade_subcategory:roof_leak(high-audit cell at HIGH/EMERGENCY \u2014 possible under-classification)"
+        ],
+        "risk_reasons": [
+          "base_risk:MEDIUM",
+          "sensitive_building:medical",
+          "capped_at_MEDIUM:historical_max for subcategory=roof_leak"
+        ],
+        "retrieved_record_ids": [
+          "TKT-2022-08896",
+          "TKT-2024-02022",
+          "TKT-2023-03854",
+          "TKT-2024-02634",
+          "TKT-2023-03725",
+          "TKT-2022-04243",
+          "TKT-2022-07093",
+          "TKT-2023-05153"
+        ]
+      }
+    },
+    "transcript_id": "EVAL-0319"
+  },
+  {
+    "category": "JANITORIAL",
+    "subcategory": "waste_odor",
+    "risk_level": "LOW",
+    "needs_human_review": false,
+    "needs_clarification": false,
+    "building_name": null,
+    "address": null,
+    "floor": "Floor 14",
+    "dispatched_vendor_id": "v_023",
+    "dispatched_emergency_services": false,
+    "call_summary": "Waste/odor issue reported at Floor 14. LOW risk. Dispatched Sparkle Commercial Cleaning.",
+    "trainer_log": {
+      "full_transcript": "[AGENT] CBRE dispatch, talk to me.\n[CALLER] [door closing] Hi, Bad garbage smell in the hallway on Floor 14 in Suite 1402 outside the main trash.\n[AGENT] Mhm. How bad is the smell?\n[CALLER] Pretty bad \u2014 can't really ignore it.\n[AGENT] Okay, I'll line that up now. Confirmation text will come through shortly.\n[CALLER] Alright, appreciate it.",
+      "ai_prediction": {
+        "category": "JANITORIAL",
+        "subcategory": "waste_odor",
+        "risk_level": "LOW",
+        "dispatched_vendor_id": "v_023",
+        "dispatched_emergency_services": false,
+        "needs_human_review": false,
+        "needs_clarification": false,
+        "confidence_category": 0.95,
+        "confidence_subcategory": 0.95,
+        "validator_reasons": [
+          "auto_resolve:no_flags_fired"
+        ],
+        "risk_reasons": [
+          "base_risk:LOW"
+        ],
+        "retrieved_record_ids": [
+          "TKT-2023-09734",
+          "TKT-2024-09987",
+          "TKT-2022-08695",
+          "TKT-2022-04177",
+          "TKT-2023-02486",
+          "TKT-2022-07282",
+          "TKT-2023-05465",
+          "TKT-2024-08667"
+        ]
+      },
+      "human_override": null,
+      "final_decision": {
+        "category": "JANITORIAL",
+        "subcategory": "waste_odor",
+        "risk_level": "LOW",
+        "dispatched_vendor_id": "v_023",
+        "dispatched_emergency_services": false,
+        "needs_human_review": false,
+        "needs_clarification": false,
+        "confidence_category": 0.95,
+        "confidence_subcategory": 0.95,
+        "validator_reasons": [
+          "auto_resolve:no_flags_fired"
+        ],
+        "risk_reasons": [
+          "base_risk:LOW"
+        ],
+        "retrieved_record_ids": [
+          "TKT-2023-09734",
+          "TKT-2024-09987",
+          "TKT-2022-08695",
+          "TKT-2022-04177",
+          "TKT-2023-02486",
+          "TKT-2022-07282",
+          "TKT-2023-05465",
+          "TKT-2024-08667"
+        ]
+      }
+    },
+    "transcript_id": "EVAL-0324"
+  },
+  {
+    "category": "ELECTRICAL",
+    "subcategory": "power_outage",
+    "risk_level": "HIGH",
+    "needs_human_review": true,
+    "needs_clarification": true,
+    "building_name": "Rancho Del Sol Office Park",
+    "address": "600 Rancho del Sol Dr",
+    "floor": "Floor 1",
+    "dispatched_vendor_id": "v_008",
+    "dispatched_emergency_services": false,
+    "call_summary": "Power outage reported at Rancho Del Sol Office Park, Floor 1. HIGH risk. Flagged for review. Rapid Response Electricians dispatched pending approval.",
+    "trainer_log": {
+      "full_transcript": "[AGENT] CBRE facilities, Marcus speaking. How can I help?\n[CALLER] Half the suite on Floor 6 has no power - breaker keeps tripping.\n[AGENT] I want to make sure I have the right location \u2014 Rancho Del Sol Office Park only has 3 floors. Can you confirm the floor?\n[CALLER] Hold on, oh sorry \u2014 I meant Floor 1. I'm a little flustered.\n[AGENT] Bumping this up to the on-call supervisor \u2014 vendor's going out as we speak.",
+      "ai_prediction": {
+        "category": "ELECTRICAL",
+        "subcategory": "power_outage",
+        "risk_level": "HIGH",
+        "dispatched_vendor_id": "v_008",
+        "dispatched_emergency_services": false,
+        "needs_human_review": true,
+        "needs_clarification": true,
+        "confidence_category": 0.95,
+        "confidence_subcategory": 0.95,
+        "validator_reasons": [
+          "high_band:always_pause"
+        ],
+        "risk_reasons": [
+          "base_risk:HIGH"
+        ],
+        "retrieved_record_ids": [
+          "TKT-2024-03357",
+          "TKT-2023-08147",
+          "TKT-2023-01232",
+          "TKT-2022-08248",
+          "TKT-2024-06999",
+          "TKT-2023-06818",
+          "TKT-2023-00458",
+          "TKT-2024-05736"
+        ]
+      },
+      "human_override": null,
+      "final_decision": {
+        "category": "ELECTRICAL",
+        "subcategory": "power_outage",
+        "risk_level": "HIGH",
+        "dispatched_vendor_id": "v_008",
+        "dispatched_emergency_services": false,
+        "needs_human_review": true,
+        "needs_clarification": true,
+        "confidence_category": 0.95,
+        "confidence_subcategory": 0.95,
+        "validator_reasons": [
+          "high_band:always_pause"
+        ],
+        "risk_reasons": [
+          "base_risk:HIGH"
+        ],
+        "retrieved_record_ids": [
+          "TKT-2024-03357",
+          "TKT-2023-08147",
+          "TKT-2023-01232",
+          "TKT-2022-08248",
+          "TKT-2024-06999",
+          "TKT-2023-06818",
+          "TKT-2023-00458",
+          "TKT-2024-05736"
+        ]
+      }
+    },
+    "transcript_id": "EVAL-0329"
+  },
+  {
+    "category": "SECURITY",
+    "subcategory": "active_threat",
+    "risk_level": "EMERGENCY",
+    "needs_human_review": true,
+    "needs_clarification": false,
+    "building_name": "Oakwood Corporate Campus - Building A",
+    "address": "400 Oakwood Pkwy",
+    "floor": "Floor 4",
+    "dispatched_vendor_id": "v_027",
+    "dispatched_emergency_services": false,
+    "call_summary": "Active threat reported at Oakwood Corporate Campus - Building A, Floor 4. EMERGENCY risk. Flagged for review. Elite Protective Services dispatched pending approval.",
+    "trainer_log": {
+      "full_transcript": "[AGENT] CBRE maintenance line, this is Priya \u2014 what do you need?\n[CALLER] I just saw someone with a knife in the lobby at Oakwood Corporate Campus - Building A on Floor 4. Please send police.\n[AGENT] Mhm. Is anyone hurt?\n[CALLER] No injuries here.\n[AGENT] Is anyone hurt?\n[CALLER] White male, maybe forties, dark jacket.\n[AGENT] Nobody in our vendor list matches everything you need. Let me kick this over to the on-call PM.\n[CALLER] Like, okay, please hurry.",
+      "ai_prediction": {
+        "category": "SECURITY",
+        "subcategory": "active_threat",
+        "risk_level": "EMERGENCY",
+        "dispatched_vendor_id": "v_027",
+        "dispatched_emergency_services": false,
+        "needs_human_review": true,
+        "needs_clarification": false,
+        "confidence_category": 0.95,
+        "confidence_subcategory": 0.95,
+        "validator_reasons": [
+          "emergency_band:always_pause",
+          "life_safety_no_autodispatch:no_hazard_cue"
+        ],
+        "risk_reasons": [
+          "base_risk:EMERGENCY"
+        ],
+        "retrieved_record_ids": [
+          "TKT-2022-08749",
+          "TKT-2022-05752",
+          "TKT-2023-03944",
+          "TKT-2024-06576",
+          "TKT-2022-01522",
+          "TKT-2024-03684",
+          "TKT-2024-00768",
+          "TKT-2023-00974"
+        ]
+      },
+      "human_override": null,
+      "final_decision": {
+        "category": "SECURITY",
+        "subcategory": "active_threat",
+        "risk_level": "EMERGENCY",
+        "dispatched_vendor_id": "v_027",
+        "dispatched_emergency_services": false,
+        "needs_human_review": true,
+        "needs_clarification": false,
+        "confidence_category": 0.95,
+        "confidence_subcategory": 0.95,
+        "validator_reasons": [
+          "emergency_band:always_pause",
+          "life_safety_no_autodispatch:no_hazard_cue"
+        ],
+        "risk_reasons": [
+          "base_risk:EMERGENCY"
+        ],
+        "retrieved_record_ids": [
+          "TKT-2022-08749",
+          "TKT-2022-05752",
+          "TKT-2023-03944",
+          "TKT-2024-06576",
+          "TKT-2022-01522",
+          "TKT-2024-03684",
+          "TKT-2024-00768",
+          "TKT-2023-00974"
+        ]
+      }
+    },
+    "transcript_id": "EVAL-0341"
+  },
+  {
+    "category": "DOORS_ACCESS",
+    "subcategory": "auto_door",
+    "risk_level": "LOW",
+    "needs_human_review": false,
+    "needs_clarification": false,
+    "building_name": "Civic Center Tower",
+    "address": "300 Civic Center Dr",
+    "floor": "Floor 14",
+    "dispatched_vendor_id": "v_020",
+    "dispatched_emergency_services": false,
+    "call_summary": "Automatic door malfunction reported at Civic Center Tower, Floor 14. LOW risk. Dispatched SecurePass Access Systems.",
+    "trainer_log": {
+      "full_transcript": "[AGENT] CBRE facilities, Marcus speaking. How can I help?\n[CALLER] Hi there, The automatic doors keep opening when no one's there.\n[AGENT] Alright. Is it stuck open or closed?\n[CALLER] Stuck half-open, like, won't go either way.\n[AGENT] Can you tell me the building, floor, and suite?\n[CALLER] Civic Center Tower, Floor 14, Suite 1408.\n[AGENT] Okay, ticket's logged. Someone'll come out during business hours.\n[CALLER] Got it, thanks.",
+      "ai_prediction": {
+        "category": "DOORS_ACCESS",
+        "subcategory": "auto_door",
+        "risk_level": "LOW",
+        "dispatched_vendor_id": "v_020",
+        "dispatched_emergency_services": false,
+        "needs_human_review": false,
+        "needs_clarification": false,
+        "confidence_category": 0.95,
+        "confidence_subcategory": 0.95,
+        "validator_reasons": [
+          "auto_resolve:no_flags_fired"
+        ],
+        "risk_reasons": [
+          "base_risk:LOW"
+        ],
+        "retrieved_record_ids": [
+          "TKT-2024-03315",
+          "TKT-2022-08659",
+          "TKT-2023-03683",
+          "TKT-2023-08684",
+          "TKT-2022-01765",
+          "TKT-2024-08076",
+          "TKT-2023-07724",
+          "TKT-2022-04471"
+        ]
+      },
+      "human_override": null,
+      "final_decision": {
+        "category": "DOORS_ACCESS",
+        "subcategory": "auto_door",
+        "risk_level": "LOW",
+        "dispatched_vendor_id": "v_020",
+        "dispatched_emergency_services": false,
+        "needs_human_review": false,
+        "needs_clarification": false,
+        "confidence_category": 0.95,
+        "confidence_subcategory": 0.95,
+        "validator_reasons": [
+          "auto_resolve:no_flags_fired"
+        ],
+        "risk_reasons": [
+          "base_risk:LOW"
+        ],
+        "retrieved_record_ids": [
+          "TKT-2024-03315",
+          "TKT-2022-08659",
+          "TKT-2023-03683",
+          "TKT-2023-08684",
+          "TKT-2022-01765",
+          "TKT-2024-08076",
+          "TKT-2023-07724",
+          "TKT-2022-04471"
+        ]
+      }
+    },
+    "transcript_id": "EVAL-0344"
+  },
+  {
+    "category": "LIFE_SAFETY",
+    "subcategory": "slip_trip",
+    "risk_level": "LOW",
+    "needs_human_review": false,
+    "needs_clarification": false,
+    "building_name": "Tower One at Tech Park",
+    "address": "3000 Innovation Way",
+    "floor": "Floor 4",
+    "dispatched_vendor_id": "v_024",
+    "dispatched_emergency_services": false,
+    "call_summary": "Slip/trip hazard reported at Tower One at Tech Park, Floor 4. LOW risk. Dispatched Bay Area Cleaning Solutions.",
+    "trainer_log": {
+      "full_transcript": "[AGENT] CBRE maintenance \u2014 what's going on?\n[CALLER] Good morning, hold on, Wet floor, no signs, someone already slipped.\n[AGENT] Understood. Is the area blocked off?\n[CALLER] Yeah, we set up a cone.\n[AGENT] Which building and floor are you at?\n[CALLER] [background: hvac hum] Tower One at Tech Park, Floor 4, Suite 404.\n[AGENT] Got it. I'll get someone out as soon as I can \u2014 should hear back within the hour.",
+      "ai_prediction": {
+        "category": "LIFE_SAFETY",
+        "subcategory": "slip_trip",
+        "risk_level": "LOW",
+        "dispatched_vendor_id": "v_024",
+        "dispatched_emergency_services": false,
+        "needs_human_review": false,
+        "needs_clarification": false,
+        "confidence_category": 0.95,
+        "confidence_subcategory": 0.95,
+        "validator_reasons": [
+          "auto_resolve:no_flags_fired"
+        ],
+        "risk_reasons": [
+          "base_risk:LOW"
+        ],
+        "retrieved_record_ids": [
+          "TKT-2023-04583",
+          "TKT-2023-09524",
+          "TKT-2024-07200",
+          "TKT-2024-08001",
+          "TKT-2022-02269",
+          "TKT-2024-04347",
+          "TKT-2023-05261",
+          "TKT-2022-04201"
+        ]
+      },
+      "human_override": null,
+      "final_decision": {
+        "category": "LIFE_SAFETY",
+        "subcategory": "slip_trip",
+        "risk_level": "LOW",
+        "dispatched_vendor_id": "v_024",
+        "dispatched_emergency_services": false,
+        "needs_human_review": false,
+        "needs_clarification": false,
+        "confidence_category": 0.95,
+        "confidence_subcategory": 0.95,
+        "validator_reasons": [
+          "auto_resolve:no_flags_fired"
+        ],
+        "risk_reasons": [
+          "base_risk:LOW"
+        ],
+        "retrieved_record_ids": [
+          "TKT-2023-04583",
+          "TKT-2023-09524",
+          "TKT-2024-07200",
+          "TKT-2024-08001",
+          "TKT-2022-02269",
+          "TKT-2024-04347",
+          "TKT-2023-05261",
+          "TKT-2022-04201"
+        ]
+      }
+    },
+    "transcript_id": "EVAL-0347"
+  },
+  {
+    "category": "SECURITY",
+    "subcategory": "suspicious_person",
+    "risk_level": "MEDIUM",
+    "needs_human_review": true,
+    "needs_clarification": true,
+    "building_name": "Palm Court Offices",
+    "address": "420 Palm Ave",
+    "floor": "Floor 2",
+    "dispatched_vendor_id": "v_027",
+    "dispatched_emergency_services": false,
+    "call_summary": "Suspicious person reported reported at Palm Court Offices, Floor 2. MEDIUM risk. Flagged for review. Elite Protective Services dispatched pending approval.",
+    "trainer_log": {
+      "full_transcript": "[AGENT] CBRE facilities, this is Sam. What's going on?\n[CALLER] Someone loitering outside.\n[AGENT] Are they being aggressive?\n[CALLER] Yeah, still there by the elevators.\n[AGENT] Where exactly \u2014 which suite?\n[CALLER] Palm Court Offices, Floor 2, Suite 201.\n[AGENT] Alright \u2014 sending a vendor over and giving the PM a heads-up.",
+      "ai_prediction": {
+        "category": "SECURITY",
+        "subcategory": "suspicious_person",
+        "risk_level": "MEDIUM",
+        "dispatched_vendor_id": "v_027",
+        "dispatched_emergency_services": false,
+        "needs_human_review": true,
+        "needs_clarification": true,
+        "confidence_category": 0.95,
+        "confidence_subcategory": 0.95,
+        "validator_reasons": [
+          "trap_cascade_subcategory:suspicious_person(high-audit cell at HIGH/EMERGENCY \u2014 possible under-classification)"
+        ],
+        "risk_reasons": [
+          "base_risk:MEDIUM"
+        ],
+        "retrieved_record_ids": [
+          "TKT-2024-02427",
+          "TKT-2024-09969",
+          "TKT-2023-01427",
+          "TKT-2024-06153",
+          "TKT-2022-09928",
+          "TKT-2024-04503",
+          "TKT-2022-04246",
+          "TKT-2022-04957"
+        ]
+      },
+      "human_override": null,
+      "final_decision": {
+        "category": "SECURITY",
+        "subcategory": "suspicious_person",
+        "risk_level": "MEDIUM",
+        "dispatched_vendor_id": "v_027",
+        "dispatched_emergency_services": false,
+        "needs_human_review": true,
+        "needs_clarification": true,
+        "confidence_category": 0.95,
+        "confidence_subcategory": 0.95,
+        "validator_reasons": [
+          "trap_cascade_subcategory:suspicious_person(high-audit cell at HIGH/EMERGENCY \u2014 possible under-classification)"
+        ],
+        "risk_reasons": [
+          "base_risk:MEDIUM"
+        ],
+        "retrieved_record_ids": [
+          "TKT-2024-02427",
+          "TKT-2024-09969",
+          "TKT-2023-01427",
+          "TKT-2024-06153",
+          "TKT-2022-09928",
+          "TKT-2024-04503",
+          "TKT-2022-04246",
+          "TKT-2022-04957"
+        ]
+      }
+    },
+    "transcript_id": "EVAL-0349"
+  },
+  {
+    "category": "ELEVATOR",
+    "subcategory": "malfunction",
+    "risk_level": "MEDIUM",
+    "needs_human_review": true,
+    "needs_clarification": false,
+    "building_name": "Palm Court Offices",
+    "address": "420 Palm Ave",
+    "floor": "Floor 2",
+    "dispatched_vendor_id": "v_016",
+    "dispatched_emergency_services": false,
+    "call_summary": "Equipment malfunction reported at Palm Court Offices, Floor 2. MEDIUM risk. Flagged for review. Skyline Elevator Co dispatched pending approval.",
+    "trainer_log": {
+      "full_transcript": "[AGENT] Dispatch, what do you need?\n[CALLER] Hi there, hold on, Elevator at Palm Court Offices on Floor 2 is stuck on the ground floor, nobody was in it.\n[AGENT] Alright. Is the car moving at all?\n[CALLER] Not moving at all.\n[AGENT] Sending a tech your way now. You'll hear from them en route.\n[CALLER] Got it, thanks.",
+      "ai_prediction": {
+        "category": "ELEVATOR",
+        "subcategory": "malfunction",
+        "risk_level": "MEDIUM",
+        "dispatched_vendor_id": "v_016",
+        "dispatched_emergency_services": false,
+        "needs_human_review": true,
+        "needs_clarification": false,
+        "confidence_category": 0.9,
+        "confidence_subcategory": 0.9,
+        "validator_reasons": [
+          "trap_cascade_subcategory:malfunction(high-audit cell at HIGH/EMERGENCY \u2014 possible under-classification)"
+        ],
+        "risk_reasons": [
+          "base_risk:MEDIUM"
+        ],
+        "retrieved_record_ids": [
+          "TKT-2022-09418",
+          "TKT-2023-01373",
+          "TKT-2023-05729",
+          "TKT-2022-08062",
+          "TKT-2022-00403",
+          "TKT-2023-05915",
+          "TKT-2024-00861",
+          "TKT-2023-05780"
+        ]
+      },
+      "human_override": null,
+      "final_decision": {
+        "category": "ELEVATOR",
+        "subcategory": "malfunction",
+        "risk_level": "MEDIUM",
+        "dispatched_vendor_id": "v_016",
+        "dispatched_emergency_services": false,
+        "needs_human_review": true,
+        "needs_clarification": false,
+        "confidence_category": 0.9,
+        "confidence_subcategory": 0.9,
+        "validator_reasons": [
+          "trap_cascade_subcategory:malfunction(high-audit cell at HIGH/EMERGENCY \u2014 possible under-classification)"
+        ],
+        "risk_reasons": [
+          "base_risk:MEDIUM"
+        ],
+        "retrieved_record_ids": [
+          "TKT-2022-09418",
+          "TKT-2023-01373",
+          "TKT-2023-05729",
+          "TKT-2022-08062",
+          "TKT-2022-00403",
+          "TKT-2023-05915",
+          "TKT-2024-00861",
+          "TKT-2023-05780"
+        ]
+      }
+    },
+    "transcript_id": "EVAL-0358"
+  },
+  {
+    "category": "PEST_SPECIALTY",
+    "subcategory": "infestation",
+    "risk_level": "LOW",
+    "needs_human_review": false,
+    "needs_clarification": true,
+    "building_name": "Harbor Point Tower",
+    "address": "250 Harbor Dr",
+    "floor": "Floor 15",
+    "dispatched_vendor_id": "v_030",
+    "dispatched_emergency_services": false,
+    "call_summary": "Pest infestation reported at Harbor Point Tower, Floor 15. LOW risk. Dispatched Westside Pest Control.",
+    "trainer_log": {
+      "full_transcript": "[AGENT] CBRE facilities, this is Sam. What's going on?\n[CALLER] There's an issue with infestation.\n[AGENT] What kind of pest?\n[CALLER] [dog barking faintly] There's droppings behind the trash bins.\n[AGENT] Which building and floor are you at?\n[CALLER] Harbor Point Tower, Floor 15, Suite 1506.\n[AGENT] Okay, ticket's logged. Someone'll come out during business hours.",
+      "ai_prediction": {
+        "category": "PEST_SPECIALTY",
+        "subcategory": "infestation",
+        "risk_level": "LOW",
+        "dispatched_vendor_id": "v_030",
+        "dispatched_emergency_services": false,
+        "needs_human_review": false,
+        "needs_clarification": true,
+        "confidence_category": 0.9,
+        "confidence_subcategory": 0.9,
+        "validator_reasons": [
+          "auto_resolve:no_flags_fired"
+        ],
+        "risk_reasons": [
+          "base_risk:LOW"
+        ],
+        "retrieved_record_ids": [
+          "TKT-2023-01886",
+          "TKT-2022-09499",
+          "TKT-2024-05604",
+          "TKT-2022-08386",
+          "TKT-2023-09824",
+          "TKT-2024-04998",
+          "TKT-2022-06580",
+          "TKT-2024-00663"
+        ]
+      },
+      "human_override": null,
+      "final_decision": {
+        "category": "PEST_SPECIALTY",
+        "subcategory": "infestation",
+        "risk_level": "LOW",
+        "dispatched_vendor_id": "v_030",
+        "dispatched_emergency_services": false,
+        "needs_human_review": false,
+        "needs_clarification": true,
+        "confidence_category": 0.9,
+        "confidence_subcategory": 0.9,
+        "validator_reasons": [
+          "auto_resolve:no_flags_fired"
+        ],
+        "risk_reasons": [
+          "base_risk:LOW"
+        ],
+        "retrieved_record_ids": [
+          "TKT-2023-01886",
+          "TKT-2022-09499",
+          "TKT-2024-05604",
+          "TKT-2022-08386",
+          "TKT-2023-09824",
+          "TKT-2024-04998",
+          "TKT-2022-06580",
+          "TKT-2024-00663"
+        ]
+      }
+    },
+    "transcript_id": "EVAL-0361"
+  },
+  {
+    "category": "LIFE_SAFETY",
+    "subcategory": "fire_smoke",
+    "risk_level": "EMERGENCY",
+    "needs_human_review": true,
+    "needs_clarification": false,
+    "building_name": "Rancho Del Sol Office Park",
+    "address": "600 Rancho del Sol Dr",
+    "floor": "Floor 2",
+    "dispatched_vendor_id": null,
+    "dispatched_emergency_services": true,
+    "call_summary": "Fire/smoke detected reported at Rancho Del Sol Office Park, Floor 2. EMERGENCY risk. Emergency services dispatched.",
+    "trainer_log": {
+      "full_transcript": "[AGENT] CBRE facilities \u2014 how can I help?\n[CALLER] Hi there, There's smoke coming from the electrical room, I can see it.\n[AGENT] Mhm. Is there visible fire?\n[CALLER] Just smoke right now, no flames visible.\n[AGENT] Can you confirm the building and floor?\n[CALLER] Rancho Del Sol Office Park, Floor 2, Suite 205.\n[AGENT] Is anyone trapped?\n[CALLER] Uh, yes I pulled the alarm, it's going off.\n[AGENT] Hmm, none of our vendors are quite the right fit \u2014 let me bump this up to the on-call PM so they can handle it directly.\n[CALLER] Okay, sorry, please hurry.",
+      "ai_prediction": {
+        "category": "LIFE_SAFETY",
+        "subcategory": "fire_smoke",
+        "risk_level": "EMERGENCY",
+        "dispatched_vendor_id": null,
+        "dispatched_emergency_services": true,
+        "needs_human_review": true,
+        "needs_clarification": false,
+        "confidence_category": 0.95,
+        "confidence_subcategory": 0.95,
+        "validator_reasons": [
+          "emergency_band:always_pause",
+          "emergency_dispatch:fire_smoke:hazard_cue_confirmed"
+        ],
+        "risk_reasons": [
+          "base_risk:EMERGENCY",
+          "hard_cue:smoke",
+          "hard_cue:trapped",
+          "capped_at_EMERGENCY:historical_max for subcategory=fire_smoke"
+        ],
+        "retrieved_record_ids": [
+          "TKT-2024-05448",
+          "TKT-2023-06458",
+          "TKT-2022-03901",
+          "TKT-2023-02639",
+          "TKT-2024-02424",
+          "TKT-2022-01963",
+          "TKT-2022-03139",
+          "TKT-2023-03410"
+        ]
+      },
+      "human_override": null,
+      "final_decision": {
+        "category": "LIFE_SAFETY",
+        "subcategory": "fire_smoke",
+        "risk_level": "EMERGENCY",
+        "dispatched_vendor_id": null,
+        "dispatched_emergency_services": true,
+        "needs_human_review": true,
+        "needs_clarification": false,
+        "confidence_category": 0.95,
+        "confidence_subcategory": 0.95,
+        "validator_reasons": [
+          "emergency_band:always_pause",
+          "emergency_dispatch:fire_smoke:hazard_cue_confirmed"
+        ],
+        "risk_reasons": [
+          "base_risk:EMERGENCY",
+          "hard_cue:smoke",
+          "hard_cue:trapped",
+          "capped_at_EMERGENCY:historical_max for subcategory=fire_smoke"
+        ],
+        "retrieved_record_ids": [
+          "TKT-2024-05448",
+          "TKT-2023-06458",
+          "TKT-2022-03901",
+          "TKT-2023-02639",
+          "TKT-2024-02424",
+          "TKT-2022-01963",
+          "TKT-2022-03139",
+          "TKT-2023-03410"
+        ]
+      }
+    },
+    "transcript_id": "EVAL-0367"
+  },
+  {
+    "category": "SECURITY",
+    "subcategory": "suspicious_person",
+    "risk_level": "MEDIUM",
+    "needs_human_review": true,
+    "needs_clarification": false,
+    "building_name": "Golden State Towers",
+    "address": "900 Golden State Blvd",
+    "floor": "Floor 2",
+    "dispatched_vendor_id": "v_027",
+    "dispatched_emergency_services": false,
+    "call_summary": "Suspicious person reported reported at Golden State Towers, Floor 2. MEDIUM risk. Flagged for review. Elite Protective Services dispatched pending approval.",
+    "trainer_log": {
+      "full_transcript": "[AGENT] CBRE facilities, this is Sam. What's going on?\n[CALLER] There's yelling in the lobby \u2014 just two tenants arguing loudly, nothing physical, no weapons.\n[AGENT] Okay \u2014 can you confirm there's no actual fire or injury right now?\n[CALLER] No weapons, no physical contact. Just loud arguing.\n[AGENT] Can you tell me the building, floor, and suite?\n[CALLER] Golden State Towers, Floor 2, Suite 205.\n[AGENT] Alright \u2014 sending a vendor over and giving the PM a heads-up.",
+      "ai_prediction": {
+        "category": "SECURITY",
+        "subcategory": "suspicious_person",
+        "risk_level": "MEDIUM",
+        "dispatched_vendor_id": "v_027",
+        "dispatched_emergency_services": false,
+        "needs_human_review": true,
+        "needs_clarification": false,
+        "confidence_category": 0.95,
+        "confidence_subcategory": 0.95,
+        "validator_reasons": [
+          "trap_cascade_subcategory:suspicious_person(high-audit cell at HIGH/EMERGENCY \u2014 possible under-classification)"
+        ],
+        "risk_reasons": [
+          "base_risk:MEDIUM"
+        ],
+        "retrieved_record_ids": [
+          "TKT-2024-02895",
+          "TKT-2022-03949",
+          "TKT-2022-07336",
+          "TKT-2023-04154",
+          "TKT-2023-05648",
+          "TKT-2024-01959",
+          "TKT-2024-08799",
+          "TKT-2024-03333"
+        ]
+      },
+      "human_override": null,
+      "final_decision": {
+        "category": "SECURITY",
+        "subcategory": "suspicious_person",
+        "risk_level": "MEDIUM",
+        "dispatched_vendor_id": "v_027",
+        "dispatched_emergency_services": false,
+        "needs_human_review": true,
+        "needs_clarification": false,
+        "confidence_category": 0.95,
+        "confidence_subcategory": 0.95,
+        "validator_reasons": [
+          "trap_cascade_subcategory:suspicious_person(high-audit cell at HIGH/EMERGENCY \u2014 possible under-classification)"
+        ],
+        "risk_reasons": [
+          "base_risk:MEDIUM"
+        ],
+        "retrieved_record_ids": [
+          "TKT-2024-02895",
+          "TKT-2022-03949",
+          "TKT-2022-07336",
+          "TKT-2023-04154",
+          "TKT-2023-05648",
+          "TKT-2024-01959",
+          "TKT-2024-08799",
+          "TKT-2024-03333"
+        ]
+      }
+    },
+    "transcript_id": "EVAL-0373"
+  },
+  {
+    "category": "SECURITY",
+    "subcategory": "suspicious_person",
+    "risk_level": "MEDIUM",
+    "needs_human_review": true,
+    "needs_clarification": false,
+    "building_name": "Brookfield Retail Center",
+    "address": "2200 Brookfield Rd",
+    "floor": "Floor 1",
+    "dispatched_vendor_id": "v_027",
+    "dispatched_emergency_services": false,
+    "call_summary": "Suspicious person reported reported at Brookfield Retail Center, Floor 1. MEDIUM risk. Flagged for review. Elite Protective Services dispatched pending approval.",
+    "trainer_log": {
+      "full_transcript": "[AGENT] Hi, CBRE facilities. What can I do for you?\n[CALLER] I mean, there's yelling in the lobby \u2014 just two tenants arguing loudly, nothing physical, no weapons.\n[AGENT] Okay \u2014 can you confirm there's no actual fire or injury right now?\n[CALLER] No weapons, no physical contact. Just loud arguing.\n[AGENT] Where exactly \u2014 which suite?\n[CALLER] [pa announcement in background] Brookfield Retail Center, Floor 1, Suite 105.\n[AGENT] I'll get a vendor rolling and let the property manager know.",
+      "ai_prediction": {
+        "category": "SECURITY",
+        "subcategory": "suspicious_person",
+        "risk_level": "MEDIUM",
+        "dispatched_vendor_id": "v_027",
+        "dispatched_emergency_services": false,
+        "needs_human_review": true,
+        "needs_clarification": false,
+        "confidence_category": 0.9,
+        "confidence_subcategory": 0.9,
+        "validator_reasons": [
+          "trap_cascade_subcategory:suspicious_person(high-audit cell at HIGH/EMERGENCY \u2014 possible under-classification)"
+        ],
+        "risk_reasons": [
+          "base_risk:MEDIUM"
+        ],
+        "retrieved_record_ids": [
+          "TKT-2022-07336",
+          "TKT-2024-05484",
+          "TKT-2024-02532",
+          "TKT-2022-03949",
+          "TKT-2024-02895",
+          "TKT-2022-02020",
+          "TKT-2023-04154",
+          "TKT-2022-04522"
+        ]
+      },
+      "human_override": null,
+      "final_decision": {
+        "category": "SECURITY",
+        "subcategory": "suspicious_person",
+        "risk_level": "MEDIUM",
+        "dispatched_vendor_id": "v_027",
+        "dispatched_emergency_services": false,
+        "needs_human_review": true,
+        "needs_clarification": false,
+        "confidence_category": 0.9,
+        "confidence_subcategory": 0.9,
+        "validator_reasons": [
+          "trap_cascade_subcategory:suspicious_person(high-audit cell at HIGH/EMERGENCY \u2014 possible under-classification)"
+        ],
+        "risk_reasons": [
+          "base_risk:MEDIUM"
+        ],
+        "retrieved_record_ids": [
+          "TKT-2022-07336",
+          "TKT-2024-05484",
+          "TKT-2024-02532",
+          "TKT-2022-03949",
+          "TKT-2024-02895",
+          "TKT-2022-02020",
+          "TKT-2023-04154",
+          "TKT-2022-04522"
+        ]
+      }
+    },
+    "transcript_id": "EVAL-0376"
+  },
+  {
+    "category": "PEST_SPECIALTY",
+    "subcategory": "landscaping",
+    "risk_level": "LOW",
+    "needs_human_review": false,
+    "needs_clarification": true,
+    "building_name": "Central Tower",
+    "address": "700 S Grand Ave",
+    "floor": "Floor 27",
+    "dispatched_vendor_id": "v_031",
+    "dispatched_emergency_services": false,
+    "call_summary": "Landscaping issue reported at Central Tower, Floor 27. LOW risk. Dispatched Cal-Coast Grounds Care.",
+    "trainer_log": {
+      "full_transcript": "[AGENT] CBRE facilities, this is Sam. What's going on?\n[CALLER] There's an issue with landscaping.\n[AGENT] Is water damaging anything?\n[CALLER] I mean, water's going across the walkway.\n[AGENT] Where exactly \u2014 which suite?\n[CALLER] Central Tower, Floor 27, Suite 2706.\n[AGENT] Alright, I'll send a vendor over. You'll get a text once they're rolling.",
+      "ai_prediction": {
+        "category": "PEST_SPECIALTY",
+        "subcategory": "landscaping",
+        "risk_level": "LOW",
+        "dispatched_vendor_id": "v_031",
+        "dispatched_emergency_services": false,
+        "needs_human_review": false,
+        "needs_clarification": true,
+        "confidence_category": 0.95,
+        "confidence_subcategory": 0.95,
+        "validator_reasons": [
+          "auto_resolve:no_flags_fired"
+        ],
+        "risk_reasons": [
+          "base_risk:LOW"
+        ],
+        "retrieved_record_ids": [
+          "TKT-2023-07367",
+          "TKT-2024-00234",
+          "TKT-2023-00839",
+          "TKT-2024-03057",
+          "TKT-2022-05548",
+          "TKT-2023-05765",
+          "TKT-2022-09598",
+          "TKT-2022-06973"
+        ]
+      },
+      "human_override": null,
+      "final_decision": {
+        "category": "PEST_SPECIALTY",
+        "subcategory": "landscaping",
+        "risk_level": "LOW",
+        "dispatched_vendor_id": "v_031",
+        "dispatched_emergency_services": false,
+        "needs_human_review": false,
+        "needs_clarification": true,
+        "confidence_category": 0.95,
+        "confidence_subcategory": 0.95,
+        "validator_reasons": [
+          "auto_resolve:no_flags_fired"
+        ],
+        "risk_reasons": [
+          "base_risk:LOW"
+        ],
+        "retrieved_record_ids": [
+          "TKT-2023-07367",
+          "TKT-2024-00234",
+          "TKT-2023-00839",
+          "TKT-2024-03057",
+          "TKT-2022-05548",
+          "TKT-2023-05765",
+          "TKT-2022-09598",
+          "TKT-2022-06973"
+        ]
+      }
+    },
+    "transcript_id": "EVAL-0379"
+  },
+  {
+    "category": "SECURITY",
+    "subcategory": "suspicious_person",
+    "risk_level": "MEDIUM",
+    "needs_human_review": true,
+    "needs_clarification": false,
+    "building_name": "Greenway Towers",
+    "address": "1200 Greenway Blvd",
+    "floor": "Floor 13",
+    "dispatched_vendor_id": "v_027",
+    "dispatched_emergency_services": false,
+    "call_summary": "Suspicious person reported reported at Greenway Towers, Floor 13. MEDIUM risk. Flagged for review. Elite Protective Services dispatched pending approval.",
+    "trainer_log": {
+      "full_transcript": "[AGENT] CBRE facilities \u2014 how can I help?\n[CALLER] Hi there, Someone has been hanging around for over an hour, watching people enter.\n[AGENT] Got it. Can you describe them?\n[CALLER] Yeah, still there by the elevators.\n[AGENT] Which building and floor are you at?\n[CALLER] Greenway Towers, Floor 13, Suite 1303.\n[AGENT] I'll send a vendor out and loop in the PM.\n[CALLER] Thanks, you know, bye.",
+      "ai_prediction": {
+        "category": "SECURITY",
+        "subcategory": "suspicious_person",
+        "risk_level": "MEDIUM",
+        "dispatched_vendor_id": "v_027",
+        "dispatched_emergency_services": false,
+        "needs_human_review": true,
+        "needs_clarification": false,
+        "confidence_category": 0.95,
+        "confidence_subcategory": 0.95,
+        "validator_reasons": [
+          "trap_cascade_subcategory:suspicious_person(high-audit cell at HIGH/EMERGENCY \u2014 possible under-classification)"
+        ],
+        "risk_reasons": [
+          "base_risk:MEDIUM"
+        ],
+        "retrieved_record_ids": [
+          "TKT-2024-07572",
+          "TKT-2024-06630",
+          "TKT-2024-06153",
+          "TKT-2024-05484",
+          "TKT-2023-07253",
+          "TKT-2022-09928",
+          "TKT-2023-02528",
+          "TKT-2024-02559"
+        ]
+      },
+      "human_override": null,
+      "final_decision": {
+        "category": "SECURITY",
+        "subcategory": "suspicious_person",
+        "risk_level": "MEDIUM",
+        "dispatched_vendor_id": "v_027",
+        "dispatched_emergency_services": false,
+        "needs_human_review": true,
+        "needs_clarification": false,
+        "confidence_category": 0.95,
+        "confidence_subcategory": 0.95,
+        "validator_reasons": [
+          "trap_cascade_subcategory:suspicious_person(high-audit cell at HIGH/EMERGENCY \u2014 possible under-classification)"
+        ],
+        "risk_reasons": [
+          "base_risk:MEDIUM"
+        ],
+        "retrieved_record_ids": [
+          "TKT-2024-07572",
+          "TKT-2024-06630",
+          "TKT-2024-06153",
+          "TKT-2024-05484",
+          "TKT-2023-07253",
+          "TKT-2022-09928",
+          "TKT-2023-02528",
+          "TKT-2024-02559"
+        ]
+      }
+    },
+    "transcript_id": "EVAL-0380"
+  },
+  {
+    "category": "ELECTRICAL",
+    "subcategory": "panel_hazard",
+    "risk_level": "EMERGENCY",
+    "needs_human_review": true,
+    "needs_clarification": false,
+    "building_name": "Crossroads Business Park",
+    "address": "3300 Crossroads Pkwy",
+    "floor": "Floor 5",
+    "dispatched_vendor_id": "v_008",
+    "dispatched_emergency_services": false,
+    "call_summary": "Electrical panel hazard reported at Crossroads Business Park, Floor 5. EMERGENCY risk. Flagged for review. Rapid Response Electricians dispatched pending approval.",
+    "trainer_log": {
+      "full_transcript": "[AGENT] CBRE dispatch, talk to me.\n[CALLER] Like, we lost power on the floor about ten minutes ago.\n[AGENT] Mhm. Any lights flickering before it went out?\n[CALLER] Hold on \u2014 I'm getting a burnt-plastic smell from the electrical closet now. This isn't just a power outage.\n[AGENT] Got it \u2014 updating the ticket. Do you see any smoke?\n[CALLER] Nobody's near it, I told everyone to back away.\n[AGENT] Which building and floor are you at?\n[CALLER] [pa announcement in background] Crossroads Business Park, like, Floor 5.\n[AGENT] 911 is going out now and I'm alerting building ops \u2014 stay with me on the line if you can.",
+      "ai_prediction": {
+        "category": "ELECTRICAL",
+        "subcategory": "panel_hazard",
+        "risk_level": "EMERGENCY",
+        "dispatched_vendor_id": "v_008",
+        "dispatched_emergency_services": false,
+        "needs_human_review": true,
+        "needs_clarification": false,
+        "confidence_category": 0.95,
+        "confidence_subcategory": 0.95,
+        "validator_reasons": [
+          "emergency_band:always_pause",
+          "life_safety_no_autodispatch:no_hazard_cue"
+        ],
+        "risk_reasons": [
+          "base_risk:EMERGENCY"
+        ],
+        "retrieved_record_ids": [
+          "TKT-2024-06501",
+          "TKT-2022-07612",
+          "TKT-2022-06100",
+          "TKT-2022-08641",
+          "TKT-2024-07923",
+          "TKT-2022-08857",
+          "TKT-2023-07805",
+          "TKT-2024-05862"
+        ]
+      },
+      "human_override": null,
+      "final_decision": {
+        "category": "ELECTRICAL",
+        "subcategory": "panel_hazard",
+        "risk_level": "EMERGENCY",
+        "dispatched_vendor_id": "v_008",
+        "dispatched_emergency_services": false,
+        "needs_human_review": true,
+        "needs_clarification": false,
+        "confidence_category": 0.95,
+        "confidence_subcategory": 0.95,
+        "validator_reasons": [
+          "emergency_band:always_pause",
+          "life_safety_no_autodispatch:no_hazard_cue"
+        ],
+        "risk_reasons": [
+          "base_risk:EMERGENCY"
+        ],
+        "retrieved_record_ids": [
+          "TKT-2024-06501",
+          "TKT-2022-07612",
+          "TKT-2022-06100",
+          "TKT-2022-08641",
+          "TKT-2024-07923",
+          "TKT-2022-08857",
+          "TKT-2023-07805",
+          "TKT-2024-05862"
+        ]
+      }
+    },
+    "transcript_id": "EVAL-0389"
+  },
+  {
+    "category": "DOORS_ACCESS",
+    "subcategory": "auto_door",
+    "risk_level": "LOW",
+    "needs_human_review": false,
+    "needs_clarification": false,
+    "building_name": "North Hollywood Arts Center",
+    "address": "5200 Lankershim Blvd",
+    "floor": "Floor 4",
+    "dispatched_vendor_id": "v_020",
+    "dispatched_emergency_services": false,
+    "call_summary": "Automatic door malfunction reported at North Hollywood Arts Center, Floor 4. LOW risk. Dispatched SecurePass Access Systems.",
+    "trainer_log": {
+      "full_transcript": "[AGENT] CBRE maintenance, this is Dana. What's going on?\n[CALLER] The main doors are being weird.\n[AGENT] Okay, can you describe what you're seeing or smelling?\n[CALLER] Yeah it's a fire exit.\n[AGENT] Is the door a fire exit?\n[CALLER] Yeah it's a fire exit.\n[AGENT] Where exactly \u2014 which suite?\n[CALLER] North Hollywood Arts Center, Floor 4, Suite 402.\n[AGENT] Alright, I've put a ticket in \u2014 vendor will swing by during business hours.",
+      "ai_prediction": {
+        "category": "DOORS_ACCESS",
+        "subcategory": "auto_door",
+        "risk_level": "LOW",
+        "dispatched_vendor_id": "v_020",
+        "dispatched_emergency_services": false,
+        "needs_human_review": false,
+        "needs_clarification": false,
+        "confidence_category": 0.95,
+        "confidence_subcategory": 0.95,
+        "validator_reasons": [
+          "auto_resolve:no_flags_fired"
+        ],
+        "risk_reasons": [
+          "base_risk:LOW",
+          "hard_cue:fire",
+          "capped_at_LOW:historical_max for subcategory=auto_door"
+        ],
+        "retrieved_record_ids": [
+          "TKT-2024-00618",
+          "TKT-2023-02864",
+          "TKT-2022-00496",
+          "TKT-2022-07021",
+          "TKT-2023-06659",
+          "TKT-2023-04286",
+          "TKT-2024-04047",
+          "TKT-2024-03627"
+        ]
+      },
+      "human_override": null,
+      "final_decision": {
+        "category": "DOORS_ACCESS",
+        "subcategory": "auto_door",
+        "risk_level": "LOW",
+        "dispatched_vendor_id": "v_020",
+        "dispatched_emergency_services": false,
+        "needs_human_review": false,
+        "needs_clarification": false,
+        "confidence_category": 0.95,
+        "confidence_subcategory": 0.95,
+        "validator_reasons": [
+          "auto_resolve:no_flags_fired"
+        ],
+        "risk_reasons": [
+          "base_risk:LOW",
+          "hard_cue:fire",
+          "capped_at_LOW:historical_max for subcategory=auto_door"
+        ],
+        "retrieved_record_ids": [
+          "TKT-2024-00618",
+          "TKT-2023-02864",
+          "TKT-2022-00496",
+          "TKT-2022-07021",
+          "TKT-2023-06659",
+          "TKT-2023-04286",
+          "TKT-2024-04047",
+          "TKT-2024-03627"
+        ]
+      }
+    },
+    "transcript_id": "EVAL-0395"
+  },
+  {
+    "category": "HVAC",
+    "subcategory": "refrigerant",
+    "risk_level": "LOW",
+    "needs_human_review": false,
+    "needs_clarification": false,
+    "building_name": null,
+    "address": null,
+    "floor": "Floor 1",
+    "dispatched_vendor_id": "v_014",
+    "dispatched_emergency_services": false,
+    "call_summary": "Refrigerant issue reported at Floor 1. LOW risk. Dispatched MediCool HVAC Systems.",
+    "trainer_log": {
+      "full_transcript": "[AGENT] CBRE facilities, this is Sam. What's going on?\n[CALLER] Uh, good afternoon, Chiller on Floor 1 is hissing and the cold air isn't very cold anymore.\n[AGENT] Understood. Has the cooling dropped noticeably?\n[CALLER] Still running but not cold.\n[AGENT] Okay, ticket's logged. Someone'll come out during business hours.\n[CALLER] Okay, please hurry.",
+      "ai_prediction": {
+        "category": "HVAC",
+        "subcategory": "refrigerant",
+        "risk_level": "LOW",
+        "dispatched_vendor_id": "v_014",
+        "dispatched_emergency_services": false,
+        "needs_human_review": false,
+        "needs_clarification": false,
+        "confidence_category": 0.95,
+        "confidence_subcategory": 0.95,
+        "validator_reasons": [
+          "auto_resolve:no_flags_fired"
+        ],
+        "risk_reasons": [
+          "base_risk:LOW"
+        ],
+        "retrieved_record_ids": [
+          "TKT-2024-06807",
+          "TKT-2023-07895",
+          "TKT-2024-06756",
+          "TKT-2023-07349",
+          "TKT-2023-01943",
+          "TKT-2023-01688",
+          "TKT-2024-02445",
+          "TKT-2024-01890"
+        ]
+      },
+      "human_override": null,
+      "final_decision": {
+        "category": "HVAC",
+        "subcategory": "refrigerant",
+        "risk_level": "LOW",
+        "dispatched_vendor_id": "v_014",
+        "dispatched_emergency_services": false,
+        "needs_human_review": false,
+        "needs_clarification": false,
+        "confidence_category": 0.95,
+        "confidence_subcategory": 0.95,
+        "validator_reasons": [
+          "auto_resolve:no_flags_fired"
+        ],
+        "risk_reasons": [
+          "base_risk:LOW"
+        ],
+        "retrieved_record_ids": [
+          "TKT-2024-06807",
+          "TKT-2023-07895",
+          "TKT-2024-06756",
+          "TKT-2023-07349",
+          "TKT-2023-01943",
+          "TKT-2023-01688",
+          "TKT-2024-02445",
+          "TKT-2024-01890"
+        ]
+      }
+    },
+    "transcript_id": "EVAL-0415"
+  },
+  {
+    "category": "PLUMBING",
+    "subcategory": "roof_leak",
+    "risk_level": "MEDIUM",
+    "needs_human_review": true,
+    "needs_clarification": false,
+    "building_name": "The Atrium at South Coast",
+    "address": "3100 Bristol St",
+    "floor": "Floor 1",
+    "dispatched_vendor_id": "v_005",
+    "dispatched_emergency_services": false,
+    "call_summary": "Roof leak reported at The Atrium at South Coast, Floor 1. MEDIUM risk. Flagged for review. Bayside Roofing Co dispatched pending approval.",
+    "trainer_log": {
+      "full_transcript": "[AGENT] CBRE maintenance \u2014 what's going on?\n[CALLER] A piece of the ceiling fell \u2014 it's just one drop-ceiling tile, water-damaged, nothing structural, nobody hurt.\n[AGENT] Okay \u2014 can you confirm there's no actual fire or injury right now?\n[CALLER] [door closing] It was one tile from a water leak \u2014 nobody hurt, like, just a mess.\n[AGENT] Which building, floor, and suite are you in?\n[CALLER] The Atrium at South Coast, Floor 1, Suite 104.\n[AGENT] I'll send a vendor out and loop in the PM.",
+      "ai_prediction": {
+        "category": "PLUMBING",
+        "subcategory": "roof_leak",
+        "risk_level": "MEDIUM",
+        "dispatched_vendor_id": "v_005",
+        "dispatched_emergency_services": false,
+        "needs_human_review": true,
+        "needs_clarification": false,
+        "confidence_category": 0.9,
+        "confidence_subcategory": 0.9,
+        "validator_reasons": [
+          "trap_cascade_subcategory:roof_leak(high-audit cell at HIGH/EMERGENCY \u2014 possible under-classification)"
+        ],
+        "risk_reasons": [
+          "base_risk:MEDIUM"
+        ],
+        "retrieved_record_ids": [
+          "TKT-2022-04243",
+          "TKT-2023-03854",
+          "TKT-2024-02634",
+          "TKT-2024-02022",
+          "TKT-2023-03725",
+          "TKT-2023-07067",
+          "TKT-2022-05023",
+          "TKT-2023-05153"
+        ]
+      },
+      "human_override": null,
+      "final_decision": {
+        "category": "PLUMBING",
+        "subcategory": "roof_leak",
+        "risk_level": "MEDIUM",
+        "dispatched_vendor_id": "v_005",
+        "dispatched_emergency_services": false,
+        "needs_human_review": true,
+        "needs_clarification": false,
+        "confidence_category": 0.9,
+        "confidence_subcategory": 0.9,
+        "validator_reasons": [
+          "trap_cascade_subcategory:roof_leak(high-audit cell at HIGH/EMERGENCY \u2014 possible under-classification)"
+        ],
+        "risk_reasons": [
+          "base_risk:MEDIUM"
+        ],
+        "retrieved_record_ids": [
+          "TKT-2022-04243",
+          "TKT-2023-03854",
+          "TKT-2024-02634",
+          "TKT-2024-02022",
+          "TKT-2023-03725",
+          "TKT-2023-07067",
+          "TKT-2022-05023",
+          "TKT-2023-05153"
+        ]
+      }
+    },
+    "transcript_id": "EVAL-0416"
+  },
+  {
+    "category": "HVAC",
+    "subcategory": "no_cooling",
+    "risk_level": "LOW",
+    "needs_human_review": false,
+    "needs_clarification": false,
+    "building_name": "Summit Office Towers",
+    "address": "800 Summit Blvd",
+    "floor": "Floor 9",
+    "dispatched_vendor_id": "v_013",
+    "dispatched_emergency_services": false,
+    "call_summary": "No cooling reported at Summit Office Towers, Floor 9. LOW risk. Dispatched CoolZone HVAC.",
+    "trainer_log": {
+      "full_transcript": "[AGENT] Maintenance, what's the situation?\n[CALLER] It's really hot in here, like, not sure what's going on.\n[AGENT] Okay, can you describe what you're seeing or smelling?\n[CALLER] Everyone on the floor is complaining.\n[AGENT] Are any servers or equipment at risk?\n[CALLER] Like, it's 79 and climbing in here.\n[AGENT] What's your building, floor, suite?\n[CALLER] Like, summit Office Towers, Floor 9, Suite 902.\n[AGENT] Okay, I'll line that up now. Confirmation text will come through shortly.",
+      "ai_prediction": {
+        "category": "HVAC",
+        "subcategory": "no_cooling",
+        "risk_level": "LOW",
+        "dispatched_vendor_id": "v_013",
+        "dispatched_emergency_services": false,
+        "needs_human_review": false,
+        "needs_clarification": false,
+        "confidence_category": 0.95,
+        "confidence_subcategory": 0.95,
+        "validator_reasons": [
+          "auto_resolve:no_flags_fired"
+        ],
+        "risk_reasons": [
+          "base_risk:LOW"
+        ],
+        "retrieved_record_ids": [
+          "TKT-2022-02740",
+          "TKT-2023-06968",
+          "TKT-2023-04940",
+          "TKT-2024-05121",
+          "TKT-2023-07109",
+          "TKT-2024-01338",
+          "TKT-2024-02451",
+          "TKT-2024-05748"
+        ]
+      },
+      "human_override": null,
+      "final_decision": {
+        "category": "HVAC",
+        "subcategory": "no_cooling",
+        "risk_level": "LOW",
+        "dispatched_vendor_id": "v_013",
+        "dispatched_emergency_services": false,
+        "needs_human_review": false,
+        "needs_clarification": false,
+        "confidence_category": 0.95,
+        "confidence_subcategory": 0.95,
+        "validator_reasons": [
+          "auto_resolve:no_flags_fired"
+        ],
+        "risk_reasons": [
+          "base_risk:LOW"
+        ],
+        "retrieved_record_ids": [
+          "TKT-2022-02740",
+          "TKT-2023-06968",
+          "TKT-2023-04940",
+          "TKT-2024-05121",
+          "TKT-2023-07109",
+          "TKT-2024-01338",
+          "TKT-2024-02451",
+          "TKT-2024-05748"
+        ]
+      }
+    },
+    "transcript_id": "EVAL-0418"
+  },
+  {
+    "category": "PEST_SPECIALTY",
+    "subcategory": "landscaping",
+    "risk_level": "LOW",
+    "needs_human_review": false,
+    "needs_clarification": false,
+    "building_name": "Capitol Mall Tower",
+    "address": "400 Capitol Mall",
+    "floor": "Floor 22",
+    "dispatched_vendor_id": "v_031",
+    "dispatched_emergency_services": false,
+    "call_summary": "Landscaping issue reported at Capitol Mall Tower, Floor 22. LOW risk. Dispatched Cal-Coast Grounds Care.",
+    "trainer_log": {
+      "full_transcript": "[AGENT] Hi, CBRE facilities. What can I do for you?\n[CALLER] Hi there, I mean, Sprinkler head is stuck on, water everywhere.\n[AGENT] Okay. Is it a safety hazard?\n[CALLER] Not immediately, but wasteful.\n[AGENT] Can you confirm the building and floor?\n[CALLER] Capitol Mall Tower, Floor 22, Suite 2207.\n[AGENT] Okay, I'll line that up now. Confirmation text will come through shortly.",
+      "ai_prediction": {
+        "category": "PEST_SPECIALTY",
+        "subcategory": "landscaping",
+        "risk_level": "LOW",
+        "dispatched_vendor_id": "v_031",
+        "dispatched_emergency_services": false,
+        "needs_human_review": false,
+        "needs_clarification": false,
+        "confidence_category": 0.95,
+        "confidence_subcategory": 0.95,
+        "validator_reasons": [
+          "auto_resolve:no_flags_fired"
+        ],
+        "risk_reasons": [
+          "base_risk:LOW"
+        ],
+        "retrieved_record_ids": [
+          "TKT-2024-04674",
+          "TKT-2024-00888",
+          "TKT-2024-07266",
+          "TKT-2024-08415",
+          "TKT-2024-01134",
+          "TKT-2024-01812",
+          "TKT-2024-09852",
+          "TKT-2023-01607"
+        ]
+      },
+      "human_override": null,
+      "final_decision": {
+        "category": "PEST_SPECIALTY",
+        "subcategory": "landscaping",
+        "risk_level": "LOW",
+        "dispatched_vendor_id": "v_031",
+        "dispatched_emergency_services": false,
+        "needs_human_review": false,
+        "needs_clarification": false,
+        "confidence_category": 0.95,
+        "confidence_subcategory": 0.95,
+        "validator_reasons": [
+          "auto_resolve:no_flags_fired"
+        ],
+        "risk_reasons": [
+          "base_risk:LOW"
+        ],
+        "retrieved_record_ids": [
+          "TKT-2024-04674",
+          "TKT-2024-00888",
+          "TKT-2024-07266",
+          "TKT-2024-08415",
+          "TKT-2024-01134",
+          "TKT-2024-01812",
+          "TKT-2024-09852",
+          "TKT-2023-01607"
+        ]
+      }
+    },
+    "transcript_id": "EVAL-0422"
+  },
+  {
+    "category": "ELEVATOR",
+    "subcategory": "malfunction",
+    "risk_level": "MEDIUM",
+    "needs_human_review": true,
+    "needs_clarification": true,
+    "building_name": "Metro Center Offices",
+    "address": "650 Metro Center Way",
+    "floor": "Floor 2",
+    "dispatched_vendor_id": "v_016",
+    "dispatched_emergency_services": false,
+    "call_summary": "Equipment malfunction reported at Metro Center Offices, Floor 2. MEDIUM risk. Flagged for review. Skyline Elevator Co dispatched pending approval.",
+    "trainer_log": {
+      "full_transcript": "[AGENT] CBRE maintenance, this is Dana. What's going on?\n[CALLER] You know, there's an issue with malfunction.\n[AGENT] Is the car moving at all?\n[CALLER] Not moving at all.\n[AGENT] Can you confirm the building and floor?\n[CALLER] Metro Center Offices, Floor 2, Suite 202.\n[AGENT] I'll send a vendor out and loop in the PM.",
+      "ai_prediction": {
+        "category": "ELEVATOR",
+        "subcategory": "malfunction",
+        "risk_level": "MEDIUM",
+        "dispatched_vendor_id": "v_016",
+        "dispatched_emergency_services": false,
+        "needs_human_review": true,
+        "needs_clarification": true,
+        "confidence_category": 0.9,
+        "confidence_subcategory": 0.9,
+        "validator_reasons": [
+          "trap_cascade_subcategory:malfunction(high-audit cell at HIGH/EMERGENCY \u2014 possible under-classification)"
+        ],
+        "risk_reasons": [
+          "base_risk:MEDIUM"
+        ],
+        "retrieved_record_ids": [
+          "TKT-2022-03739",
+          "TKT-2024-08619",
+          "TKT-2023-01961",
+          "TKT-2023-05702",
+          "TKT-2022-07741",
+          "TKT-2024-08886",
+          "TKT-2022-01810",
+          "TKT-2023-04301"
+        ]
+      },
+      "human_override": null,
+      "final_decision": {
+        "category": "ELEVATOR",
+        "subcategory": "malfunction",
+        "risk_level": "MEDIUM",
+        "dispatched_vendor_id": "v_016",
+        "dispatched_emergency_services": false,
+        "needs_human_review": true,
+        "needs_clarification": true,
+        "confidence_category": 0.9,
+        "confidence_subcategory": 0.9,
+        "validator_reasons": [
+          "trap_cascade_subcategory:malfunction(high-audit cell at HIGH/EMERGENCY \u2014 possible under-classification)"
+        ],
+        "risk_reasons": [
+          "base_risk:MEDIUM"
+        ],
+        "retrieved_record_ids": [
+          "TKT-2022-03739",
+          "TKT-2024-08619",
+          "TKT-2023-01961",
+          "TKT-2023-05702",
+          "TKT-2022-07741",
+          "TKT-2024-08886",
+          "TKT-2022-01810",
+          "TKT-2023-04301"
+        ]
+      }
+    },
+    "transcript_id": "EVAL-0426"
+  },
+  {
+    "category": "HVAC",
+    "subcategory": "air_quality",
+    "risk_level": "MEDIUM",
+    "needs_human_review": true,
+    "needs_clarification": false,
+    "building_name": "Seaside Professional Center",
+    "address": "350 Ocean View Ave",
+    "floor": "Floor 5",
+    "dispatched_vendor_id": "v_012",
+    "dispatched_emergency_services": false,
+    "call_summary": "Air quality concern reported at Seaside Professional Center, Floor 5. MEDIUM risk. Flagged for review. Pacific HVAC Services dispatched pending approval.",
+    "trainer_log": {
+      "full_transcript": "[AGENT] CBRE maintenance line, what do you need?\n[CALLER] Strong chemical smell in the hallway, like cleaning fluid \u2014 the janitor just mopped with bleach solution.\n[AGENT] Okay \u2014 can you confirm there's no actual fire or injury right now?\n[CALLER] No, just the smell \u2014 no one's hurt, just annoying.\n[AGENT] Can you confirm the building and floor?\n[CALLER] Seaside Professional Center, Floor 5, Suite 505.\n[AGENT] Alright \u2014 sending a vendor over and giving the PM a heads-up.",
+      "ai_prediction": {
+        "category": "HVAC",
+        "subcategory": "air_quality",
+        "risk_level": "MEDIUM",
+        "dispatched_vendor_id": "v_012",
+        "dispatched_emergency_services": false,
+        "needs_human_review": true,
+        "needs_clarification": false,
+        "confidence_category": 0.95,
+        "confidence_subcategory": 0.95,
+        "validator_reasons": [
+          "trap_prone_subcategory:air_quality(over_escalation_rate=19%)"
+        ],
+        "risk_reasons": [
+          "base_risk:MEDIUM"
+        ],
+        "retrieved_record_ids": [
+          "TKT-2023-00554",
+          "TKT-2024-08193",
+          "TKT-2022-07963",
+          "TKT-2023-02927",
+          "TKT-2023-01952",
+          "TKT-2022-07075",
+          "TKT-2023-01151",
+          "TKT-2022-04255"
+        ]
+      },
+      "human_override": null,
+      "final_decision": {
+        "category": "HVAC",
+        "subcategory": "air_quality",
+        "risk_level": "MEDIUM",
+        "dispatched_vendor_id": "v_012",
+        "dispatched_emergency_services": false,
+        "needs_human_review": true,
+        "needs_clarification": false,
+        "confidence_category": 0.95,
+        "confidence_subcategory": 0.95,
+        "validator_reasons": [
+          "trap_prone_subcategory:air_quality(over_escalation_rate=19%)"
+        ],
+        "risk_reasons": [
+          "base_risk:MEDIUM"
+        ],
+        "retrieved_record_ids": [
+          "TKT-2023-00554",
+          "TKT-2024-08193",
+          "TKT-2022-07963",
+          "TKT-2023-02927",
+          "TKT-2023-01952",
+          "TKT-2022-07075",
+          "TKT-2023-01151",
+          "TKT-2022-04255"
+        ]
+      }
+    },
+    "transcript_id": "EVAL-0431"
+  },
+  {
+    "category": "GROUNDS_EXTERIOR",
+    "subcategory": "pavement_damage",
+    "risk_level": "LOW",
+    "needs_human_review": false,
+    "needs_clarification": false,
+    "building_name": "Ventura Harbor Center",
+    "address": "1550 Spinnaker Dr",
+    "floor": "Floor 1",
+    "dispatched_vendor_id": "v_029",
+    "dispatched_emergency_services": false,
+    "call_summary": "Pavement damage reported at Ventura Harbor Center, Floor 1. LOW risk. Dispatched Golden State Exterior Maintenance.",
+    "trainer_log": {
+      "full_transcript": "[AGENT] Hi, CBRE facilities. What can I do for you?\n[CALLER] Hey, Chunk of the sidewalk on Floor 1 in Suite 208 heaved up, someone's going to trip on it.\n[AGENT] Understood. How large is the damage?\n[CALLER] Six inches across maybe, deep.\n[AGENT] Got the ticket open. Vendor should make it out during business hours.\n[CALLER] Okay, thanks.",
+      "ai_prediction": {
+        "category": "GROUNDS_EXTERIOR",
+        "subcategory": "pavement_damage",
+        "risk_level": "LOW",
+        "dispatched_vendor_id": "v_029",
+        "dispatched_emergency_services": false,
+        "needs_human_review": false,
+        "needs_clarification": false,
+        "confidence_category": 0.95,
+        "confidence_subcategory": 0.95,
+        "validator_reasons": [
+          "auto_resolve:no_flags_fired"
+        ],
+        "risk_reasons": [
+          "base_risk:LOW"
+        ],
+        "retrieved_record_ids": [
+          "TKT-2023-03317",
+          "TKT-2024-06879",
+          "TKT-2023-06194",
+          "TKT-2024-00120",
+          "TKT-2022-08767",
+          "TKT-2023-02156",
+          "TKT-2022-04642",
+          "TKT-2023-04934"
+        ]
+      },
+      "human_override": null,
+      "final_decision": {
+        "category": "GROUNDS_EXTERIOR",
+        "subcategory": "pavement_damage",
+        "risk_level": "LOW",
+        "dispatched_vendor_id": "v_029",
+        "dispatched_emergency_services": false,
+        "needs_human_review": false,
+        "needs_clarification": false,
+        "confidence_category": 0.95,
+        "confidence_subcategory": 0.95,
+        "validator_reasons": [
+          "auto_resolve:no_flags_fired"
+        ],
+        "risk_reasons": [
+          "base_risk:LOW"
+        ],
+        "retrieved_record_ids": [
+          "TKT-2023-03317",
+          "TKT-2024-06879",
+          "TKT-2023-06194",
+          "TKT-2024-00120",
+          "TKT-2022-08767",
+          "TKT-2023-02156",
+          "TKT-2022-04642",
+          "TKT-2023-04934"
+        ]
+      }
+    },
+    "transcript_id": "EVAL-0440"
+  },
+  {
+    "category": "LIFE_SAFETY",
+    "subcategory": "gas_chemical",
+    "risk_level": "EMERGENCY",
+    "needs_human_review": true,
+    "needs_clarification": false,
+    "building_name": "Ventura Harbor Center",
+    "address": "1550 Spinnaker Dr",
+    "floor": "Floor 2",
+    "dispatched_vendor_id": null,
+    "dispatched_emergency_services": true,
+    "call_summary": "Gas or chemical hazard reported at Ventura Harbor Center, Floor 2. EMERGENCY risk. Emergency services dispatched.",
+    "trainer_log": {
+      "full_transcript": "[AGENT] CBRE maintenance line, what do you need?\n[CALLER] Hello, I smell gas very strongly. Getting a headache.\n[AGENT] Alright. Have you evacuated the area?\n[CALLER] Smells like rotten eggs \u2014 pretty strong.\n[AGENT] Where exactly \u2014 which suite?\n[CALLER] Ventura Harbor Center, Floor 2, Suite 210.\n[AGENT] Calling emergency services this second. Get out safely if you can.",
+      "ai_prediction": {
+        "category": "LIFE_SAFETY",
+        "subcategory": "gas_chemical",
+        "risk_level": "EMERGENCY",
+        "dispatched_vendor_id": null,
+        "dispatched_emergency_services": true,
+        "needs_human_review": true,
+        "needs_clarification": false,
+        "confidence_category": 0.95,
+        "confidence_subcategory": 0.95,
+        "validator_reasons": [
+          "emergency_band:always_pause",
+          "emergency_dispatch:gas_chemical:hazard_cue_confirmed"
+        ],
+        "risk_reasons": [
+          "base_risk:EMERGENCY",
+          "hard_cue:gas leak",
+          "capped_at_EMERGENCY:historical_max for subcategory=gas_chemical"
+        ],
+        "retrieved_record_ids": [
+          "TKT-2022-01732",
+          "TKT-2023-00401",
+          "TKT-2022-07693",
+          "TKT-2023-06872",
+          "TKT-2023-01940",
+          "TKT-2022-09112",
+          "TKT-2023-07994",
+          "TKT-2023-08489"
+        ]
+      },
+      "human_override": null,
+      "final_decision": {
+        "category": "LIFE_SAFETY",
+        "subcategory": "gas_chemical",
+        "risk_level": "EMERGENCY",
+        "dispatched_vendor_id": null,
+        "dispatched_emergency_services": true,
+        "needs_human_review": true,
+        "needs_clarification": false,
+        "confidence_category": 0.95,
+        "confidence_subcategory": 0.95,
+        "validator_reasons": [
+          "emergency_band:always_pause",
+          "emergency_dispatch:gas_chemical:hazard_cue_confirmed"
+        ],
+        "risk_reasons": [
+          "base_risk:EMERGENCY",
+          "hard_cue:gas leak",
+          "capped_at_EMERGENCY:historical_max for subcategory=gas_chemical"
+        ],
+        "retrieved_record_ids": [
+          "TKT-2022-01732",
+          "TKT-2023-00401",
+          "TKT-2022-07693",
+          "TKT-2023-06872",
+          "TKT-2023-01940",
+          "TKT-2022-09112",
+          "TKT-2023-07994",
+          "TKT-2023-08489"
+        ]
+      }
+    },
+    "transcript_id": "EVAL-0444"
+  },
+  {
+    "category": "ELEVATOR",
+    "subcategory": "minor_issue",
+    "risk_level": "LOW",
+    "needs_human_review": false,
+    "needs_clarification": false,
+    "building_name": "The Atrium at South Coast",
+    "address": "3100 Bristol St",
+    "floor": "Floor 3",
+    "dispatched_vendor_id": "v_016",
+    "dispatched_emergency_services": false,
+    "call_summary": "Minor maintenance issue reported at The Atrium at South Coast, Floor 3. LOW risk. Dispatched Skyline Elevator Co.",
+    "trainer_log": {
+      "full_transcript": "[AGENT] CBRE dispatch \u2014 go ahead.\n[CALLER] Like, the elevator isn't leveling properly at our floor.\n[AGENT] Understood. How long has this been happening?\n[CALLER] Probably fine but sounds awful.\n[AGENT] Where exactly \u2014 which suite?\n[CALLER] The Atrium at South Coast, Floor 3, Suite 305.\n[AGENT] Alright, I've put a ticket in \u2014 vendor will swing by during business hours.",
+      "ai_prediction": {
+        "category": "ELEVATOR",
+        "subcategory": "minor_issue",
+        "risk_level": "LOW",
+        "dispatched_vendor_id": "v_016",
+        "dispatched_emergency_services": false,
+        "needs_human_review": false,
+        "needs_clarification": false,
+        "confidence_category": 0.9,
+        "confidence_subcategory": 0.9,
+        "validator_reasons": [
+          "auto_resolve:no_flags_fired"
+        ],
+        "risk_reasons": [
+          "base_risk:LOW"
+        ],
+        "retrieved_record_ids": [
+          "TKT-2023-04187",
+          "TKT-2023-06341",
+          "TKT-2024-03555",
+          "TKT-2024-08505",
+          "TKT-2024-06666",
+          "TKT-2023-09815",
+          "TKT-2024-00024",
+          "TKT-2024-03744"
+        ]
+      },
+      "human_override": null,
+      "final_decision": {
+        "category": "ELEVATOR",
+        "subcategory": "minor_issue",
+        "risk_level": "LOW",
+        "dispatched_vendor_id": "v_016",
+        "dispatched_emergency_services": false,
+        "needs_human_review": false,
+        "needs_clarification": false,
+        "confidence_category": 0.9,
+        "confidence_subcategory": 0.9,
+        "validator_reasons": [
+          "auto_resolve:no_flags_fired"
+        ],
+        "risk_reasons": [
+          "base_risk:LOW"
+        ],
+        "retrieved_record_ids": [
+          "TKT-2023-04187",
+          "TKT-2023-06341",
+          "TKT-2024-03555",
+          "TKT-2024-08505",
+          "TKT-2024-06666",
+          "TKT-2023-09815",
+          "TKT-2024-00024",
+          "TKT-2024-03744"
+        ]
+      }
+    },
+    "transcript_id": "EVAL-0464"
+  },
+  {
+    "category": "DOORS_ACCESS",
+    "subcategory": "auto_door",
+    "risk_level": "LOW",
+    "needs_human_review": false,
+    "needs_clarification": false,
+    "building_name": "Pinnacle Financial Center",
+    "address": "600 Financial Dr",
+    "floor": "Floor 5",
+    "dispatched_vendor_id": "v_020",
+    "dispatched_emergency_services": false,
+    "call_summary": "Automatic door malfunction reported at Pinnacle Financial Center, Floor 5. LOW risk. Dispatched SecurePass Access Systems.",
+    "trainer_log": {
+      "full_transcript": "[AGENT] Maintenance, what's the situation?\n[CALLER] Um, the main doors are being weird.\n[AGENT] Okay, can you describe what you're seeing or smelling?\n[CALLER] Stuck half-open, won't go either way.\n[AGENT] Is the door a fire exit?\n[CALLER] You know, yeah it's a fire exit.\n[AGENT] Can you confirm the building and floor?\n[CALLER] Pinnacle Financial Center, Floor 5, Suite 506.\n[AGENT] Okay, I'll line that up now. Confirmation text will come through shortly.",
+      "ai_prediction": {
+        "category": "DOORS_ACCESS",
+        "subcategory": "auto_door",
+        "risk_level": "LOW",
+        "dispatched_vendor_id": "v_020",
+        "dispatched_emergency_services": false,
+        "needs_human_review": false,
+        "needs_clarification": false,
+        "confidence_category": 0.95,
+        "confidence_subcategory": 0.95,
+        "validator_reasons": [
+          "auto_resolve:no_flags_fired"
+        ],
+        "risk_reasons": [
+          "base_risk:LOW",
+          "hard_cue:fire",
+          "capped_at_LOW:historical_max for subcategory=auto_door"
+        ],
+        "retrieved_record_ids": [
+          "TKT-2023-06659",
+          "TKT-2023-03056",
+          "TKT-2024-03873",
+          "TKT-2024-09573",
+          "TKT-2023-01664",
+          "TKT-2024-00618",
+          "TKT-2022-07741",
+          "TKT-2024-05385"
+        ]
+      },
+      "human_override": null,
+      "final_decision": {
+        "category": "DOORS_ACCESS",
+        "subcategory": "auto_door",
+        "risk_level": "LOW",
+        "dispatched_vendor_id": "v_020",
+        "dispatched_emergency_services": false,
+        "needs_human_review": false,
+        "needs_clarification": false,
+        "confidence_category": 0.95,
+        "confidence_subcategory": 0.95,
+        "validator_reasons": [
+          "auto_resolve:no_flags_fired"
+        ],
+        "risk_reasons": [
+          "base_risk:LOW",
+          "hard_cue:fire",
+          "capped_at_LOW:historical_max for subcategory=auto_door"
+        ],
+        "retrieved_record_ids": [
+          "TKT-2023-06659",
+          "TKT-2023-03056",
+          "TKT-2024-03873",
+          "TKT-2024-09573",
+          "TKT-2023-01664",
+          "TKT-2024-00618",
+          "TKT-2022-07741",
+          "TKT-2024-05385"
+        ]
+      }
+    },
+    "transcript_id": "EVAL-0467"
+  },
+  {
+    "category": "SECURITY",
+    "subcategory": "suspicious_person",
+    "risk_level": "MEDIUM",
+    "needs_human_review": true,
+    "needs_clarification": false,
+    "building_name": "El Monte Distribution Center",
+    "address": "8000 Valley Blvd",
+    "floor": null,
+    "dispatched_vendor_id": "v_027",
+    "dispatched_emergency_services": false,
+    "call_summary": "Suspicious person reported reported at El Monte Distribution Center. MEDIUM risk. Flagged for review. Elite Protective Services dispatched pending approval.",
+    "trainer_log": {
+      "full_transcript": "[AGENT] Maintenance, what's the situation?\n[CALLER] Hello, Guy asking employees for their badge numbers \u2014 something's off.\n[AGENT] Alright. Are they being aggressive?\n[CALLER] He's just standing there, not doing anything overt.\n[AGENT] Where exactly \u2014 which suite?\n[CALLER] El Monte Distribution Center, Loading Dock 2.\n[AGENT] Are they still there?\n[CALLER] Yeah, still there by the elevators.\n[AGENT] Pulling in the supervisor and dispatching a vendor right now.\n[AGENT] Nobody in our vendor list matches everything you need. Let me kick this over to the on-call PM.\n[CALLER] Okay, please hurry.",
+      "ai_prediction": {
+        "category": "SECURITY",
+        "subcategory": "suspicious_person",
+        "risk_level": "MEDIUM",
+        "dispatched_vendor_id": "v_027",
+        "dispatched_emergency_services": false,
+        "needs_human_review": true,
+        "needs_clarification": false,
+        "confidence_category": 0.9,
+        "confidence_subcategory": 0.9,
+        "validator_reasons": [
+          "trap_cascade_subcategory:suspicious_person(high-audit cell at HIGH/EMERGENCY \u2014 possible under-classification)"
+        ],
+        "risk_reasons": [
+          "base_risk:MEDIUM"
+        ],
+        "retrieved_record_ids": [
+          "TKT-2024-02046",
+          "TKT-2023-02048",
+          "TKT-2023-07526",
+          "TKT-2022-01624",
+          "TKT-2024-08589",
+          "TKT-2024-03927",
+          "TKT-2023-03527",
+          "TKT-2024-05253"
+        ]
+      },
+      "human_override": null,
+      "final_decision": {
+        "category": "SECURITY",
+        "subcategory": "suspicious_person",
+        "risk_level": "MEDIUM",
+        "dispatched_vendor_id": "v_027",
+        "dispatched_emergency_services": false,
+        "needs_human_review": true,
+        "needs_clarification": false,
+        "confidence_category": 0.9,
+        "confidence_subcategory": 0.9,
+        "validator_reasons": [
+          "trap_cascade_subcategory:suspicious_person(high-audit cell at HIGH/EMERGENCY \u2014 possible under-classification)"
+        ],
+        "risk_reasons": [
+          "base_risk:MEDIUM"
+        ],
+        "retrieved_record_ids": [
+          "TKT-2024-02046",
+          "TKT-2023-02048",
+          "TKT-2023-07526",
+          "TKT-2022-01624",
+          "TKT-2024-08589",
+          "TKT-2024-03927",
+          "TKT-2023-03527",
+          "TKT-2024-05253"
+        ]
+      }
+    },
+    "transcript_id": "EVAL-0468"
+  },
+  {
+    "category": "LIFE_SAFETY",
+    "subcategory": "gas_chemical",
+    "risk_level": "EMERGENCY",
+    "needs_human_review": true,
+    "needs_clarification": false,
+    "building_name": null,
+    "address": null,
+    "floor": "Floor 1",
+    "dispatched_vendor_id": null,
+    "dispatched_emergency_services": true,
+    "call_summary": "Gas or chemical hazard reported at Floor 1. EMERGENCY risk. Emergency services dispatched.",
+    "trainer_log": {
+      "full_transcript": "[AGENT] CBRE facilities, Marcus speaking. How can I help?\n[CALLER] [background: hvac hum] Hey, I smell gas very strongly on Floor 1. Getting a headache.\n[AGENT] Alright. Did you see a container or source?\n[CALLER] Yes, we've cleared the floor.\n[AGENT] Calling emergency services this second and looping in building ops. Hang on the line if it's safe.",
+      "ai_prediction": {
+        "category": "LIFE_SAFETY",
+        "subcategory": "gas_chemical",
+        "risk_level": "EMERGENCY",
+        "dispatched_vendor_id": null,
+        "dispatched_emergency_services": true,
+        "needs_human_review": true,
+        "needs_clarification": false,
+        "confidence_category": 0.95,
+        "confidence_subcategory": 0.95,
+        "validator_reasons": [
+          "emergency_band:always_pause",
+          "emergency_dispatch:gas_chemical:hazard_cue_confirmed"
+        ],
+        "risk_reasons": [
+          "base_risk:EMERGENCY",
+          "hard_cue:gas leak",
+          "capped_at_EMERGENCY:historical_max for subcategory=gas_chemical"
+        ],
+        "retrieved_record_ids": [
+          "TKT-2022-01732",
+          "TKT-2022-09112",
+          "TKT-2023-06872",
+          "TKT-2023-08489",
+          "TKT-2023-07994",
+          "TKT-2023-05168",
+          "TKT-2023-00401",
+          "TKT-2023-01940"
+        ]
+      },
+      "human_override": null,
+      "final_decision": {
+        "category": "LIFE_SAFETY",
+        "subcategory": "gas_chemical",
+        "risk_level": "EMERGENCY",
+        "dispatched_vendor_id": null,
+        "dispatched_emergency_services": true,
+        "needs_human_review": true,
+        "needs_clarification": false,
+        "confidence_category": 0.95,
+        "confidence_subcategory": 0.95,
+        "validator_reasons": [
+          "emergency_band:always_pause",
+          "emergency_dispatch:gas_chemical:hazard_cue_confirmed"
+        ],
+        "risk_reasons": [
+          "base_risk:EMERGENCY",
+          "hard_cue:gas leak",
+          "capped_at_EMERGENCY:historical_max for subcategory=gas_chemical"
+        ],
+        "retrieved_record_ids": [
+          "TKT-2022-01732",
+          "TKT-2022-09112",
+          "TKT-2023-06872",
+          "TKT-2023-08489",
+          "TKT-2023-07994",
+          "TKT-2023-05168",
+          "TKT-2023-00401",
+          "TKT-2023-01940"
+        ]
+      }
+    },
+    "transcript_id": "EVAL-0471"
+  },
+  {
+    "category": "HVAC",
+    "subcategory": "air_quality",
+    "risk_level": "MEDIUM",
+    "needs_human_review": true,
+    "needs_clarification": false,
+    "building_name": "Crossroads Business Park",
+    "address": "3300 Crossroads Pkwy",
+    "floor": "Floor 3",
+    "dispatched_vendor_id": null,
+    "dispatched_emergency_services": false,
+    "call_summary": "Air quality concern reported at Crossroads Business Park, Floor 3. MEDIUM risk. Escalated to human review \u2014 no qualified vendor available.",
+    "trainer_log": {
+      "full_transcript": "[AGENT] CBRE maintenance \u2014 what's going on?\n[CALLER] Sorry, smells like gas but it's actually nail polish remover \u2014 someone's doing their nails at their desk.\n[AGENT] Okay \u2014 can you confirm there's no actual fire or injury right now?\n[CALLER] No, just the smell \u2014 no one's hurt, just annoying.\n[AGENT] Which building, floor, and suite are you in?\n[CALLER] Like, crossroads Business Park, Floor 3, Suite 303.\n[AGENT] I'll get a tech out \u2014 they'll text you when they're heading over.",
+      "ai_prediction": {
+        "category": "HVAC",
+        "subcategory": "air_quality",
+        "risk_level": "MEDIUM",
+        "dispatched_vendor_id": null,
+        "dispatched_emergency_services": false,
+        "needs_human_review": true,
+        "needs_clarification": false,
+        "confidence_category": 0.95,
+        "confidence_subcategory": 0.95,
+        "validator_reasons": [
+          "trap_prone_subcategory:air_quality(over_escalation_rate=19%)"
+        ],
+        "risk_reasons": [
+          "base_risk:MEDIUM"
+        ],
+        "retrieved_record_ids": [
+          "TKT-2023-02570",
+          "TKT-2023-09923",
+          "TKT-2023-01568",
+          "TKT-2024-03399",
+          "TKT-2022-00262",
+          "TKT-2022-00508",
+          "TKT-2023-01151",
+          "TKT-2023-03023"
+        ]
+      },
+      "human_override": null,
+      "final_decision": {
+        "category": "HVAC",
+        "subcategory": "air_quality",
+        "risk_level": "MEDIUM",
+        "dispatched_vendor_id": null,
+        "dispatched_emergency_services": false,
+        "needs_human_review": true,
+        "needs_clarification": false,
+        "confidence_category": 0.95,
+        "confidence_subcategory": 0.95,
+        "validator_reasons": [
+          "trap_prone_subcategory:air_quality(over_escalation_rate=19%)"
+        ],
+        "risk_reasons": [
+          "base_risk:MEDIUM"
+        ],
+        "retrieved_record_ids": [
+          "TKT-2023-02570",
+          "TKT-2023-09923",
+          "TKT-2023-01568",
+          "TKT-2024-03399",
+          "TKT-2022-00262",
+          "TKT-2022-00508",
+          "TKT-2023-01151",
+          "TKT-2023-03023"
+        ]
+      }
+    },
+    "transcript_id": "EVAL-0473"
+  },
+  {
+    "category": "ELEVATOR",
+    "subcategory": "malfunction",
+    "risk_level": "MEDIUM",
+    "needs_human_review": true,
+    "needs_clarification": false,
+    "building_name": "Fremont Tech Hub",
+    "address": "4700 Auto Mall Pkwy",
+    "floor": "Floor 5",
+    "dispatched_vendor_id": "v_017",
+    "dispatched_emergency_services": false,
+    "call_summary": "Equipment malfunction reported at Fremont Tech Hub, Floor 5. MEDIUM risk. Flagged for review. Valley Elevator Service dispatched pending approval.",
+    "trainer_log": {
+      "full_transcript": "[AGENT] CBRE facilities, this is Sam. What's going on?\n[CALLER] Hey, Elevator is just sitting there with the doors open, won't respond to calls.\n[AGENT] Got it. Are the doors stuck open or closed?\n[CALLER] Not moving at all.\n[AGENT] Which building and floor are you at?\n[CALLER] Fremont Tech Hub, Floor 5, Suite 504.\n[AGENT] Alright \u2014 sending a vendor over and giving the PM a heads-up.",
+      "ai_prediction": {
+        "category": "ELEVATOR",
+        "subcategory": "malfunction",
+        "risk_level": "MEDIUM",
+        "dispatched_vendor_id": "v_017",
+        "dispatched_emergency_services": false,
+        "needs_human_review": true,
+        "needs_clarification": false,
+        "confidence_category": 0.9,
+        "confidence_subcategory": 0.9,
+        "validator_reasons": [
+          "trap_cascade_subcategory:malfunction(high-audit cell at HIGH/EMERGENCY \u2014 possible under-classification)"
+        ],
+        "risk_reasons": [
+          "base_risk:MEDIUM"
+        ],
+        "retrieved_record_ids": [
+          "TKT-2022-07741",
+          "TKT-2024-02205",
+          "TKT-2024-01425",
+          "TKT-2024-06018",
+          "TKT-2024-03417",
+          "TKT-2023-07646",
+          "TKT-2022-04444",
+          "TKT-2024-05385"
+        ]
+      },
+      "human_override": null,
+      "final_decision": {
+        "category": "ELEVATOR",
+        "subcategory": "malfunction",
+        "risk_level": "MEDIUM",
+        "dispatched_vendor_id": "v_017",
+        "dispatched_emergency_services": false,
+        "needs_human_review": true,
+        "needs_clarification": false,
+        "confidence_category": 0.9,
+        "confidence_subcategory": 0.9,
+        "validator_reasons": [
+          "trap_cascade_subcategory:malfunction(high-audit cell at HIGH/EMERGENCY \u2014 possible under-classification)"
+        ],
+        "risk_reasons": [
+          "base_risk:MEDIUM"
+        ],
+        "retrieved_record_ids": [
+          "TKT-2022-07741",
+          "TKT-2024-02205",
+          "TKT-2024-01425",
+          "TKT-2024-06018",
+          "TKT-2024-03417",
+          "TKT-2023-07646",
+          "TKT-2022-04444",
+          "TKT-2024-05385"
+        ]
+      }
+    },
+    "transcript_id": "EVAL-0477"
+  },
+  {
+    "category": "PLUMBING",
+    "subcategory": "drainage_backup",
+    "risk_level": "LOW",
+    "needs_human_review": false,
+    "needs_clarification": false,
+    "building_name": "Rancho Del Sol Office Park",
+    "address": "600 Rancho del Sol Dr",
+    "floor": "Floor 2",
+    "dispatched_vendor_id": "v_004",
+    "dispatched_emergency_services": false,
+    "call_summary": "Drainage backup reported at Rancho Del Sol Office Park, Floor 2. LOW risk. Dispatched Regency Commercial Plumbing.",
+    "trainer_log": {
+      "full_transcript": "[AGENT] CBRE maintenance \u2014 what's going on?\n[CALLER] Like, good afternoon, Kitchen sink drain is completely backed up.\n[AGENT] Alright. Is the water overflowing onto the floor?\n[CALLER] Yeah, there's definitely a smell.\n[AGENT] Which building, floor, and suite are you in?\n[CALLER] I mean, rancho Del Sol Office Park, Floor 2, Suite 203.\n[AGENT] Alright, I've put a ticket in \u2014 vendor will swing by during business hours.\n[CALLER] Okay.",
+      "ai_prediction": {
+        "category": "PLUMBING",
+        "subcategory": "drainage_backup",
+        "risk_level": "LOW",
+        "dispatched_vendor_id": "v_004",
+        "dispatched_emergency_services": false,
+        "needs_human_review": false,
+        "needs_clarification": false,
+        "confidence_category": 0.95,
+        "confidence_subcategory": 0.95,
+        "validator_reasons": [
+          "auto_resolve:no_flags_fired"
+        ],
+        "risk_reasons": [
+          "base_risk:LOW"
+        ],
+        "retrieved_record_ids": [
+          "TKT-2023-08162",
+          "TKT-2023-02702",
+          "TKT-2022-03835",
+          "TKT-2023-03428",
+          "TKT-2023-08645",
+          "TKT-2024-03798",
+          "TKT-2023-06320",
+          "TKT-2024-08865"
+        ]
+      },
+      "human_override": null,
+      "final_decision": {
+        "category": "PLUMBING",
+        "subcategory": "drainage_backup",
+        "risk_level": "LOW",
+        "dispatched_vendor_id": "v_004",
+        "dispatched_emergency_services": false,
+        "needs_human_review": false,
+        "needs_clarification": false,
+        "confidence_category": 0.95,
+        "confidence_subcategory": 0.95,
+        "validator_reasons": [
+          "auto_resolve:no_flags_fired"
+        ],
+        "risk_reasons": [
+          "base_risk:LOW"
+        ],
+        "retrieved_record_ids": [
+          "TKT-2023-08162",
+          "TKT-2023-02702",
+          "TKT-2022-03835",
+          "TKT-2023-03428",
+          "TKT-2023-08645",
+          "TKT-2024-03798",
+          "TKT-2023-06320",
+          "TKT-2024-08865"
+        ]
+      }
+    },
+    "transcript_id": "EVAL-0480"
+  },
+  {
+    "category": "GROUNDS_EXTERIOR",
+    "subcategory": "parking_lighting",
+    "risk_level": "LOW",
+    "needs_human_review": false,
+    "needs_clarification": false,
+    "building_name": "Pacific Ridge Medical Plaza",
+    "address": "3200 Pacific Coast Hwy",
+    "floor": "Floor 7",
+    "dispatched_vendor_id": "v_008",
+    "dispatched_emergency_services": false,
+    "call_summary": "Parking area lighting issue reported at Pacific Ridge Medical Plaza, Floor 7. LOW risk. Dispatched Rapid Response Electricians.",
+    "trainer_log": {
+      "full_transcript": "[AGENT] CBRE maintenance line, this is Priya \u2014 what do you need?\n[CALLER] Hold on, it's really dark outside the building.\n[AGENT] Okay, can you describe what you're seeing or smelling?\n[CALLER] The back row is all out.\n[AGENT] How many fixtures are out?\n[CALLER] Two of the lamp posts by the north entrance.\n[AGENT] Where exactly \u2014 which suite?\n[CALLER] Pacific Ridge Medical Plaza, Floor 7, Suite 410.\n[AGENT] Okay, I'll line that up now. Confirmation text will come through shortly.",
+      "ai_prediction": {
+        "category": "GROUNDS_EXTERIOR",
+        "subcategory": "parking_lighting",
+        "risk_level": "LOW",
+        "dispatched_vendor_id": "v_008",
+        "dispatched_emergency_services": false,
+        "needs_human_review": false,
+        "needs_clarification": false,
+        "confidence_category": 0.9,
+        "confidence_subcategory": 0.9,
+        "validator_reasons": [
+          "auto_resolve:no_flags_fired"
+        ],
+        "risk_reasons": [
+          "base_risk:LOW",
+          "sensitive_building:medical",
+          "capped_at_LOW:historical_max for subcategory=parking_lighting"
+        ],
+        "retrieved_record_ids": [
+          "TKT-2022-02446",
+          "TKT-2023-01841",
+          "TKT-2023-01367",
+          "TKT-2024-09657",
+          "TKT-2024-02265",
+          "TKT-2022-10000",
+          "TKT-2024-08781",
+          "TKT-2023-05837"
+        ]
+      },
+      "human_override": null,
+      "final_decision": {
+        "category": "GROUNDS_EXTERIOR",
+        "subcategory": "parking_lighting",
+        "risk_level": "LOW",
+        "dispatched_vendor_id": "v_008",
+        "dispatched_emergency_services": false,
+        "needs_human_review": false,
+        "needs_clarification": false,
+        "confidence_category": 0.9,
+        "confidence_subcategory": 0.9,
+        "validator_reasons": [
+          "auto_resolve:no_flags_fired"
+        ],
+        "risk_reasons": [
+          "base_risk:LOW",
+          "sensitive_building:medical",
+          "capped_at_LOW:historical_max for subcategory=parking_lighting"
+        ],
+        "retrieved_record_ids": [
+          "TKT-2022-02446",
+          "TKT-2023-01841",
+          "TKT-2023-01367",
+          "TKT-2024-09657",
+          "TKT-2024-02265",
+          "TKT-2022-10000",
+          "TKT-2024-08781",
+          "TKT-2023-05837"
+        ]
+      }
+    },
+    "transcript_id": "EVAL-0486"
+  },
+  {
+    "category": "PLUMBING",
+    "subcategory": "restroom_fixture",
+    "risk_level": "LOW",
+    "needs_human_review": false,
+    "needs_clarification": false,
+    "building_name": null,
+    "address": null,
+    "floor": "Floor 2",
+    "dispatched_vendor_id": "v_004",
+    "dispatched_emergency_services": false,
+    "call_summary": "Restroom fixture issue reported at Floor 2. LOW risk. Dispatched Regency Commercial Plumbing.",
+    "trainer_log": {
+      "full_transcript": "[AGENT] CBRE maintenance \u2014 what's going on?\n[CALLER] Toilet in the men's room on Floor 2 in Suite 205 won't stop running.\n[AGENT] Okay, I see. Is it overflowing or just running?\n[CALLER] Floor is still dry for now.\n[AGENT] Hmm, none of our vendors are quite the right fit \u2014 let me bump this up to the on-call PM so they can handle it directly.\n[CALLER] Okay, like, please hurry.",
+      "ai_prediction": {
+        "category": "PLUMBING",
+        "subcategory": "restroom_fixture",
+        "risk_level": "LOW",
+        "dispatched_vendor_id": "v_004",
+        "dispatched_emergency_services": false,
+        "needs_human_review": false,
+        "needs_clarification": false,
+        "confidence_category": 0.95,
+        "confidence_subcategory": 0.95,
+        "validator_reasons": [
+          "auto_resolve:no_flags_fired"
+        ],
+        "risk_reasons": [
+          "base_risk:LOW"
+        ],
+        "retrieved_record_ids": [
+          "TKT-2022-01435",
+          "TKT-2024-09777",
+          "TKT-2024-01917",
+          "TKT-2022-05551",
+          "TKT-2023-03701",
+          "TKT-2022-07780",
+          "TKT-2023-05816",
+          "TKT-2024-08388"
+        ]
+      },
+      "human_override": null,
+      "final_decision": {
+        "category": "PLUMBING",
+        "subcategory": "restroom_fixture",
+        "risk_level": "LOW",
+        "dispatched_vendor_id": "v_004",
+        "dispatched_emergency_services": false,
+        "needs_human_review": false,
+        "needs_clarification": false,
+        "confidence_category": 0.95,
+        "confidence_subcategory": 0.95,
+        "validator_reasons": [
+          "auto_resolve:no_flags_fired"
+        ],
+        "risk_reasons": [
+          "base_risk:LOW"
+        ],
+        "retrieved_record_ids": [
+          "TKT-2022-01435",
+          "TKT-2024-09777",
+          "TKT-2024-01917",
+          "TKT-2022-05551",
+          "TKT-2023-03701",
+          "TKT-2022-07780",
+          "TKT-2023-05816",
+          "TKT-2024-08388"
+        ]
+      }
+    },
+    "transcript_id": "EVAL-0491"
+  },
+  {
+    "category": "HVAC",
+    "subcategory": "refrigerant",
+    "risk_level": "LOW",
+    "needs_human_review": false,
+    "needs_clarification": true,
+    "building_name": "Central Tower",
+    "address": "700 S Grand Ave",
+    "floor": "Floor 27",
+    "dispatched_vendor_id": "v_014",
+    "dispatched_emergency_services": false,
+    "call_summary": "Refrigerant issue reported at Central Tower, Floor 27. LOW risk. Dispatched MediCool HVAC Systems.",
+    "trainer_log": {
+      "full_transcript": "[AGENT] CBRE facilities \u2014 how can I help?\n[CALLER] There's an issue with refrigerant.\n[AGENT] Has the cooling dropped noticeably?\n[CALLER] [muffled voices nearby] Performance dropped a lot since this morning.\n[AGENT] Which building and floor are you at?\n[CALLER] Central Tower, Floor 27, Suite 2708.\n[AGENT] Got it. I'll get someone out as soon as I can \u2014 should hear back within the hour.",
+      "ai_prediction": {
+        "category": "HVAC",
+        "subcategory": "refrigerant",
+        "risk_level": "LOW",
+        "dispatched_vendor_id": "v_014",
+        "dispatched_emergency_services": false,
+        "needs_human_review": false,
+        "needs_clarification": true,
+        "confidence_category": 0.95,
+        "confidence_subcategory": 0.95,
+        "validator_reasons": [
+          "auto_resolve:no_flags_fired"
+        ],
+        "risk_reasons": [
+          "base_risk:LOW"
+        ],
+        "retrieved_record_ids": [
+          "TKT-2022-00328",
+          "TKT-2022-01279",
+          "TKT-2024-04833",
+          "TKT-2023-03905",
+          "TKT-2022-01327",
+          "TKT-2024-04170",
+          "TKT-2024-02958",
+          "TKT-2023-07208"
+        ]
+      },
+      "human_override": null,
+      "final_decision": {
+        "category": "HVAC",
+        "subcategory": "refrigerant",
+        "risk_level": "LOW",
+        "dispatched_vendor_id": "v_014",
+        "dispatched_emergency_services": false,
+        "needs_human_review": false,
+        "needs_clarification": true,
+        "confidence_category": 0.95,
+        "confidence_subcategory": 0.95,
+        "validator_reasons": [
+          "auto_resolve:no_flags_fired"
+        ],
+        "risk_reasons": [
+          "base_risk:LOW"
+        ],
+        "retrieved_record_ids": [
+          "TKT-2022-00328",
+          "TKT-2022-01279",
+          "TKT-2024-04833",
+          "TKT-2023-03905",
+          "TKT-2022-01327",
+          "TKT-2024-04170",
+          "TKT-2024-02958",
+          "TKT-2023-07208"
+        ]
+      }
+    },
+    "transcript_id": "EVAL-0492"
+  },
+  {
+    "category": "LIFE_SAFETY",
+    "subcategory": "gas_chemical",
+    "risk_level": "EMERGENCY",
+    "needs_human_review": true,
+    "needs_clarification": false,
+    "building_name": "Rancho Del Sol Office Park",
+    "address": "600 Rancho del Sol Dr",
+    "floor": "Floor 3",
+    "dispatched_vendor_id": null,
+    "dispatched_emergency_services": true,
+    "call_summary": "Gas or chemical hazard reported at Rancho Del Sol Office Park, Floor 3. EMERGENCY risk. Emergency services dispatched.",
+    "trainer_log": {
+      "full_transcript": "[AGENT] CBRE maintenance line, what do you need?\n[CALLER] Good afternoon, Something smells like rotten eggs, people are feeling sick.\n[AGENT] Mhm. Did you see a container or source?\n[CALLER] I saw a small bottle on its side.\n[AGENT] Can you tell me the building, floor, and suite?\n[CALLER] Rancho Del Sol Office Park, Floor 3, Suite 302.\n[AGENT] Can you describe the smell?\n[CALLER] Yes, we've cleared the floor.\n[AGENT] Dialing 911 now and pushing a vendor out at the same time.\n[CALLER] Thanks, bye.",
+      "ai_prediction": {
+        "category": "LIFE_SAFETY",
+        "subcategory": "gas_chemical",
+        "risk_level": "EMERGENCY",
+        "dispatched_vendor_id": null,
+        "dispatched_emergency_services": true,
+        "needs_human_review": true,
+        "needs_clarification": false,
+        "confidence_category": 0.95,
+        "confidence_subcategory": 0.95,
+        "validator_reasons": [
+          "emergency_band:always_pause",
+          "emergency_dispatch:gas_chemical:hazard_cue_confirmed"
+        ],
+        "risk_reasons": [
+          "base_risk:EMERGENCY",
+          "hard_cue:people trapped",
+          "capped_at_EMERGENCY:historical_max for subcategory=gas_chemical"
+        ],
+        "retrieved_record_ids": [
+          "TKT-2022-04555",
+          "TKT-2024-04020",
+          "TKT-2023-03950",
+          "TKT-2024-03792",
+          "TKT-2022-09499",
+          "TKT-2024-07848",
+          "TKT-2022-01438",
+          "TKT-2022-00538"
+        ]
+      },
+      "human_override": null,
+      "final_decision": {
+        "category": "LIFE_SAFETY",
+        "subcategory": "gas_chemical",
+        "risk_level": "EMERGENCY",
+        "dispatched_vendor_id": null,
+        "dispatched_emergency_services": true,
+        "needs_human_review": true,
+        "needs_clarification": false,
+        "confidence_category": 0.95,
+        "confidence_subcategory": 0.95,
+        "validator_reasons": [
+          "emergency_band:always_pause",
+          "emergency_dispatch:gas_chemical:hazard_cue_confirmed"
+        ],
+        "risk_reasons": [
+          "base_risk:EMERGENCY",
+          "hard_cue:people trapped",
+          "capped_at_EMERGENCY:historical_max for subcategory=gas_chemical"
+        ],
+        "retrieved_record_ids": [
+          "TKT-2022-04555",
+          "TKT-2024-04020",
+          "TKT-2023-03950",
+          "TKT-2024-03792",
+          "TKT-2022-09499",
+          "TKT-2024-07848",
+          "TKT-2022-01438",
+          "TKT-2022-00538"
+        ]
+      }
+    },
+    "transcript_id": "EVAL-0496"
+  },
+  {
+    "category": "HVAC",
+    "subcategory": "air_quality",
+    "risk_level": "MEDIUM",
+    "needs_human_review": true,
+    "needs_clarification": false,
+    "building_name": "Brookfield Retail Center",
+    "address": "2200 Brookfield Rd",
+    "floor": "Floor 2",
+    "dispatched_vendor_id": "v_012",
+    "dispatched_emergency_services": false,
+    "call_summary": "Air quality concern reported at Brookfield Retail Center, Floor 2. MEDIUM risk. Flagged for review. Pacific HVAC Services dispatched pending approval.",
+    "trainer_log": {
+      "full_transcript": "[AGENT] CBRE facilities, this is Sam. What's going on?\n[CALLER] Good morning, Musty smell and I think I see mold.\n[AGENT] Okay, I see. Is anyone feeling sick?\n[CALLER] Kind of chemical, sharp.\n[AGENT] Can you confirm the building and floor?\n[CALLER] Brookfield Retail Center, Floor 2, Suite 205.\n[AGENT] Sending a tech your way now. You'll hear from them en route.",
+      "ai_prediction": {
+        "category": "HVAC",
+        "subcategory": "air_quality",
+        "risk_level": "MEDIUM",
+        "dispatched_vendor_id": "v_012",
+        "dispatched_emergency_services": false,
+        "needs_human_review": true,
+        "needs_clarification": false,
+        "confidence_category": 0.95,
+        "confidence_subcategory": 0.95,
+        "validator_reasons": [
+          "trap_prone_subcategory:air_quality(over_escalation_rate=19%)"
+        ],
+        "risk_reasons": [
+          "base_risk:MEDIUM"
+        ],
+        "retrieved_record_ids": [
+          "TKT-2023-04004",
+          "TKT-2023-08717",
+          "TKT-2023-06251",
+          "TKT-2024-00762",
+          "TKT-2024-09060",
+          "TKT-2023-06722",
+          "TKT-2023-02885",
+          "TKT-2023-02927"
+        ]
+      },
+      "human_override": null,
+      "final_decision": {
+        "category": "HVAC",
+        "subcategory": "air_quality",
+        "risk_level": "MEDIUM",
+        "dispatched_vendor_id": "v_012",
+        "dispatched_emergency_services": false,
+        "needs_human_review": true,
+        "needs_clarification": false,
+        "confidence_category": 0.95,
+        "confidence_subcategory": 0.95,
+        "validator_reasons": [
+          "trap_prone_subcategory:air_quality(over_escalation_rate=19%)"
+        ],
+        "risk_reasons": [
+          "base_risk:MEDIUM"
+        ],
+        "retrieved_record_ids": [
+          "TKT-2023-04004",
+          "TKT-2023-08717",
+          "TKT-2023-06251",
+          "TKT-2024-00762",
+          "TKT-2024-09060",
+          "TKT-2023-06722",
+          "TKT-2023-02885",
+          "TKT-2023-02927"
+        ]
+      }
+    },
+    "transcript_id": "EVAL-0504"
+  },
+  {
+    "category": "GROUNDS_EXTERIOR",
+    "subcategory": "signage_fencing",
+    "risk_level": "LOW",
+    "needs_human_review": false,
+    "needs_clarification": false,
+    "building_name": "Olive Garden Business Center",
+    "address": "1400 Olive Ave",
+    "floor": "Floor 5",
+    "dispatched_vendor_id": "v_029",
+    "dispatched_emergency_services": false,
+    "call_summary": "Signage/fencing issue reported at Olive Garden Business Center, Floor 5. LOW risk. Dispatched Golden State Exterior Maintenance.",
+    "trainer_log": {
+      "full_transcript": "[AGENT] CBRE maintenance \u2014 what's going on?\n[CALLER] Sorry, something outside fell over, looks bad.\n[AGENT] Okay, can you describe what you're seeing or smelling?\n[CALLER] Not blocking anything but it looks bad.\n[AGENT] Could it fall and hurt someone?\n[CALLER] The sign is propped up but could fall.\n[AGENT] Which building and floor are you at?\n[CALLER] Olive Garden Business Center, Floor 5, Suite 505.\n[AGENT] Got it. I'll get someone out as soon as I can \u2014 should hear back within the hour.",
+      "ai_prediction": {
+        "category": "GROUNDS_EXTERIOR",
+        "subcategory": "signage_fencing",
+        "risk_level": "LOW",
+        "dispatched_vendor_id": "v_029",
+        "dispatched_emergency_services": false,
+        "needs_human_review": false,
+        "needs_clarification": false,
+        "confidence_category": 0.95,
+        "confidence_subcategory": 0.95,
+        "validator_reasons": [
+          "auto_resolve:no_flags_fired"
+        ],
+        "risk_reasons": [
+          "base_risk:LOW"
+        ],
+        "retrieved_record_ids": [
+          "TKT-2023-01055",
+          "TKT-2023-01409",
+          "TKT-2022-00103",
+          "TKT-2023-07331",
+          "TKT-2024-03438",
+          "TKT-2023-08894",
+          "TKT-2023-01010",
+          "TKT-2024-07887"
+        ]
+      },
+      "human_override": null,
+      "final_decision": {
+        "category": "GROUNDS_EXTERIOR",
+        "subcategory": "signage_fencing",
+        "risk_level": "LOW",
+        "dispatched_vendor_id": "v_029",
+        "dispatched_emergency_services": false,
+        "needs_human_review": false,
+        "needs_clarification": false,
+        "confidence_category": 0.95,
+        "confidence_subcategory": 0.95,
+        "validator_reasons": [
+          "auto_resolve:no_flags_fired"
+        ],
+        "risk_reasons": [
+          "base_risk:LOW"
+        ],
+        "retrieved_record_ids": [
+          "TKT-2023-01055",
+          "TKT-2023-01409",
+          "TKT-2022-00103",
+          "TKT-2023-07331",
+          "TKT-2024-03438",
+          "TKT-2023-08894",
+          "TKT-2023-01010",
+          "TKT-2024-07887"
+        ]
+      }
+    },
+    "transcript_id": "EVAL-0505"
+  },
+  {
+    "category": "LIFE_SAFETY",
+    "subcategory": "fire_smoke",
+    "risk_level": "EMERGENCY",
+    "needs_human_review": true,
+    "needs_clarification": false,
+    "building_name": "Lakewood Plaza",
+    "address": "550 Lakewood Center Mall",
+    "floor": "Floor 4",
+    "dispatched_vendor_id": null,
+    "dispatched_emergency_services": true,
+    "call_summary": "Fire/smoke detected reported at Lakewood Plaza, Floor 4. EMERGENCY risk. Emergency services dispatched.",
+    "trainer_log": {
+      "full_transcript": "[AGENT] CBRE maintenance line, this is Priya \u2014 what do you need?\n[CALLER] Alarm went off and I see some haze.\n[AGENT] Okay, can you describe what you're seeing or smelling?\n[CALLER] Like, yes, people are out.\n[AGENT] Is anyone trapped?\n[CALLER] I mean, i see flames in the trash can.\n[AGENT] Can you confirm the building and floor?\n[CALLER] Lakewood Plaza, sorry, Floor 4, Suite 406.\n[AGENT] Calling 911 and getting a vendor rolling \u2014 both happening now.",
+      "ai_prediction": {
+        "category": "LIFE_SAFETY",
+        "subcategory": "fire_smoke",
+        "risk_level": "EMERGENCY",
+        "dispatched_vendor_id": null,
+        "dispatched_emergency_services": true,
+        "needs_human_review": true,
+        "needs_clarification": false,
+        "confidence_category": 0.95,
+        "confidence_subcategory": 0.95,
+        "validator_reasons": [
+          "emergency_band:always_pause",
+          "emergency_dispatch:fire_smoke:hazard_cue_confirmed"
+        ],
+        "risk_reasons": [
+          "base_risk:EMERGENCY",
+          "hard_cue:fire",
+          "capped_at_EMERGENCY:historical_max for subcategory=fire_smoke"
+        ],
+        "retrieved_record_ids": [
+          "TKT-2023-06413",
+          "TKT-2024-09942",
+          "TKT-2024-03225",
+          "TKT-2022-00514",
+          "TKT-2023-07523",
+          "TKT-2023-02654",
+          "TKT-2022-05671",
+          "TKT-2023-08669"
+        ]
+      },
+      "human_override": null,
+      "final_decision": {
+        "category": "LIFE_SAFETY",
+        "subcategory": "fire_smoke",
+        "risk_level": "EMERGENCY",
+        "dispatched_vendor_id": null,
+        "dispatched_emergency_services": true,
+        "needs_human_review": true,
+        "needs_clarification": false,
+        "confidence_category": 0.95,
+        "confidence_subcategory": 0.95,
+        "validator_reasons": [
+          "emergency_band:always_pause",
+          "emergency_dispatch:fire_smoke:hazard_cue_confirmed"
+        ],
+        "risk_reasons": [
+          "base_risk:EMERGENCY",
+          "hard_cue:fire",
+          "capped_at_EMERGENCY:historical_max for subcategory=fire_smoke"
+        ],
+        "retrieved_record_ids": [
+          "TKT-2023-06413",
+          "TKT-2024-09942",
+          "TKT-2024-03225",
+          "TKT-2022-00514",
+          "TKT-2023-07523",
+          "TKT-2023-02654",
+          "TKT-2022-05671",
+          "TKT-2023-08669"
+        ]
+      }
+    },
+    "transcript_id": "EVAL-0506"
+  },
+  {
+    "category": "PLUMBING",
+    "subcategory": "roof_leak",
+    "risk_level": "MEDIUM",
+    "needs_human_review": true,
+    "needs_clarification": false,
+    "building_name": "Meridian Business Park",
+    "address": "1500 Meridian Ave",
+    "floor": "Floor 2",
+    "dispatched_vendor_id": "v_005",
+    "dispatched_emergency_services": false,
+    "call_summary": "Roof leak reported at Meridian Business Park, Floor 2. MEDIUM risk. Flagged for review. Bayside Roofing Co dispatched pending approval.",
+    "trainer_log": {
+      "full_transcript": "[AGENT] CBRE facilities, Marcus speaking. How can I help?\n[CALLER] I mean, something's dripping from up top.\n[AGENT] Okay, can you describe what you're seeing or smelling?\n[CALLER] It's a steady drip, I've got a bucket under it.\n[AGENT] Is the ceiling sagging?\n[CALLER] Yeah, it's been pouring for like an hour.\n[AGENT] Where exactly \u2014 which suite?\n[CALLER] Like, meridian Business Park, Floor 2, Suite 201.\n[AGENT] Sending a tech your way now. You'll hear from them en route.",
+      "ai_prediction": {
+        "category": "PLUMBING",
+        "subcategory": "roof_leak",
+        "risk_level": "MEDIUM",
+        "dispatched_vendor_id": "v_005",
+        "dispatched_emergency_services": false,
+        "needs_human_review": true,
+        "needs_clarification": false,
+        "confidence_category": 0.95,
+        "confidence_subcategory": 0.95,
+        "validator_reasons": [
+          "trap_cascade_subcategory:roof_leak(high-audit cell at HIGH/EMERGENCY \u2014 possible under-classification)"
+        ],
+        "risk_reasons": [
+          "base_risk:MEDIUM"
+        ],
+        "retrieved_record_ids": [
+          "TKT-2022-05638",
+          "TKT-2022-08299",
+          "TKT-2024-09768",
+          "TKT-2024-07929",
+          "TKT-2023-06353",
+          "TKT-2024-05037",
+          "TKT-2022-06217",
+          "TKT-2022-04045"
+        ]
+      },
+      "human_override": null,
+      "final_decision": {
+        "category": "PLUMBING",
+        "subcategory": "roof_leak",
+        "risk_level": "MEDIUM",
+        "dispatched_vendor_id": "v_005",
+        "dispatched_emergency_services": false,
+        "needs_human_review": true,
+        "needs_clarification": false,
+        "confidence_category": 0.95,
+        "confidence_subcategory": 0.95,
+        "validator_reasons": [
+          "trap_cascade_subcategory:roof_leak(high-audit cell at HIGH/EMERGENCY \u2014 possible under-classification)"
+        ],
+        "risk_reasons": [
+          "base_risk:MEDIUM"
+        ],
+        "retrieved_record_ids": [
+          "TKT-2022-05638",
+          "TKT-2022-08299",
+          "TKT-2024-09768",
+          "TKT-2024-07929",
+          "TKT-2023-06353",
+          "TKT-2024-05037",
+          "TKT-2022-06217",
+          "TKT-2022-04045"
+        ]
+      }
+    },
+    "transcript_id": "EVAL-0510"
+  },
+  {
+    "category": "ELEVATOR",
+    "subcategory": "minor_issue",
+    "risk_level": "LOW",
+    "needs_human_review": false,
+    "needs_clarification": true,
+    "building_name": "Heritage Square Office Park",
+    "address": "1000 Heritage Sq Dr",
+    "floor": "Floor 1",
+    "dispatched_vendor_id": "v_016",
+    "dispatched_emergency_services": false,
+    "call_summary": "Minor maintenance issue reported at Heritage Square Office Park, Floor 1. LOW risk. Dispatched Skyline Elevator Co.",
+    "trainer_log": {
+      "full_transcript": "[AGENT] CBRE dispatch \u2014 go ahead.\n[CALLER] The elevator on Floor 7 isn't leveling properly at our floor.\n[AGENT] I want to make sure I have the right location \u2014 Heritage Square Office Park only has 5 floors. Can you confirm the floor?\n[CALLER] Oh sorry \u2014 I meant Floor 1. I'm a little flustered.\n[AGENT] Got it. I'll get someone out as soon as I can \u2014 should hear back within the hour.",
+      "ai_prediction": {
+        "category": "ELEVATOR",
+        "subcategory": "minor_issue",
+        "risk_level": "LOW",
+        "dispatched_vendor_id": "v_016",
+        "dispatched_emergency_services": false,
+        "needs_human_review": false,
+        "needs_clarification": true,
+        "confidence_category": 0.9,
+        "confidence_subcategory": 0.9,
+        "validator_reasons": [
+          "auto_resolve:no_flags_fired"
+        ],
+        "risk_reasons": [
+          "base_risk:LOW"
+        ],
+        "retrieved_record_ids": [
+          "TKT-2024-08505",
+          "TKT-2022-05380",
+          "TKT-2023-04187",
+          "TKT-2023-06341",
+          "TKT-2024-02934",
+          "TKT-2023-01847",
+          "TKT-2024-03555",
+          "TKT-2023-09011"
+        ]
+      },
+      "human_override": null,
+      "final_decision": {
+        "category": "ELEVATOR",
+        "subcategory": "minor_issue",
+        "risk_level": "LOW",
+        "dispatched_vendor_id": "v_016",
+        "dispatched_emergency_services": false,
+        "needs_human_review": false,
+        "needs_clarification": true,
+        "confidence_category": 0.9,
+        "confidence_subcategory": 0.9,
+        "validator_reasons": [
+          "auto_resolve:no_flags_fired"
+        ],
+        "risk_reasons": [
+          "base_risk:LOW"
+        ],
+        "retrieved_record_ids": [
+          "TKT-2024-08505",
+          "TKT-2022-05380",
+          "TKT-2023-04187",
+          "TKT-2023-06341",
+          "TKT-2024-02934",
+          "TKT-2023-01847",
+          "TKT-2024-03555",
+          "TKT-2023-09011"
+        ]
+      }
+    },
+    "transcript_id": "EVAL-0511"
+  },
+  {
+    "category": "SECURITY",
+    "subcategory": "suspicious_person",
+    "risk_level": "MEDIUM",
+    "needs_human_review": true,
+    "needs_clarification": false,
+    "building_name": "Shoreline Tech Campus",
+    "address": "2500 Shoreline Blvd",
+    "floor": "Floor 4",
+    "dispatched_vendor_id": "v_027",
+    "dispatched_emergency_services": false,
+    "call_summary": "Suspicious person reported reported at Shoreline Tech Campus, Floor 4. MEDIUM risk. Flagged for review. Elite Protective Services dispatched pending approval.",
+    "trainer_log": {
+      "full_transcript": "[AGENT] CBRE facilities, Marcus speaking. How can I help?\n[CALLER] You know, hi there, Someone has been hanging around for over an hour, watching people enter.\n[AGENT] Got it. Can you describe them?\n[CALLER] He's just standing there, not doing anything overt.\n[AGENT] Where exactly \u2014 which suite?\n[CALLER] Shoreline Tech Campus, Floor 4, Suite 405.\n[AGENT] Alright \u2014 sending a vendor over and giving the PM a heads-up.\n[CALLER] Okay, thanks.",
+      "ai_prediction": {
+        "category": "SECURITY",
+        "subcategory": "suspicious_person",
+        "risk_level": "MEDIUM",
+        "dispatched_vendor_id": "v_027",
+        "dispatched_emergency_services": false,
+        "needs_human_review": true,
+        "needs_clarification": false,
+        "confidence_category": 0.95,
+        "confidence_subcategory": 0.95,
+        "validator_reasons": [
+          "trap_cascade_subcategory:suspicious_person(high-audit cell at HIGH/EMERGENCY \u2014 possible under-classification)"
+        ],
+        "risk_reasons": [
+          "base_risk:MEDIUM"
+        ],
+        "retrieved_record_ids": [
+          "TKT-2023-07253",
+          "TKT-2024-07572",
+          "TKT-2024-06630",
+          "TKT-2022-05947",
+          "TKT-2024-06153",
+          "TKT-2022-09928",
+          "TKT-2023-03797",
+          "TKT-2022-04957"
+        ]
+      },
+      "human_override": null,
+      "final_decision": {
+        "category": "SECURITY",
+        "subcategory": "suspicious_person",
+        "risk_level": "MEDIUM",
+        "dispatched_vendor_id": "v_027",
+        "dispatched_emergency_services": false,
+        "needs_human_review": true,
+        "needs_clarification": false,
+        "confidence_category": 0.95,
+        "confidence_subcategory": 0.95,
+        "validator_reasons": [
+          "trap_cascade_subcategory:suspicious_person(high-audit cell at HIGH/EMERGENCY \u2014 possible under-classification)"
+        ],
+        "risk_reasons": [
+          "base_risk:MEDIUM"
+        ],
+        "retrieved_record_ids": [
+          "TKT-2023-07253",
+          "TKT-2024-07572",
+          "TKT-2024-06630",
+          "TKT-2022-05947",
+          "TKT-2024-06153",
+          "TKT-2022-09928",
+          "TKT-2023-03797",
+          "TKT-2022-04957"
+        ]
+      }
+    },
+    "transcript_id": "EVAL-0517"
+  },
+  {
+    "category": "ELECTRICAL",
+    "subcategory": "lighting",
+    "risk_level": "LOW",
+    "needs_human_review": false,
+    "needs_clarification": true,
+    "building_name": "Westpark Professional Center",
+    "address": "700 Westpark Dr",
+    "floor": "Floor 1",
+    "dispatched_vendor_id": "v_010",
+    "dispatched_emergency_services": false,
+    "call_summary": "Lighting failure reported at Westpark Professional Center, Floor 1. LOW risk. Dispatched All-Site Facilities Co.",
+    "trainer_log": {
+      "full_transcript": "[AGENT] CBRE maintenance line, what do you need?\n[CALLER] There's an issue with lighting.\n[AGENT] Is it one fixture or multiple?\n[CALLER] Flickering, kind of strobing.\n[AGENT] Can you confirm the building and floor?\n[CALLER] Westpark Professional Center, Floor 1, Suite 108.\n[AGENT] Okay, ticket's logged. Someone'll come out during business hours.",
+      "ai_prediction": {
+        "category": "ELECTRICAL",
+        "subcategory": "lighting",
+        "risk_level": "LOW",
+        "dispatched_vendor_id": "v_010",
+        "dispatched_emergency_services": false,
+        "needs_human_review": false,
+        "needs_clarification": true,
+        "confidence_category": 0.9,
+        "confidence_subcategory": 0.9,
+        "validator_reasons": [
+          "auto_resolve:no_flags_fired"
+        ],
+        "risk_reasons": [
+          "base_risk:LOW"
+        ],
+        "retrieved_record_ids": [
+          "TKT-2022-06409",
+          "TKT-2024-05280",
+          "TKT-2023-04085",
+          "TKT-2022-04633",
+          "TKT-2023-07454",
+          "TKT-2023-04493",
+          "TKT-2024-03345",
+          "TKT-2022-00652"
+        ]
+      },
+      "human_override": null,
+      "final_decision": {
+        "category": "ELECTRICAL",
+        "subcategory": "lighting",
+        "risk_level": "LOW",
+        "dispatched_vendor_id": "v_010",
+        "dispatched_emergency_services": false,
+        "needs_human_review": false,
+        "needs_clarification": true,
+        "confidence_category": 0.9,
+        "confidence_subcategory": 0.9,
+        "validator_reasons": [
+          "auto_resolve:no_flags_fired"
+        ],
+        "risk_reasons": [
+          "base_risk:LOW"
+        ],
+        "retrieved_record_ids": [
+          "TKT-2022-06409",
+          "TKT-2024-05280",
+          "TKT-2023-04085",
+          "TKT-2022-04633",
+          "TKT-2023-07454",
+          "TKT-2023-04493",
+          "TKT-2024-03345",
+          "TKT-2022-00652"
+        ]
+      }
+    },
+    "transcript_id": "EVAL-0518"
+  },
+  {
+    "category": "LIFE_SAFETY",
+    "subcategory": "slip_trip",
+    "risk_level": "LOW",
+    "needs_human_review": false,
+    "needs_clarification": false,
+    "building_name": "Crossroads Business Park",
+    "address": "3300 Crossroads Pkwy",
+    "floor": "Floor 4",
+    "dispatched_vendor_id": "v_025",
+    "dispatched_emergency_services": false,
+    "call_summary": "Slip/trip hazard reported at Crossroads Business Park, Floor 4. LOW risk. Dispatched ProClean Facility Services.",
+    "trainer_log": {
+      "full_transcript": "[AGENT] CBRE facilities, Marcus speaking. How can I help?\n[CALLER] Good morning, hold on, Ice on the sidewalk outside the main entrance.\n[AGENT] Okay, I see. Is the area blocked off?\n[CALLER] Yeah, we set up a cone.\n[AGENT] Which building and floor are you at?\n[CALLER] Crossroads Business Park, like, Floor 4, Suite 304.\n[AGENT] I'm not seeing anyone in the pool who fully covers this \u2014 I'll escalate to the on-call PM to route manually.\n[CALLER] Okay, please hurry.",
+      "ai_prediction": {
+        "category": "LIFE_SAFETY",
+        "subcategory": "slip_trip",
+        "risk_level": "LOW",
+        "dispatched_vendor_id": "v_025",
+        "dispatched_emergency_services": false,
+        "needs_human_review": false,
+        "needs_clarification": false,
+        "confidence_category": 0.95,
+        "confidence_subcategory": 0.95,
+        "validator_reasons": [
+          "auto_resolve:no_flags_fired"
+        ],
+        "risk_reasons": [
+          "base_risk:LOW"
+        ],
+        "retrieved_record_ids": [
+          "TKT-2023-06509",
+          "TKT-2023-05726",
+          "TKT-2024-08586",
+          "TKT-2022-05908",
+          "TKT-2023-09332",
+          "TKT-2023-06692",
+          "TKT-2023-08279",
+          "TKT-2024-09372"
+        ]
+      },
+      "human_override": null,
+      "final_decision": {
+        "category": "LIFE_SAFETY",
+        "subcategory": "slip_trip",
+        "risk_level": "LOW",
+        "dispatched_vendor_id": "v_025",
+        "dispatched_emergency_services": false,
+        "needs_human_review": false,
+        "needs_clarification": false,
+        "confidence_category": 0.95,
+        "confidence_subcategory": 0.95,
+        "validator_reasons": [
+          "auto_resolve:no_flags_fired"
+        ],
+        "risk_reasons": [
+          "base_risk:LOW"
+        ],
+        "retrieved_record_ids": [
+          "TKT-2023-06509",
+          "TKT-2023-05726",
+          "TKT-2024-08586",
+          "TKT-2022-05908",
+          "TKT-2023-09332",
+          "TKT-2023-06692",
+          "TKT-2023-08279",
+          "TKT-2024-09372"
+        ]
+      }
+    },
+    "transcript_id": "EVAL-0528"
+  },
+  {
+    "category": "ELECTRICAL",
+    "subcategory": "power_outage",
+    "risk_level": "HIGH",
+    "needs_human_review": true,
+    "needs_clarification": false,
+    "building_name": "Olive Garden Business Center",
+    "address": "1400 Olive Ave",
+    "floor": "Floor 2",
+    "dispatched_vendor_id": "v_008",
+    "dispatched_emergency_services": false,
+    "call_summary": "Power outage reported at Olive Garden Business Center, Floor 2. HIGH risk. Flagged for review. Rapid Response Electricians dispatched pending approval.",
+    "trainer_log": {
+      "full_transcript": "[AGENT] Hi, CBRE facilities. What can I do for you?\n[CALLER] Uh, our stuff isn't turning on.\n[AGENT] Okay, can you describe what you're seeing or smelling?\n[CALLER] Whole floor, all the lights and outlets.\n[AGENT] Is it the whole floor or just your suite?\n[CALLER] Emergency lights came on, yeah.\n[AGENT] What's your building, floor, suite?\n[CALLER] Olive Garden Business Center, Floor 2.\n[AGENT] I'll get a vendor rolling and let the property manager know.",
+      "ai_prediction": {
+        "category": "ELECTRICAL",
+        "subcategory": "power_outage",
+        "risk_level": "HIGH",
+        "dispatched_vendor_id": "v_008",
+        "dispatched_emergency_services": false,
+        "needs_human_review": true,
+        "needs_clarification": false,
+        "confidence_category": 0.9,
+        "confidence_subcategory": 0.9,
+        "validator_reasons": [
+          "high_band:always_pause"
+        ],
+        "risk_reasons": [
+          "base_risk:HIGH"
+        ],
+        "retrieved_record_ids": [
+          "TKT-2022-02182",
+          "TKT-2022-00649",
+          "TKT-2023-07733",
+          "TKT-2022-07882",
+          "TKT-2024-01965",
+          "TKT-2023-07601",
+          "TKT-2024-01536",
+          "TKT-2024-00681"
+        ]
+      },
+      "human_override": null,
+      "final_decision": {
+        "category": "ELECTRICAL",
+        "subcategory": "power_outage",
+        "risk_level": "HIGH",
+        "dispatched_vendor_id": "v_008",
+        "dispatched_emergency_services": false,
+        "needs_human_review": true,
+        "needs_clarification": false,
+        "confidence_category": 0.9,
+        "confidence_subcategory": 0.9,
+        "validator_reasons": [
+          "high_band:always_pause"
+        ],
+        "risk_reasons": [
+          "base_risk:HIGH"
+        ],
+        "retrieved_record_ids": [
+          "TKT-2022-02182",
+          "TKT-2022-00649",
+          "TKT-2023-07733",
+          "TKT-2022-07882",
+          "TKT-2024-01965",
+          "TKT-2023-07601",
+          "TKT-2024-01536",
+          "TKT-2024-00681"
+        ]
+      }
+    },
+    "transcript_id": "EVAL-0529"
+  },
+  {
+    "category": "HVAC",
+    "subcategory": "controls_bms",
+    "risk_level": "LOW",
+    "needs_human_review": false,
+    "needs_clarification": false,
+    "building_name": "Tower One at Tech Park",
+    "address": "3000 Innovation Way",
+    "floor": "Floor 15",
+    "dispatched_vendor_id": "v_013",
+    "dispatched_emergency_services": false,
+    "call_summary": "Building controls issue reported at Tower One at Tech Park, Floor 15. LOW risk. Dispatched CoolZone HVAC.",
+    "trainer_log": {
+      "full_transcript": "[AGENT] CBRE maintenance line, what do you need?\n[CALLER] Can't change the temp on Floor 15, uh, thermostat screen is frozen.\n[AGENT] Got it. Is the thermostat display blank or showing something?\n[CALLER] Says 'zone 4 comm loss' or something.\n[AGENT] Okay, ticket's logged. Someone'll come out during business hours.\n[AGENT] I'm not seeing anyone in the pool who fully covers this \u2014 I'll escalate to the on-call PM to route manually.\n[CALLER] Okay, please hurry.",
+      "ai_prediction": {
+        "category": "HVAC",
+        "subcategory": "controls_bms",
+        "risk_level": "LOW",
+        "dispatched_vendor_id": "v_013",
+        "dispatched_emergency_services": false,
+        "needs_human_review": false,
+        "needs_clarification": false,
+        "confidence_category": 0.9,
+        "confidence_subcategory": 0.9,
+        "validator_reasons": [
+          "auto_resolve:no_flags_fired"
+        ],
+        "risk_reasons": [
+          "base_risk:LOW"
+        ],
+        "retrieved_record_ids": [
+          "TKT-2024-01731",
+          "TKT-2024-04464",
+          "TKT-2023-09260",
+          "TKT-2022-00958",
+          "TKT-2023-01295",
+          "TKT-2024-02217",
+          "TKT-2022-09271",
+          "TKT-2024-07695"
+        ]
+      },
+      "human_override": null,
+      "final_decision": {
+        "category": "HVAC",
+        "subcategory": "controls_bms",
+        "risk_level": "LOW",
+        "dispatched_vendor_id": "v_013",
+        "dispatched_emergency_services": false,
+        "needs_human_review": false,
+        "needs_clarification": false,
+        "confidence_category": 0.9,
+        "confidence_subcategory": 0.9,
+        "validator_reasons": [
+          "auto_resolve:no_flags_fired"
+        ],
+        "risk_reasons": [
+          "base_risk:LOW"
+        ],
+        "retrieved_record_ids": [
+          "TKT-2024-01731",
+          "TKT-2024-04464",
+          "TKT-2023-09260",
+          "TKT-2022-00958",
+          "TKT-2023-01295",
+          "TKT-2024-02217",
+          "TKT-2022-09271",
+          "TKT-2024-07695"
+        ]
+      }
+    },
+    "transcript_id": "EVAL-0534"
+  },
+  {
+    "category": "JANITORIAL",
+    "subcategory": "waste_odor",
+    "risk_level": "LOW",
+    "needs_human_review": false,
+    "needs_clarification": false,
+    "building_name": null,
+    "address": null,
+    "floor": "Floor 1",
+    "dispatched_vendor_id": "v_023",
+    "dispatched_emergency_services": false,
+    "call_summary": "Waste/odor issue reported at Floor 1. LOW risk. Dispatched Sparkle Commercial Cleaning.",
+    "trainer_log": {
+      "full_transcript": "[AGENT] CBRE facilities \u2014 how can I help?\n[CALLER] Hi there, Bad garbage smell in the hallway on Floor 1 in Suite 106 outside the main trash.\n[AGENT] Okay, I see. How bad is the smell?\n[CALLER] Just near the breakroom.\n[AGENT] I'll send a vendor out and loop in the PM.\n[AGENT] Hmm, none of our vendors are quite the right fit \u2014 let me bump this up to the on-call PM so they can handle it directly.\n[CALLER] Uh, okay, please hurry.",
+      "ai_prediction": {
+        "category": "JANITORIAL",
+        "subcategory": "waste_odor",
+        "risk_level": "LOW",
+        "dispatched_vendor_id": "v_023",
+        "dispatched_emergency_services": false,
+        "needs_human_review": false,
+        "needs_clarification": false,
+        "confidence_category": 0.95,
+        "confidence_subcategory": 0.95,
+        "validator_reasons": [
+          "auto_resolve:no_flags_fired"
+        ],
+        "risk_reasons": [
+          "base_risk:LOW"
+        ],
+        "retrieved_record_ids": [
+          "TKT-2024-00477",
+          "TKT-2022-03841",
+          "TKT-2023-06731",
+          "TKT-2022-00820",
+          "TKT-2022-09856",
+          "TKT-2022-02917",
+          "TKT-2024-04812",
+          "TKT-2024-01218"
+        ]
+      },
+      "human_override": null,
+      "final_decision": {
+        "category": "JANITORIAL",
+        "subcategory": "waste_odor",
+        "risk_level": "LOW",
+        "dispatched_vendor_id": "v_023",
+        "dispatched_emergency_services": false,
+        "needs_human_review": false,
+        "needs_clarification": false,
+        "confidence_category": 0.95,
+        "confidence_subcategory": 0.95,
+        "validator_reasons": [
+          "auto_resolve:no_flags_fired"
+        ],
+        "risk_reasons": [
+          "base_risk:LOW"
+        ],
+        "retrieved_record_ids": [
+          "TKT-2024-00477",
+          "TKT-2022-03841",
+          "TKT-2023-06731",
+          "TKT-2022-00820",
+          "TKT-2022-09856",
+          "TKT-2022-02917",
+          "TKT-2024-04812",
+          "TKT-2024-01218"
+        ]
+      }
+    },
+    "transcript_id": "EVAL-0546"
+  },
+  {
+    "category": "SECURITY",
+    "subcategory": "suspicious_person",
+    "risk_level": "MEDIUM",
+    "needs_human_review": true,
+    "needs_clarification": false,
+    "building_name": "Summit Office Towers",
+    "address": "800 Summit Blvd",
+    "floor": "Floor 12",
+    "dispatched_vendor_id": "v_027",
+    "dispatched_emergency_services": false,
+    "call_summary": "Suspicious person reported reported at Summit Office Towers, Floor 12. MEDIUM risk. Flagged for review. Elite Protective Services dispatched pending approval.",
+    "trainer_log": {
+      "full_transcript": "[AGENT] CBRE maintenance, this is Dana. What's going on?\n[CALLER] Hello, Guy on Floor 12 in Suite 1204 asking employees for their badge numbers \u2014 something's off.\n[AGENT] Alright. Are they still there?\n[CALLER] He's just standing there, not doing anything overt.\n[AGENT] I'll send a vendor out and loop in the PM.",
+      "ai_prediction": {
+        "category": "SECURITY",
+        "subcategory": "suspicious_person",
+        "risk_level": "MEDIUM",
+        "dispatched_vendor_id": "v_027",
+        "dispatched_emergency_services": false,
+        "needs_human_review": true,
+        "needs_clarification": false,
+        "confidence_category": 0.95,
+        "confidence_subcategory": 0.95,
+        "validator_reasons": [
+          "trap_cascade_subcategory:suspicious_person(high-audit cell at HIGH/EMERGENCY \u2014 possible under-classification)"
+        ],
+        "risk_reasons": [
+          "base_risk:MEDIUM"
+        ],
+        "retrieved_record_ids": [
+          "TKT-2024-07068",
+          "TKT-2022-02512",
+          "TKT-2023-01982",
+          "TKT-2024-03681",
+          "TKT-2024-01191",
+          "TKT-2023-06764",
+          "TKT-2024-02919",
+          "TKT-2024-08940"
+        ]
+      },
+      "human_override": null,
+      "final_decision": {
+        "category": "SECURITY",
+        "subcategory": "suspicious_person",
+        "risk_level": "MEDIUM",
+        "dispatched_vendor_id": "v_027",
+        "dispatched_emergency_services": false,
+        "needs_human_review": true,
+        "needs_clarification": false,
+        "confidence_category": 0.95,
+        "confidence_subcategory": 0.95,
+        "validator_reasons": [
+          "trap_cascade_subcategory:suspicious_person(high-audit cell at HIGH/EMERGENCY \u2014 possible under-classification)"
+        ],
+        "risk_reasons": [
+          "base_risk:MEDIUM"
+        ],
+        "retrieved_record_ids": [
+          "TKT-2024-07068",
+          "TKT-2022-02512",
+          "TKT-2023-01982",
+          "TKT-2024-03681",
+          "TKT-2024-01191",
+          "TKT-2023-06764",
+          "TKT-2024-02919",
+          "TKT-2024-08940"
+        ]
+      }
+    },
+    "transcript_id": "EVAL-0551"
+  },
+  {
+    "category": "JANITORIAL",
+    "subcategory": "carpet_floor",
+    "risk_level": "LOW",
+    "needs_human_review": false,
+    "needs_clarification": false,
+    "building_name": "Eastlake Medical Plaza",
+    "address": "820 Eastlake Pkwy",
+    "floor": "Floor 4",
+    "dispatched_vendor_id": "v_025",
+    "dispatched_emergency_services": false,
+    "call_summary": "Carpet/flooring damage reported at Eastlake Medical Plaza, Floor 4. LOW risk. Dispatched ProClean Facility Services.",
+    "trainer_log": {
+      "full_transcript": "[AGENT] CBRE maintenance \u2014 what's going on?\n[CALLER] Hi, Stain on the lobby floor, spilled drink.\n[AGENT] Understood. What was spilled?\n[CALLER] Uh, yeah, like a large iced coffee.\n[AGENT] Which building and floor are you at?\n[CALLER] Eastlake Medical Plaza, Floor 4, Suite 304.\n[AGENT] Got it. I'll get someone out as soon as I can \u2014 should hear back within the hour.",
+      "ai_prediction": {
+        "category": "JANITORIAL",
+        "subcategory": "carpet_floor",
+        "risk_level": "LOW",
+        "dispatched_vendor_id": "v_025",
+        "dispatched_emergency_services": false,
+        "needs_human_review": false,
+        "needs_clarification": false,
+        "confidence_category": 0.9,
+        "confidence_subcategory": 0.9,
+        "validator_reasons": [
+          "auto_resolve:no_flags_fired"
+        ],
+        "risk_reasons": [
+          "base_risk:LOW",
+          "sensitive_building:medical",
+          "capped_at_LOW:historical_max for subcategory=carpet_floor"
+        ],
+        "retrieved_record_ids": [
+          "TKT-2023-03194",
+          "TKT-2023-07988",
+          "TKT-2022-08071",
+          "TKT-2023-04334",
+          "TKT-2024-06957",
+          "TKT-2023-01628",
+          "TKT-2023-08789",
+          "TKT-2022-02509"
+        ]
+      },
+      "human_override": null,
+      "final_decision": {
+        "category": "JANITORIAL",
+        "subcategory": "carpet_floor",
+        "risk_level": "LOW",
+        "dispatched_vendor_id": "v_025",
+        "dispatched_emergency_services": false,
+        "needs_human_review": false,
+        "needs_clarification": false,
+        "confidence_category": 0.9,
+        "confidence_subcategory": 0.9,
+        "validator_reasons": [
+          "auto_resolve:no_flags_fired"
+        ],
+        "risk_reasons": [
+          "base_risk:LOW",
+          "sensitive_building:medical",
+          "capped_at_LOW:historical_max for subcategory=carpet_floor"
+        ],
+        "retrieved_record_ids": [
+          "TKT-2023-03194",
+          "TKT-2023-07988",
+          "TKT-2022-08071",
+          "TKT-2023-04334",
+          "TKT-2024-06957",
+          "TKT-2023-01628",
+          "TKT-2023-08789",
+          "TKT-2022-02509"
+        ]
+      }
+    },
+    "transcript_id": "EVAL-0566"
+  },
+  {
+    "category": "ELECTRICAL",
+    "subcategory": "low_voltage_data",
+    "risk_level": "LOW",
+    "needs_human_review": false,
+    "needs_clarification": false,
+    "building_name": "Golden State Towers",
+    "address": "900 Golden State Blvd",
+    "floor": "Floor 1",
+    "dispatched_vendor_id": "v_011",
+    "dispatched_emergency_services": false,
+    "call_summary": "Low-voltage/data issue reported at Golden State Towers, Floor 1. LOW risk. Dispatched NetCom Low-Voltage Tech.",
+    "trainer_log": {
+      "full_transcript": "[AGENT] CBRE dispatch \u2014 go ahead.\n[CALLER] Computers are down, but the lights work.\n[AGENT] Okay, can you describe what you're seeing or smelling?\n[CALLER] Uh, internet and phones both dead.\n[AGENT] Is it just network or also phones?\n[CALLER] Uh, internet and phones both dead.\n[AGENT] Which building and floor are you at?\n[CALLER] Golden State Towers, Floor 1, Suite 106.\n[AGENT] Got it. I'll get someone out as soon as I can \u2014 should hear back within the hour.",
+      "ai_prediction": {
+        "category": "ELECTRICAL",
+        "subcategory": "low_voltage_data",
+        "risk_level": "LOW",
+        "dispatched_vendor_id": "v_011",
+        "dispatched_emergency_services": false,
+        "needs_human_review": false,
+        "needs_clarification": false,
+        "confidence_category": 0.95,
+        "confidence_subcategory": 0.95,
+        "validator_reasons": [
+          "auto_resolve:no_flags_fired"
+        ],
+        "risk_reasons": [
+          "base_risk:LOW"
+        ],
+        "retrieved_record_ids": [
+          "TKT-2022-05269",
+          "TKT-2022-08032",
+          "TKT-2024-00351",
+          "TKT-2024-02487",
+          "TKT-2023-02441",
+          "TKT-2024-06066",
+          "TKT-2024-09603",
+          "TKT-2022-06562"
+        ]
+      },
+      "human_override": null,
+      "final_decision": {
+        "category": "ELECTRICAL",
+        "subcategory": "low_voltage_data",
+        "risk_level": "LOW",
+        "dispatched_vendor_id": "v_011",
+        "dispatched_emergency_services": false,
+        "needs_human_review": false,
+        "needs_clarification": false,
+        "confidence_category": 0.95,
+        "confidence_subcategory": 0.95,
+        "validator_reasons": [
+          "auto_resolve:no_flags_fired"
+        ],
+        "risk_reasons": [
+          "base_risk:LOW"
+        ],
+        "retrieved_record_ids": [
+          "TKT-2022-05269",
+          "TKT-2022-08032",
+          "TKT-2024-00351",
+          "TKT-2024-02487",
+          "TKT-2023-02441",
+          "TKT-2024-06066",
+          "TKT-2024-09603",
+          "TKT-2022-06562"
+        ]
+      }
+    },
+    "transcript_id": "EVAL-0571"
+  },
+  {
+    "category": "ELEVATOR",
+    "subcategory": "malfunction",
+    "risk_level": "MEDIUM",
+    "needs_human_review": true,
+    "needs_clarification": false,
+    "building_name": "Lakewood Plaza",
+    "address": "550 Lakewood Center Mall",
+    "floor": "Floor 1",
+    "dispatched_vendor_id": "v_016",
+    "dispatched_emergency_services": false,
+    "call_summary": "Equipment malfunction reported at Lakewood Plaza, Floor 1. MEDIUM risk. Flagged for review. Skyline Elevator Co dispatched pending approval.",
+    "trainer_log": {
+      "full_transcript": "[AGENT] CBRE facilities, Marcus speaking. How can I help?\n[CALLER] The elevator's doing something weird.\n[AGENT] Okay, can you describe what you're seeing or smelling?\n[CALLER] Probably fine but sounds awful.\n[AGENT] Is it still safe to use?\n[CALLER] Hold on, been like this for two days now.\n[AGENT] Can you confirm the building and floor?\n[CALLER] Lakewood Plaza, um, Floor 1, Suite 112.\n[AGENT] Okay, ticket's logged. Someone'll come out during business hours.",
+      "ai_prediction": {
+        "category": "ELEVATOR",
+        "subcategory": "malfunction",
+        "risk_level": "MEDIUM",
+        "dispatched_vendor_id": "v_016",
+        "dispatched_emergency_services": false,
+        "needs_human_review": true,
+        "needs_clarification": false,
+        "confidence_category": 0.9,
+        "confidence_subcategory": 0.9,
+        "validator_reasons": [
+          "trap_cascade_subcategory:malfunction(high-audit cell at HIGH/EMERGENCY \u2014 possible under-classification)"
+        ],
+        "risk_reasons": [
+          "base_risk:MEDIUM"
+        ],
+        "retrieved_record_ids": [
+          "TKT-2023-06152",
+          "TKT-2022-02146",
+          "TKT-2022-08215",
+          "TKT-2022-06760",
+          "TKT-2024-06393",
+          "TKT-2022-09670",
+          "TKT-2022-02008",
+          "TKT-2024-09897"
+        ]
+      },
+      "human_override": null,
+      "final_decision": {
+        "category": "ELEVATOR",
+        "subcategory": "malfunction",
+        "risk_level": "MEDIUM",
+        "dispatched_vendor_id": "v_016",
+        "dispatched_emergency_services": false,
+        "needs_human_review": true,
+        "needs_clarification": false,
+        "confidence_category": 0.9,
+        "confidence_subcategory": 0.9,
+        "validator_reasons": [
+          "trap_cascade_subcategory:malfunction(high-audit cell at HIGH/EMERGENCY \u2014 possible under-classification)"
+        ],
+        "risk_reasons": [
+          "base_risk:MEDIUM"
+        ],
+        "retrieved_record_ids": [
+          "TKT-2023-06152",
+          "TKT-2022-02146",
+          "TKT-2022-08215",
+          "TKT-2022-06760",
+          "TKT-2024-06393",
+          "TKT-2022-09670",
+          "TKT-2022-02008",
+          "TKT-2024-09897"
+        ]
+      }
+    },
+    "transcript_id": "EVAL-0586"
+  },
+  {
+    "category": "ELEVATOR",
+    "subcategory": "malfunction",
+    "risk_level": "MEDIUM",
+    "needs_human_review": true,
+    "needs_clarification": false,
+    "building_name": "Palm Court Offices",
+    "address": "420 Palm Ave",
+    "floor": "Floor 1",
+    "dispatched_vendor_id": "v_016",
+    "dispatched_emergency_services": false,
+    "call_summary": "Equipment malfunction reported at Palm Court Offices, Floor 1. MEDIUM risk. Flagged for review. Skyline Elevator Co dispatched pending approval.",
+    "trainer_log": {
+      "full_transcript": "[AGENT] CBRE facilities, Marcus speaking. How can I help?\n[CALLER] Elevator on Floor 1 is stuck on the ground floor, nobody was in it.\n[AGENT] Can you confirm the building and floor?\n[CALLER] I mean, palm Court Offices, Floor 1.\n[AGENT] Alright \u2014 sending a vendor over and giving the PM a heads-up.",
+      "ai_prediction": {
+        "category": "ELEVATOR",
+        "subcategory": "malfunction",
+        "risk_level": "MEDIUM",
+        "dispatched_vendor_id": "v_016",
+        "dispatched_emergency_services": false,
+        "needs_human_review": true,
+        "needs_clarification": false,
+        "confidence_category": 0.95,
+        "confidence_subcategory": 0.95,
+        "validator_reasons": [
+          "trap_cascade_subcategory:malfunction(high-audit cell at HIGH/EMERGENCY \u2014 possible under-classification)"
+        ],
+        "risk_reasons": [
+          "base_risk:MEDIUM"
+        ],
+        "retrieved_record_ids": [
+          "TKT-2023-03455",
+          "TKT-2023-01697",
+          "TKT-2022-03541",
+          "TKT-2022-03121",
+          "TKT-2022-01663",
+          "TKT-2022-08311",
+          "TKT-2022-08062",
+          "TKT-2022-03091"
+        ]
+      },
+      "human_override": null,
+      "final_decision": {
+        "category": "ELEVATOR",
+        "subcategory": "malfunction",
+        "risk_level": "MEDIUM",
+        "dispatched_vendor_id": "v_016",
+        "dispatched_emergency_services": false,
+        "needs_human_review": true,
+        "needs_clarification": false,
+        "confidence_category": 0.95,
+        "confidence_subcategory": 0.95,
+        "validator_reasons": [
+          "trap_cascade_subcategory:malfunction(high-audit cell at HIGH/EMERGENCY \u2014 possible under-classification)"
+        ],
+        "risk_reasons": [
+          "base_risk:MEDIUM"
+        ],
+        "retrieved_record_ids": [
+          "TKT-2023-03455",
+          "TKT-2023-01697",
+          "TKT-2022-03541",
+          "TKT-2022-03121",
+          "TKT-2022-01663",
+          "TKT-2022-08311",
+          "TKT-2022-08062",
+          "TKT-2022-03091"
+        ]
+      }
+    },
+    "transcript_id": "EVAL-0588"
+  },
+  {
+    "category": "JANITORIAL",
+    "subcategory": "waste_odor",
+    "risk_level": "LOW",
+    "needs_human_review": false,
+    "needs_clarification": false,
+    "building_name": "Oakwood Corporate Campus - Building A",
+    "address": "400 Oakwood Pkwy",
+    "floor": "Floor 8",
+    "dispatched_vendor_id": "v_024",
+    "dispatched_emergency_services": false,
+    "call_summary": "Waste/odor issue reported at Oakwood Corporate Campus - Building A, Floor 8. LOW risk. Dispatched Bay Area Cleaning Solutions.",
+    "trainer_log": {
+      "full_transcript": "[AGENT] CBRE maintenance, this is Dana. What's going on?\n[CALLER] Hearing scratching in the walls \u2014 I think we have rodents.\n[AGENT] Got it. Any evidence of droppings or nesting?\n[CALLER] I mean, hmm, actually \u2014 I don't think it's rodents. Trash hasn't been emptied and that's probably the smell.\n[AGENT] Got it \u2014 updating the ticket. How bad is the smell?\n[CALLER] I mean, just near the breakroom.\n[AGENT] Which building, floor, and suite are you in?\n[CALLER] Oakwood Corporate Campus - Building A, Floor 8, Suite 804.\n[AGENT] Alright, I've put a ticket in \u2014 vendor will swing by during business hours.",
+      "ai_prediction": {
+        "category": "JANITORIAL",
+        "subcategory": "waste_odor",
+        "risk_level": "LOW",
+        "dispatched_vendor_id": "v_024",
+        "dispatched_emergency_services": false,
+        "needs_human_review": false,
+        "needs_clarification": false,
+        "confidence_category": 0.95,
+        "confidence_subcategory": 0.95,
+        "validator_reasons": [
+          "auto_resolve:no_flags_fired"
+        ],
+        "risk_reasons": [
+          "base_risk:LOW"
+        ],
+        "retrieved_record_ids": [
+          "TKT-2024-00141",
+          "TKT-2022-04771",
+          "TKT-2023-01829",
+          "TKT-2022-06445",
+          "TKT-2024-03531",
+          "TKT-2024-09000",
+          "TKT-2022-06466",
+          "TKT-2023-06161"
+        ]
+      },
+      "human_override": null,
+      "final_decision": {
+        "category": "JANITORIAL",
+        "subcategory": "waste_odor",
+        "risk_level": "LOW",
+        "dispatched_vendor_id": "v_024",
+        "dispatched_emergency_services": false,
+        "needs_human_review": false,
+        "needs_clarification": false,
+        "confidence_category": 0.95,
+        "confidence_subcategory": 0.95,
+        "validator_reasons": [
+          "auto_resolve:no_flags_fired"
+        ],
+        "risk_reasons": [
+          "base_risk:LOW"
+        ],
+        "retrieved_record_ids": [
+          "TKT-2024-00141",
+          "TKT-2022-04771",
+          "TKT-2023-01829",
+          "TKT-2022-06445",
+          "TKT-2024-03531",
+          "TKT-2024-09000",
+          "TKT-2022-06466",
+          "TKT-2023-06161"
+        ]
+      }
+    },
+    "transcript_id": "EVAL-0593"
+  },
+  {
+    "category": "PLUMBING",
+    "subcategory": "drainage_backup",
+    "risk_level": "LOW",
+    "needs_human_review": false,
+    "needs_clarification": false,
+    "building_name": "Summit Office Towers",
+    "address": "800 Summit Blvd",
+    "floor": "Floor 8",
+    "dispatched_vendor_id": "v_002",
+    "dispatched_emergency_services": false,
+    "call_summary": "Drainage backup reported at Summit Office Towers, Floor 8. LOW risk. Dispatched Metro Drain & Pipe.",
+    "trainer_log": {
+      "full_transcript": "[AGENT] Maintenance, what's the situation?\n[CALLER] Slow leak under the breakroom sink; the cabinet is getting wet.\n[AGENT] Got it. How large is the leak \u2014 dripping or pouring?\n[CALLER] No wait \u2014 sorry, it's not a pipe. The floor drain is backing up, that's what's wet.\n[AGENT] Got it \u2014 updating the ticket. Is the water overflowing onto the floor?\n[CALLER] Water's coming up on the floor tiles.\n[AGENT] What's your building, floor, suite?\n[CALLER] Summit Office Towers, Floor 8.\n[AGENT] Okay, I'll line that up now. Confirmation text will come through shortly.",
+      "ai_prediction": {
+        "category": "PLUMBING",
+        "subcategory": "drainage_backup",
+        "risk_level": "LOW",
+        "dispatched_vendor_id": "v_002",
+        "dispatched_emergency_services": false,
+        "needs_human_review": false,
+        "needs_clarification": false,
+        "confidence_category": 0.95,
+        "confidence_subcategory": 0.95,
+        "validator_reasons": [
+          "auto_resolve:no_flags_fired"
+        ],
+        "risk_reasons": [
+          "base_risk:LOW"
+        ],
+        "retrieved_record_ids": [
+          "TKT-2024-07881",
+          "TKT-2022-06937",
+          "TKT-2022-07528",
+          "TKT-2022-02944",
+          "TKT-2023-03062",
+          "TKT-2022-00895",
+          "TKT-2024-05148",
+          "TKT-2023-07136"
+        ]
+      },
+      "human_override": null,
+      "final_decision": {
+        "category": "PLUMBING",
+        "subcategory": "drainage_backup",
+        "risk_level": "LOW",
+        "dispatched_vendor_id": "v_002",
+        "dispatched_emergency_services": false,
+        "needs_human_review": false,
+        "needs_clarification": false,
+        "confidence_category": 0.95,
+        "confidence_subcategory": 0.95,
+        "validator_reasons": [
+          "auto_resolve:no_flags_fired"
+        ],
+        "risk_reasons": [
+          "base_risk:LOW"
+        ],
+        "retrieved_record_ids": [
+          "TKT-2024-07881",
+          "TKT-2022-06937",
+          "TKT-2022-07528",
+          "TKT-2022-02944",
+          "TKT-2023-03062",
+          "TKT-2022-00895",
+          "TKT-2024-05148",
+          "TKT-2023-07136"
+        ]
+      }
+    },
+    "transcript_id": "EVAL-0595"
+  },
+  {
+    "category": "GROUNDS_EXTERIOR",
+    "subcategory": "parking_lighting",
+    "risk_level": "LOW",
+    "needs_human_review": false,
+    "needs_clarification": true,
+    "building_name": "Lakeview Executive Suites",
+    "address": "180 Lakeview Dr",
+    "floor": "Floor 4",
+    "dispatched_vendor_id": "v_008",
+    "dispatched_emergency_services": false,
+    "call_summary": "Parking area lighting issue reported at Lakeview Executive Suites, Floor 4. LOW risk. Dispatched Rapid Response Electricians.",
+    "trainer_log": {
+      "full_transcript": "[AGENT] CBRE dispatch, talk to me.\n[CALLER] There's an issue with parking lighting.\n[AGENT] Is it the whole lot or one area?\n[CALLER] Like, the back row is all out.\n[AGENT] Where exactly \u2014 which suite?\n[CALLER] Lakeview Executive Suites, like, Floor 4, Suite 408.\n[AGENT] Okay, I'll line that up now. Confirmation text will come through shortly.",
+      "ai_prediction": {
+        "category": "GROUNDS_EXTERIOR",
+        "subcategory": "parking_lighting",
+        "risk_level": "LOW",
+        "dispatched_vendor_id": "v_008",
+        "dispatched_emergency_services": false,
+        "needs_human_review": false,
+        "needs_clarification": true,
+        "confidence_category": 0.95,
+        "confidence_subcategory": 0.95,
+        "validator_reasons": [
+          "auto_resolve:no_flags_fired"
+        ],
+        "risk_reasons": [
+          "base_risk:LOW"
+        ],
+        "retrieved_record_ids": [
+          "TKT-2024-09243",
+          "TKT-2024-00300",
+          "TKT-2023-00662",
+          "TKT-2023-05243",
+          "TKT-2022-04672",
+          "TKT-2024-09885",
+          "TKT-2023-02879",
+          "TKT-2024-00252"
+        ]
+      },
+      "human_override": null,
+      "final_decision": {
+        "category": "GROUNDS_EXTERIOR",
+        "subcategory": "parking_lighting",
+        "risk_level": "LOW",
+        "dispatched_vendor_id": "v_008",
+        "dispatched_emergency_services": false,
+        "needs_human_review": false,
+        "needs_clarification": true,
+        "confidence_category": 0.95,
+        "confidence_subcategory": 0.95,
+        "validator_reasons": [
+          "auto_resolve:no_flags_fired"
+        ],
+        "risk_reasons": [
+          "base_risk:LOW"
+        ],
+        "retrieved_record_ids": [
+          "TKT-2024-09243",
+          "TKT-2024-00300",
+          "TKT-2023-00662",
+          "TKT-2023-05243",
+          "TKT-2022-04672",
+          "TKT-2024-09885",
+          "TKT-2023-02879",
+          "TKT-2024-00252"
+        ]
+      }
+    },
+    "transcript_id": "EVAL-0600"
+  },
+  {
+    "category": "LIFE_SAFETY",
+    "subcategory": "slip_trip",
+    "risk_level": "LOW",
+    "needs_human_review": false,
+    "needs_clarification": false,
+    "building_name": "Airport Business Center",
+    "address": "9200 Airport Blvd",
+    "floor": "Floor 7",
+    "dispatched_vendor_id": "v_023",
+    "dispatched_emergency_services": false,
+    "call_summary": "Slip/trip hazard reported at Airport Business Center, Floor 7. LOW risk. Dispatched Sparkle Commercial Cleaning.",
+    "trainer_log": {
+      "full_transcript": "[AGENT] CBRE facilities, this is Sam. What's going on?\n[CALLER] Hi there, Wet floor at Airport Business Center on Floor 7, no signs, someone already slipped.\n[AGENT] Got it. Has anyone fallen?\n[CALLER] No one's fallen yet.\n[AGENT] Okay, ticket's logged. Someone'll come out during business hours.",
+      "ai_prediction": {
+        "category": "LIFE_SAFETY",
+        "subcategory": "slip_trip",
+        "risk_level": "LOW",
+        "dispatched_vendor_id": "v_023",
+        "dispatched_emergency_services": false,
+        "needs_human_review": false,
+        "needs_clarification": false,
+        "confidence_category": 0.95,
+        "confidence_subcategory": 0.95,
+        "validator_reasons": [
+          "auto_resolve:no_flags_fired"
+        ],
+        "risk_reasons": [
+          "base_risk:LOW"
+        ],
+        "retrieved_record_ids": [
+          "TKT-2024-00162",
+          "TKT-2023-05261",
+          "TKT-2022-02479",
+          "TKT-2024-08001",
+          "TKT-2022-06247",
+          "TKT-2024-07200",
+          "TKT-2023-04583",
+          "TKT-2023-04979"
+        ]
+      },
+      "human_override": null,
+      "final_decision": {
+        "category": "LIFE_SAFETY",
+        "subcategory": "slip_trip",
+        "risk_level": "LOW",
+        "dispatched_vendor_id": "v_023",
+        "dispatched_emergency_services": false,
+        "needs_human_review": false,
+        "needs_clarification": false,
+        "confidence_category": 0.95,
+        "confidence_subcategory": 0.95,
+        "validator_reasons": [
+          "auto_resolve:no_flags_fired"
+        ],
+        "risk_reasons": [
+          "base_risk:LOW"
+        ],
+        "retrieved_record_ids": [
+          "TKT-2024-00162",
+          "TKT-2023-05261",
+          "TKT-2022-02479",
+          "TKT-2024-08001",
+          "TKT-2022-06247",
+          "TKT-2024-07200",
+          "TKT-2023-04583",
+          "TKT-2023-04979"
+        ]
+      }
+    },
+    "transcript_id": "EVAL-0606"
+  },
+  {
+    "category": "ELEVATOR",
+    "subcategory": "malfunction",
+    "risk_level": "MEDIUM",
+    "needs_human_review": true,
+    "needs_clarification": false,
+    "building_name": "Downtown Parking Garage",
+    "address": "200 Main St",
+    "floor": "Floor 1",
+    "dispatched_vendor_id": "v_016",
+    "dispatched_emergency_services": false,
+    "call_summary": "Equipment malfunction reported at Downtown Parking Garage, Floor 1. MEDIUM risk. Flagged for review. Skyline Elevator Co dispatched pending approval.",
+    "trainer_log": {
+      "full_transcript": "[AGENT] CBRE maintenance line, what do you need?\n[CALLER] Main elevator doors keep opening and closing on their own, empty.\n[AGENT] Okay, I see. Is the car moving at all?\n[CALLER] Doors open, car hasn't left the lobby.\n[AGENT] Which building and floor are you at?\n[CALLER] Downtown Parking Garage, Floor 1.\n[AGENT] Sending a tech your way now. You'll hear from them en route.\n[CALLER] Okay.",
+      "ai_prediction": {
+        "category": "ELEVATOR",
+        "subcategory": "malfunction",
+        "risk_level": "MEDIUM",
+        "dispatched_vendor_id": "v_016",
+        "dispatched_emergency_services": false,
+        "needs_human_review": true,
+        "needs_clarification": false,
+        "confidence_category": 0.95,
+        "confidence_subcategory": 0.95,
+        "validator_reasons": [
+          "trap_cascade_subcategory:malfunction(high-audit cell at HIGH/EMERGENCY \u2014 possible under-classification)"
+        ],
+        "risk_reasons": [
+          "base_risk:MEDIUM"
+        ],
+        "retrieved_record_ids": [
+          "TKT-2023-05363",
+          "TKT-2024-05592",
+          "TKT-2022-03259",
+          "TKT-2024-01521",
+          "TKT-2022-09742",
+          "TKT-2024-03288",
+          "TKT-2024-05385",
+          "TKT-2022-09205"
+        ]
+      },
+      "human_override": null,
+      "final_decision": {
+        "category": "ELEVATOR",
+        "subcategory": "malfunction",
+        "risk_level": "MEDIUM",
+        "dispatched_vendor_id": "v_016",
+        "dispatched_emergency_services": false,
+        "needs_human_review": true,
+        "needs_clarification": false,
+        "confidence_category": 0.95,
+        "confidence_subcategory": 0.95,
+        "validator_reasons": [
+          "trap_cascade_subcategory:malfunction(high-audit cell at HIGH/EMERGENCY \u2014 possible under-classification)"
+        ],
+        "risk_reasons": [
+          "base_risk:MEDIUM"
+        ],
+        "retrieved_record_ids": [
+          "TKT-2023-05363",
+          "TKT-2024-05592",
+          "TKT-2022-03259",
+          "TKT-2024-01521",
+          "TKT-2022-09742",
+          "TKT-2024-03288",
+          "TKT-2024-05385",
+          "TKT-2022-09205"
+        ]
+      }
+    },
+    "transcript_id": "EVAL-0607"
+  },
+  {
+    "category": "PEST_SPECIALTY",
+    "subcategory": "appliance_kitchen",
+    "risk_level": "LOW",
+    "needs_human_review": false,
+    "needs_clarification": false,
+    "building_name": "Civic Center Tower",
+    "address": "300 Civic Center Dr",
+    "floor": "Floor 14",
+    "dispatched_vendor_id": "v_032",
+    "dispatched_emergency_services": false,
+    "call_summary": "Kitchen appliance issue reported at Civic Center Tower, Floor 14. LOW risk. Dispatched QuickFix Appliance Tech.",
+    "trainer_log": {
+      "full_transcript": "[AGENT] CBRE facilities, Marcus speaking. How can I help?\n[CALLER] Good afternoon, Coffee machine is broken, leaking all over the counter.\n[AGENT] Okay, I see. Which appliance?\n[CALLER] Sorry, couple of days now.\n[AGENT] Where exactly \u2014 which suite?\n[CALLER] Civic Center Tower, Floor 14, Suite 1404.\n[AGENT] Okay, ticket's logged. Someone'll come out during business hours.",
+      "ai_prediction": {
+        "category": "PEST_SPECIALTY",
+        "subcategory": "appliance_kitchen",
+        "risk_level": "LOW",
+        "dispatched_vendor_id": "v_032",
+        "dispatched_emergency_services": false,
+        "needs_human_review": false,
+        "needs_clarification": false,
+        "confidence_category": 0.9,
+        "confidence_subcategory": 0.9,
+        "validator_reasons": [
+          "auto_resolve:no_flags_fired"
+        ],
+        "risk_reasons": [
+          "base_risk:LOW"
+        ],
+        "retrieved_record_ids": [
+          "TKT-2024-01230",
+          "TKT-2022-02257",
+          "TKT-2023-00542",
+          "TKT-2022-08629",
+          "TKT-2024-03855",
+          "TKT-2022-06616",
+          "TKT-2024-01419",
+          "TKT-2022-05758"
+        ]
+      },
+      "human_override": null,
+      "final_decision": {
+        "category": "PEST_SPECIALTY",
+        "subcategory": "appliance_kitchen",
+        "risk_level": "LOW",
+        "dispatched_vendor_id": "v_032",
+        "dispatched_emergency_services": false,
+        "needs_human_review": false,
+        "needs_clarification": false,
+        "confidence_category": 0.9,
+        "confidence_subcategory": 0.9,
+        "validator_reasons": [
+          "auto_resolve:no_flags_fired"
+        ],
+        "risk_reasons": [
+          "base_risk:LOW"
+        ],
+        "retrieved_record_ids": [
+          "TKT-2024-01230",
+          "TKT-2022-02257",
+          "TKT-2023-00542",
+          "TKT-2022-08629",
+          "TKT-2024-03855",
+          "TKT-2022-06616",
+          "TKT-2024-01419",
+          "TKT-2022-05758"
+        ]
+      }
+    },
+    "transcript_id": "EVAL-0617"
+  },
+  {
+    "category": "HVAC",
+    "subcategory": "no_cooling",
+    "risk_level": "LOW",
+    "needs_human_review": false,
+    "needs_clarification": false,
+    "building_name": "Harbor Point Tower",
+    "address": "250 Harbor Dr",
+    "floor": "Floor 7",
+    "dispatched_vendor_id": "v_014",
+    "dispatched_emergency_services": false,
+    "call_summary": "No cooling reported at Harbor Point Tower, Floor 7. LOW risk. Dispatched MediCool HVAC Systems.",
+    "trainer_log": {
+      "full_transcript": "[AGENT] CBRE facilities \u2014 how can I help?\n[CALLER] The AC is acting funny \u2014 not broken exactly, hold on, just weird.\n[AGENT] Okay, can you describe what you're seeing or smelling?\n[CALLER] You know, still running but not cold.\n[AGENT] Is the unit still running?\n[CALLER] Performance dropped a lot since this morning.\n[AGENT] Can you confirm the building and floor?\n[CALLER] Harbor Point Tower, Floor 7, Suite 708.\n[AGENT] Alright, I've put a ticket in \u2014 vendor will swing by during business hours.",
+      "ai_prediction": {
+        "category": "HVAC",
+        "subcategory": "no_cooling",
+        "risk_level": "LOW",
+        "dispatched_vendor_id": "v_014",
+        "dispatched_emergency_services": false,
+        "needs_human_review": false,
+        "needs_clarification": false,
+        "confidence_category": 0.95,
+        "confidence_subcategory": 0.95,
+        "validator_reasons": [
+          "auto_resolve:no_flags_fired"
+        ],
+        "risk_reasons": [
+          "base_risk:LOW"
+        ],
+        "retrieved_record_ids": [
+          "TKT-2022-03334",
+          "TKT-2023-01706",
+          "TKT-2024-07581",
+          "TKT-2023-03902",
+          "TKT-2022-04249",
+          "TKT-2024-00480",
+          "TKT-2022-00511",
+          "TKT-2022-02545"
+        ]
+      },
+      "human_override": null,
+      "final_decision": {
+        "category": "HVAC",
+        "subcategory": "no_cooling",
+        "risk_level": "LOW",
+        "dispatched_vendor_id": "v_014",
+        "dispatched_emergency_services": false,
+        "needs_human_review": false,
+        "needs_clarification": false,
+        "confidence_category": 0.95,
+        "confidence_subcategory": 0.95,
+        "validator_reasons": [
+          "auto_resolve:no_flags_fired"
+        ],
+        "risk_reasons": [
+          "base_risk:LOW"
+        ],
+        "retrieved_record_ids": [
+          "TKT-2022-03334",
+          "TKT-2023-01706",
+          "TKT-2024-07581",
+          "TKT-2023-03902",
+          "TKT-2022-04249",
+          "TKT-2024-00480",
+          "TKT-2022-00511",
+          "TKT-2022-02545"
+        ]
+      }
+    },
+    "transcript_id": "EVAL-0620"
+  },
+  {
+    "category": "HVAC",
+    "subcategory": "air_quality",
+    "risk_level": "MEDIUM",
+    "needs_human_review": true,
+    "needs_clarification": false,
+    "building_name": "Inland Empire Logistics Center",
+    "address": "12000 Etiwanda Ave",
+    "floor": "Ground Floor",
+    "dispatched_vendor_id": null,
+    "dispatched_emergency_services": false,
+    "call_summary": "Air quality concern reported at Inland Empire Logistics Center, Ground Floor. MEDIUM risk. Escalated to human review \u2014 no qualified vendor available.",
+    "trainer_log": {
+      "full_transcript": "[AGENT] Maintenance, what's the situation?\n[CALLER] There's a weird smell \u2014 not sure what it is.\n[AGENT] Okay, can you describe what you're seeing or smelling?\n[CALLER] [dog barking faintly] No, not sulfur \u2014 more like a cleaning solvent.\n[AGENT] Can you describe the smell?\n[CALLER] No, not sulfur \u2014 more like a cleaning solvent.\n[AGENT] What's your building, floor, suite?\n[CALLER] Inland Empire Logistics Center, I mean, Ground Floor.\n[AGENT] I'll get a vendor rolling and let the property manager know.",
+      "ai_prediction": {
+        "category": "HVAC",
+        "subcategory": "air_quality",
+        "risk_level": "MEDIUM",
+        "dispatched_vendor_id": null,
+        "dispatched_emergency_services": false,
+        "needs_human_review": true,
+        "needs_clarification": false,
+        "confidence_category": 0.9,
+        "confidence_subcategory": 0.9,
+        "validator_reasons": [
+          "trap_prone_subcategory:air_quality(over_escalation_rate=19%)"
+        ],
+        "risk_reasons": [
+          "base_risk:MEDIUM"
+        ],
+        "retrieved_record_ids": [
+          "TKT-2023-01883",
+          "TKT-2024-00450",
+          "TKT-2023-02570",
+          "TKT-2024-09306",
+          "TKT-2024-03792",
+          "TKT-2023-00554",
+          "TKT-2022-00508",
+          "TKT-2024-03609"
+        ]
+      },
+      "human_override": null,
+      "final_decision": {
+        "category": "HVAC",
+        "subcategory": "air_quality",
+        "risk_level": "MEDIUM",
+        "dispatched_vendor_id": null,
+        "dispatched_emergency_services": false,
+        "needs_human_review": true,
+        "needs_clarification": false,
+        "confidence_category": 0.9,
+        "confidence_subcategory": 0.9,
+        "validator_reasons": [
+          "trap_prone_subcategory:air_quality(over_escalation_rate=19%)"
+        ],
+        "risk_reasons": [
+          "base_risk:MEDIUM"
+        ],
+        "retrieved_record_ids": [
+          "TKT-2023-01883",
+          "TKT-2024-00450",
+          "TKT-2023-02570",
+          "TKT-2024-09306",
+          "TKT-2024-03792",
+          "TKT-2023-00554",
+          "TKT-2022-00508",
+          "TKT-2024-03609"
+        ]
+      }
+    },
+    "transcript_id": "EVAL-0621"
+  },
+  {
+    "category": "ELEVATOR",
+    "subcategory": "malfunction",
+    "risk_level": "MEDIUM",
+    "needs_human_review": true,
+    "needs_clarification": false,
+    "building_name": "Brookfield Retail Center",
+    "address": "2200 Brookfield Rd",
+    "floor": "Floor 2",
+    "dispatched_vendor_id": "v_016",
+    "dispatched_emergency_services": false,
+    "call_summary": "Equipment malfunction reported at Brookfield Retail Center, Floor 2. MEDIUM risk. Flagged for review. Skyline Elevator Co dispatched pending approval.",
+    "trainer_log": {
+      "full_transcript": "[AGENT] CBRE facilities, this is Sam. What's going on?\n[CALLER] Elevator stopped with someone inside \u2014 but the doors are fully open on the ground floor, they just can't get it to go.\n[AGENT] Okay \u2014 can you confirm there's no actual fire or injury right now?\n[CALLER] I mean, no, they're out of the car. It's just stuck empty.\n[AGENT] Where exactly \u2014 which suite?\n[CALLER] Brookfield Retail Center, Floor 2, Suite 205.\n[AGENT] Alright \u2014 sending a vendor over and giving the PM a heads-up.",
+      "ai_prediction": {
+        "category": "ELEVATOR",
+        "subcategory": "malfunction",
+        "risk_level": "MEDIUM",
+        "dispatched_vendor_id": "v_016",
+        "dispatched_emergency_services": false,
+        "needs_human_review": true,
+        "needs_clarification": false,
+        "confidence_category": 0.9,
+        "confidence_subcategory": 0.9,
+        "validator_reasons": [
+          "trap_cascade_subcategory:malfunction(high-audit cell at HIGH/EMERGENCY \u2014 possible under-classification)"
+        ],
+        "risk_reasons": [
+          "base_risk:MEDIUM"
+        ],
+        "retrieved_record_ids": [
+          "TKT-2022-07741",
+          "TKT-2022-05482",
+          "TKT-2022-01663",
+          "TKT-2024-02223",
+          "TKT-2024-02205",
+          "TKT-2022-08311",
+          "TKT-2023-03455",
+          "TKT-2022-03541"
+        ]
+      },
+      "human_override": null,
+      "final_decision": {
+        "category": "ELEVATOR",
+        "subcategory": "malfunction",
+        "risk_level": "MEDIUM",
+        "dispatched_vendor_id": "v_016",
+        "dispatched_emergency_services": false,
+        "needs_human_review": true,
+        "needs_clarification": false,
+        "confidence_category": 0.9,
+        "confidence_subcategory": 0.9,
+        "validator_reasons": [
+          "trap_cascade_subcategory:malfunction(high-audit cell at HIGH/EMERGENCY \u2014 possible under-classification)"
+        ],
+        "risk_reasons": [
+          "base_risk:MEDIUM"
+        ],
+        "retrieved_record_ids": [
+          "TKT-2022-07741",
+          "TKT-2022-05482",
+          "TKT-2022-01663",
+          "TKT-2024-02223",
+          "TKT-2024-02205",
+          "TKT-2022-08311",
+          "TKT-2023-03455",
+          "TKT-2022-03541"
+        ]
+      }
+    },
+    "transcript_id": "EVAL-0624"
+  },
+  {
+    "category": "ELEVATOR",
+    "subcategory": "entrapment",
+    "risk_level": "EMERGENCY",
+    "needs_human_review": true,
+    "needs_clarification": false,
+    "building_name": "Heritage Square Office Park",
+    "address": "1000 Heritage Sq Dr",
+    "floor": "Floor 1",
+    "dispatched_vendor_id": "v_016",
+    "dispatched_emergency_services": true,
+    "call_summary": "Person trapped reported at Heritage Square Office Park, Floor 1. EMERGENCY risk. Emergency services dispatched.",
+    "trainer_log": {
+      "full_transcript": "[AGENT] Maintenance, what's the situation?\n[CALLER] Like, the elevator's acting weird with someone in it.\n[AGENT] Okay, can you describe what you're seeing or smelling?\n[CALLER] Two people in there, they're pressing the call button.\n[AGENT] Are they between floors?\n[CALLER] Doors are closed, between floors three and four.\n[AGENT] Where exactly \u2014 which suite?\n[CALLER] Heritage Square Office Park, Floor 1, Suite 101.\n[AGENT] Pulling in the supervisor and dispatching a vendor right now.",
+      "ai_prediction": {
+        "category": "ELEVATOR",
+        "subcategory": "entrapment",
+        "risk_level": "EMERGENCY",
+        "dispatched_vendor_id": "v_016",
+        "dispatched_emergency_services": true,
+        "needs_human_review": true,
+        "needs_clarification": false,
+        "confidence_category": 0.95,
+        "confidence_subcategory": 0.95,
+        "validator_reasons": [
+          "emergency_band:always_pause",
+          "emergency_dispatch:entrapment:hazard_cue_confirmed"
+        ],
+        "risk_reasons": [
+          "base_risk:EMERGENCY",
+          "hard_cue:people trapped",
+          "capped_at_EMERGENCY:historical_max for subcategory=entrapment"
+        ],
+        "retrieved_record_ids": [
+          "TKT-2022-03022",
+          "TKT-2022-02566",
+          "TKT-2022-07927",
+          "TKT-2022-01069",
+          "TKT-2022-09253",
+          "TKT-2022-09172",
+          "TKT-2023-03569",
+          "TKT-2022-02071"
+        ]
+      },
+      "human_override": null,
+      "final_decision": {
+        "category": "ELEVATOR",
+        "subcategory": "entrapment",
+        "risk_level": "EMERGENCY",
+        "dispatched_vendor_id": "v_016",
+        "dispatched_emergency_services": true,
+        "needs_human_review": true,
+        "needs_clarification": false,
+        "confidence_category": 0.95,
+        "confidence_subcategory": 0.95,
+        "validator_reasons": [
+          "emergency_band:always_pause",
+          "emergency_dispatch:entrapment:hazard_cue_confirmed"
+        ],
+        "risk_reasons": [
+          "base_risk:EMERGENCY",
+          "hard_cue:people trapped",
+          "capped_at_EMERGENCY:historical_max for subcategory=entrapment"
+        ],
+        "retrieved_record_ids": [
+          "TKT-2022-03022",
+          "TKT-2022-02566",
+          "TKT-2022-07927",
+          "TKT-2022-01069",
+          "TKT-2022-09253",
+          "TKT-2022-09172",
+          "TKT-2023-03569",
+          "TKT-2022-02071"
+        ]
+      }
+    },
+    "transcript_id": "EVAL-0630"
+  },
+  {
+    "category": "ELEVATOR",
+    "subcategory": "minor_issue",
+    "risk_level": "LOW",
+    "needs_human_review": false,
+    "needs_clarification": false,
+    "building_name": "Canyon View Business Center",
+    "address": "4400 Canyon View Dr",
+    "floor": "Rooftop",
+    "dispatched_vendor_id": "v_016",
+    "dispatched_emergency_services": false,
+    "call_summary": "Minor maintenance issue reported at Canyon View Business Center, Rooftop. LOW risk. Dispatched Skyline Elevator Co.",
+    "trainer_log": {
+      "full_transcript": "[AGENT] CBRE dispatch, talk to me.\n[CALLER] The elevator's doing something weird.\n[AGENT] Okay, can you describe what you're seeing or smelling?\n[CALLER] Probably fine but sounds awful.\n[AGENT] Is it still safe to use?\n[CALLER] Hold on, probably fine but sounds awful.\n[AGENT] What's your building, floor, suite?\n[CALLER] Canyon View Business Center, Rooftop.\n[AGENT] Okay, I'll line that up now. Confirmation text will come through shortly.",
+      "ai_prediction": {
+        "category": "ELEVATOR",
+        "subcategory": "minor_issue",
+        "risk_level": "LOW",
+        "dispatched_vendor_id": "v_016",
+        "dispatched_emergency_services": false,
+        "needs_human_review": false,
+        "needs_clarification": false,
+        "confidence_category": 0.95,
+        "confidence_subcategory": 0.95,
+        "validator_reasons": [
+          "auto_resolve:no_flags_fired"
+        ],
+        "risk_reasons": [
+          "base_risk:LOW"
+        ],
+        "retrieved_record_ids": [
+          "TKT-2024-08655",
+          "TKT-2022-09670",
+          "TKT-2023-09158",
+          "TKT-2024-06315",
+          "TKT-2023-06254",
+          "TKT-2024-04182",
+          "TKT-2023-07118",
+          "TKT-2022-08215"
+        ]
+      },
+      "human_override": null,
+      "final_decision": {
+        "category": "ELEVATOR",
+        "subcategory": "minor_issue",
+        "risk_level": "LOW",
+        "dispatched_vendor_id": "v_016",
+        "dispatched_emergency_services": false,
+        "needs_human_review": false,
+        "needs_clarification": false,
+        "confidence_category": 0.95,
+        "confidence_subcategory": 0.95,
+        "validator_reasons": [
+          "auto_resolve:no_flags_fired"
+        ],
+        "risk_reasons": [
+          "base_risk:LOW"
+        ],
+        "retrieved_record_ids": [
+          "TKT-2024-08655",
+          "TKT-2022-09670",
+          "TKT-2023-09158",
+          "TKT-2024-06315",
+          "TKT-2023-06254",
+          "TKT-2024-04182",
+          "TKT-2023-07118",
+          "TKT-2022-08215"
+        ]
+      }
+    },
+    "transcript_id": "EVAL-0632"
+  },
+  {
+    "category": "PLUMBING",
+    "subcategory": "pipe_leak",
+    "risk_level": "HIGH",
+    "needs_human_review": true,
+    "needs_clarification": true,
+    "building_name": "Riverside Corporate Campus",
+    "address": "2000 Riverside Dr",
+    "floor": "Floor 4",
+    "dispatched_vendor_id": "v_002",
+    "dispatched_emergency_services": false,
+    "call_summary": "Pipe leak reported at Riverside Corporate Campus, Floor 4. HIGH risk. Flagged for review. Metro Drain & Pipe dispatched pending approval.",
+    "trainer_log": {
+      "full_transcript": "[AGENT] CBRE facilities \u2014 how can I help?\n[CALLER] There's an issue with pipe leak.\n[AGENT] Is it near any electrical outlets?\n[CALLER] It's coming out pretty fast now, filling up the floor.\n[AGENT] Which building and floor are you at?\n[CALLER] Riverside Corporate Campus, Floor 4, Suite 405.\n[AGENT] I'll get a tech out \u2014 they'll text you when they're heading over.",
+      "ai_prediction": {
+        "category": "PLUMBING",
+        "subcategory": "pipe_leak",
+        "risk_level": "HIGH",
+        "dispatched_vendor_id": "v_002",
+        "dispatched_emergency_services": false,
+        "needs_human_review": true,
+        "needs_clarification": true,
+        "confidence_category": 0.95,
+        "confidence_subcategory": 0.95,
+        "validator_reasons": [
+          "high_band:always_pause"
+        ],
+        "risk_reasons": [
+          "base_risk:HIGH",
+          "soft_cue:flooding"
+        ],
+        "retrieved_record_ids": [
+          "TKT-2023-09572",
+          "TKT-2024-05304",
+          "TKT-2022-07591",
+          "TKT-2023-09221",
+          "TKT-2023-08651",
+          "TKT-2024-01443",
+          "TKT-2023-00605",
+          "TKT-2024-03834"
+        ]
+      },
+      "human_override": null,
+      "final_decision": {
+        "category": "PLUMBING",
+        "subcategory": "pipe_leak",
+        "risk_level": "HIGH",
+        "dispatched_vendor_id": "v_002",
+        "dispatched_emergency_services": false,
+        "needs_human_review": true,
+        "needs_clarification": true,
+        "confidence_category": 0.95,
+        "confidence_subcategory": 0.95,
+        "validator_reasons": [
+          "high_band:always_pause"
+        ],
+        "risk_reasons": [
+          "base_risk:HIGH",
+          "soft_cue:flooding"
+        ],
+        "retrieved_record_ids": [
+          "TKT-2023-09572",
+          "TKT-2024-05304",
+          "TKT-2022-07591",
+          "TKT-2023-09221",
+          "TKT-2023-08651",
+          "TKT-2024-01443",
+          "TKT-2023-00605",
+          "TKT-2024-03834"
+        ]
+      }
+    },
+    "transcript_id": "EVAL-0638"
+  },
+  {
+    "category": "ELEVATOR",
+    "subcategory": "minor_issue",
+    "risk_level": "LOW",
+    "needs_human_review": false,
+    "needs_clarification": false,
+    "building_name": "Airport Business Center",
+    "address": "9200 Airport Blvd",
+    "floor": "Floor 3",
+    "dispatched_vendor_id": "v_016",
+    "dispatched_emergency_services": false,
+    "call_summary": "Minor maintenance issue reported at Airport Business Center, Floor 3. LOW risk. Dispatched Skyline Elevator Co.",
+    "trainer_log": {
+      "full_transcript": "[AGENT] Maintenance, what's the situation?\n[CALLER] I mean, good morning, The elevator isn't leveling properly at our floor.\n[AGENT] Okay, I see. Is it still safe to use?\n[CALLER] Um, probably fine but sounds awful.\n[AGENT] Which building and floor are you at?\n[CALLER] Airport Business Center, Floor 3.\n[AGENT] Okay, I'll line that up now. Confirmation text will come through shortly.\n[CALLER] Got it, thanks.",
+      "ai_prediction": {
+        "category": "ELEVATOR",
+        "subcategory": "minor_issue",
+        "risk_level": "LOW",
+        "dispatched_vendor_id": "v_016",
+        "dispatched_emergency_services": false,
+        "needs_human_review": false,
+        "needs_clarification": false,
+        "confidence_category": 0.95,
+        "confidence_subcategory": 0.95,
+        "validator_reasons": [
+          "auto_resolve:no_flags_fired"
+        ],
+        "risk_reasons": [
+          "base_risk:LOW"
+        ],
+        "retrieved_record_ids": [
+          "TKT-2023-04187",
+          "TKT-2023-06341",
+          "TKT-2024-03555",
+          "TKT-2024-08505",
+          "TKT-2024-06666",
+          "TKT-2023-09815",
+          "TKT-2024-00024",
+          "TKT-2024-03744"
+        ]
+      },
+      "human_override": null,
+      "final_decision": {
+        "category": "ELEVATOR",
+        "subcategory": "minor_issue",
+        "risk_level": "LOW",
+        "dispatched_vendor_id": "v_016",
+        "dispatched_emergency_services": false,
+        "needs_human_review": false,
+        "needs_clarification": false,
+        "confidence_category": 0.95,
+        "confidence_subcategory": 0.95,
+        "validator_reasons": [
+          "auto_resolve:no_flags_fired"
+        ],
+        "risk_reasons": [
+          "base_risk:LOW"
+        ],
+        "retrieved_record_ids": [
+          "TKT-2023-04187",
+          "TKT-2023-06341",
+          "TKT-2024-03555",
+          "TKT-2024-08505",
+          "TKT-2024-06666",
+          "TKT-2023-09815",
+          "TKT-2024-00024",
+          "TKT-2024-03744"
+        ]
+      }
+    },
+    "transcript_id": "EVAL-0640"
+  },
+  {
+    "category": "JANITORIAL",
+    "subcategory": "restroom_supplies",
+    "risk_level": "LOW",
+    "needs_human_review": false,
+    "needs_clarification": false,
+    "building_name": "Crossroads Business Park",
+    "address": "3300 Crossroads Pkwy",
+    "floor": "Floor 1",
+    "dispatched_vendor_id": "v_025",
+    "dispatched_emergency_services": false,
+    "call_summary": "Restroom supply issue reported at Crossroads Business Park, Floor 1. LOW risk. Dispatched ProClean Facility Services.",
+    "trainer_log": {
+      "full_transcript": "[AGENT] CBRE maintenance line, what do you need?\n[CALLER] The restroom's out of stuff.\n[AGENT] Okay, can you describe what you're seeing or smelling?\n[CALLER] Sorry, just TP \u2014 the rest is fine.\n[AGENT] Is the whole facility out?\n[CALLER] Women's room on three.\n[AGENT] Can you confirm the building and floor?\n[CALLER] [door closing] Crossroads Business Park, Floor 1, Suite 108.\n[AGENT] Alright, I'll send a vendor over. You'll get a text once they're rolling.",
+      "ai_prediction": {
+        "category": "JANITORIAL",
+        "subcategory": "restroom_supplies",
+        "risk_level": "LOW",
+        "dispatched_vendor_id": "v_025",
+        "dispatched_emergency_services": false,
+        "needs_human_review": false,
+        "needs_clarification": false,
+        "confidence_category": 0.9,
+        "confidence_subcategory": 0.9,
+        "validator_reasons": [
+          "auto_resolve:no_flags_fired"
+        ],
+        "risk_reasons": [
+          "base_risk:LOW"
+        ],
+        "retrieved_record_ids": [
+          "TKT-2022-08467",
+          "TKT-2022-04618",
+          "TKT-2024-02238",
+          "TKT-2023-08306",
+          "TKT-2022-06448",
+          "TKT-2022-05617",
+          "TKT-2022-01720",
+          "TKT-2024-00984"
+        ]
+      },
+      "human_override": null,
+      "final_decision": {
+        "category": "JANITORIAL",
+        "subcategory": "restroom_supplies",
+        "risk_level": "LOW",
+        "dispatched_vendor_id": "v_025",
+        "dispatched_emergency_services": false,
+        "needs_human_review": false,
+        "needs_clarification": false,
+        "confidence_category": 0.9,
+        "confidence_subcategory": 0.9,
+        "validator_reasons": [
+          "auto_resolve:no_flags_fired"
+        ],
+        "risk_reasons": [
+          "base_risk:LOW"
+        ],
+        "retrieved_record_ids": [
+          "TKT-2022-08467",
+          "TKT-2022-04618",
+          "TKT-2024-02238",
+          "TKT-2023-08306",
+          "TKT-2022-06448",
+          "TKT-2022-05617",
+          "TKT-2022-01720",
+          "TKT-2024-00984"
+        ]
+      }
+    },
+    "transcript_id": "EVAL-0641"
+  },
+  {
+    "category": "PLUMBING",
+    "subcategory": "pipe_leak",
+    "risk_level": "HIGH",
+    "needs_human_review": true,
+    "needs_clarification": false,
+    "building_name": "Redwood Corporate Plaza",
+    "address": "2400 Redwood Hwy",
+    "floor": "Floor 4",
+    "dispatched_vendor_id": "v_002",
+    "dispatched_emergency_services": false,
+    "call_summary": "Pipe leak reported at Redwood Corporate Plaza, Floor 4. HIGH risk. Flagged for review. Metro Drain & Pipe dispatched pending approval.",
+    "trainer_log": {
+      "full_transcript": "[AGENT] CBRE maintenance, this is Dana. What's going on?\n[CALLER] Toilet in the men's room won't stop running.\n[AGENT] Mhm. Is it overflowing or just running?\n[CALLER] Wait, actually \u2014 it's not the toilet. There's water coming out behind the wall. I think a pipe let go.\n[AGENT] Got it \u2014 updating the ticket. How large is the leak \u2014 dripping or pouring?\n[CALLER] It's coming out pretty fast now, filling up the floor.\n[AGENT] Where exactly \u2014 which suite?\n[CALLER] Redwood Corporate Plaza, Floor 4, Suite 405.\n[AGENT] I'll get a tech out \u2014 they'll text you when they're heading over.",
+      "ai_prediction": {
+        "category": "PLUMBING",
+        "subcategory": "pipe_leak",
+        "risk_level": "HIGH",
+        "dispatched_vendor_id": "v_002",
+        "dispatched_emergency_services": false,
+        "needs_human_review": true,
+        "needs_clarification": false,
+        "confidence_category": 0.95,
+        "confidence_subcategory": 0.95,
+        "validator_reasons": [
+          "high_band:always_pause"
+        ],
+        "risk_reasons": [
+          "base_risk:HIGH",
+          "soft_cue:flooding"
+        ],
+        "retrieved_record_ids": [
+          "TKT-2023-04874",
+          "TKT-2022-03451",
+          "TKT-2022-09307",
+          "TKT-2022-03826",
+          "TKT-2023-09572",
+          "TKT-2023-07814",
+          "TKT-2024-03597",
+          "TKT-2023-06353"
+        ]
+      },
+      "human_override": null,
+      "final_decision": {
+        "category": "PLUMBING",
+        "subcategory": "pipe_leak",
+        "risk_level": "HIGH",
+        "dispatched_vendor_id": "v_002",
+        "dispatched_emergency_services": false,
+        "needs_human_review": true,
+        "needs_clarification": false,
+        "confidence_category": 0.95,
+        "confidence_subcategory": 0.95,
+        "validator_reasons": [
+          "high_band:always_pause"
+        ],
+        "risk_reasons": [
+          "base_risk:HIGH",
+          "soft_cue:flooding"
+        ],
+        "retrieved_record_ids": [
+          "TKT-2023-04874",
+          "TKT-2022-03451",
+          "TKT-2022-09307",
+          "TKT-2022-03826",
+          "TKT-2023-09572",
+          "TKT-2023-07814",
+          "TKT-2024-03597",
+          "TKT-2023-06353"
+        ]
+      }
+    },
+    "transcript_id": "EVAL-0642"
+  },
+  {
+    "category": "PLUMBING",
+    "subcategory": "restroom_fixture",
+    "risk_level": "LOW",
+    "needs_human_review": false,
+    "needs_clarification": true,
+    "building_name": "Valley Medical Center",
+    "address": "150 Valley Health Blvd",
+    "floor": "Floor 6",
+    "dispatched_vendor_id": "v_002",
+    "dispatched_emergency_services": false,
+    "call_summary": "Restroom fixture issue reported at Valley Medical Center, Floor 6. LOW risk. Dispatched Metro Drain & Pipe.",
+    "trainer_log": {
+      "full_transcript": "[AGENT] CBRE dispatch \u2014 go ahead.\n[CALLER] [dog barking faintly] There's an issue with restroom fixture.\n[AGENT] Is it overflowing or just running?\n[CALLER] Just running continuously.\n[AGENT] Can you confirm the building and floor?\n[CALLER] Valley Medical Center, Floor 6, Suite 305.\n[AGENT] Got it. I'll get someone out as soon as I can \u2014 should hear back within the hour.",
+      "ai_prediction": {
+        "category": "PLUMBING",
+        "subcategory": "restroom_fixture",
+        "risk_level": "LOW",
+        "dispatched_vendor_id": "v_002",
+        "dispatched_emergency_services": false,
+        "needs_human_review": false,
+        "needs_clarification": true,
+        "confidence_category": 0.95,
+        "confidence_subcategory": 0.95,
+        "validator_reasons": [
+          "auto_resolve:no_flags_fired"
+        ],
+        "risk_reasons": [
+          "base_risk:LOW",
+          "sensitive_building:medical",
+          "capped_at_LOW:historical_max for subcategory=restroom_fixture"
+        ],
+        "retrieved_record_ids": [
+          "TKT-2023-03701",
+          "TKT-2024-05265",
+          "TKT-2022-01435",
+          "TKT-2023-01160",
+          "TKT-2024-09777",
+          "TKT-2022-05551",
+          "TKT-2022-01498",
+          "TKT-2024-01917"
+        ]
+      },
+      "human_override": null,
+      "final_decision": {
+        "category": "PLUMBING",
+        "subcategory": "restroom_fixture",
+        "risk_level": "LOW",
+        "dispatched_vendor_id": "v_002",
+        "dispatched_emergency_services": false,
+        "needs_human_review": false,
+        "needs_clarification": true,
+        "confidence_category": 0.95,
+        "confidence_subcategory": 0.95,
+        "validator_reasons": [
+          "auto_resolve:no_flags_fired"
+        ],
+        "risk_reasons": [
+          "base_risk:LOW",
+          "sensitive_building:medical",
+          "capped_at_LOW:historical_max for subcategory=restroom_fixture"
+        ],
+        "retrieved_record_ids": [
+          "TKT-2023-03701",
+          "TKT-2024-05265",
+          "TKT-2022-01435",
+          "TKT-2023-01160",
+          "TKT-2024-09777",
+          "TKT-2022-05551",
+          "TKT-2022-01498",
+          "TKT-2024-01917"
+        ]
+      }
+    },
+    "transcript_id": "EVAL-0646"
+  },
+  {
+    "category": "JANITORIAL",
+    "subcategory": "waste_odor",
+    "risk_level": "LOW",
+    "needs_human_review": false,
+    "needs_clarification": false,
+    "building_name": "Golden State Towers",
+    "address": "900 Golden State Blvd",
+    "floor": "Basement",
+    "dispatched_vendor_id": "v_024",
+    "dispatched_emergency_services": false,
+    "call_summary": "Waste/odor issue reported at Golden State Towers, Basement. LOW risk. Dispatched Bay Area Cleaning Solutions.",
+    "trainer_log": {
+      "full_transcript": "[AGENT] CBRE dispatch \u2014 go ahead.\n[CALLER] Some kind of bad smell coming through the vents.\n[AGENT] Mhm. Does it smell like gas or sulfur?\n[CALLER] Wait \u2014 actually it's coming from the trash area, not the vents. Been sitting there all weekend.\n[AGENT] Got it \u2014 updating the ticket. How bad is the smell?\n[CALLER] Pretty bad \u2014 can't really ignore it.\n[AGENT] Which building and floor are you at?\n[CALLER] Golden State Towers, Basement.\n[AGENT] Alright, I've put a ticket in \u2014 vendor will swing by during business hours.",
+      "ai_prediction": {
+        "category": "JANITORIAL",
+        "subcategory": "waste_odor",
+        "risk_level": "LOW",
+        "dispatched_vendor_id": "v_024",
+        "dispatched_emergency_services": false,
+        "needs_human_review": false,
+        "needs_clarification": false,
+        "confidence_category": 0.95,
+        "confidence_subcategory": 0.95,
+        "validator_reasons": [
+          "auto_resolve:no_flags_fired"
+        ],
+        "risk_reasons": [
+          "base_risk:LOW"
+        ],
+        "retrieved_record_ids": [
+          "TKT-2022-09856",
+          "TKT-2022-03841",
+          "TKT-2023-09824",
+          "TKT-2024-06561",
+          "TKT-2024-00477",
+          "TKT-2022-04036",
+          "TKT-2023-06731",
+          "TKT-2023-00680"
+        ]
+      },
+      "human_override": null,
+      "final_decision": {
+        "category": "JANITORIAL",
+        "subcategory": "waste_odor",
+        "risk_level": "LOW",
+        "dispatched_vendor_id": "v_024",
+        "dispatched_emergency_services": false,
+        "needs_human_review": false,
+        "needs_clarification": false,
+        "confidence_category": 0.95,
+        "confidence_subcategory": 0.95,
+        "validator_reasons": [
+          "auto_resolve:no_flags_fired"
+        ],
+        "risk_reasons": [
+          "base_risk:LOW"
+        ],
+        "retrieved_record_ids": [
+          "TKT-2022-09856",
+          "TKT-2022-03841",
+          "TKT-2023-09824",
+          "TKT-2024-06561",
+          "TKT-2024-00477",
+          "TKT-2022-04036",
+          "TKT-2023-06731",
+          "TKT-2023-00680"
+        ]
+      }
+    },
+    "transcript_id": "EVAL-0654"
+  },
+  {
+    "category": "GROUNDS_EXTERIOR",
+    "subcategory": "parking_lighting",
+    "risk_level": "LOW",
+    "needs_human_review": false,
+    "needs_clarification": false,
+    "building_name": null,
+    "address": null,
+    "floor": "Floor 1",
+    "dispatched_vendor_id": "v_008",
+    "dispatched_emergency_services": false,
+    "call_summary": "Parking area lighting issue reported at Floor 1. LOW risk. Dispatched Rapid Response Electricians.",
+    "trainer_log": {
+      "full_transcript": "[AGENT] Hi, CBRE facilities. What can I do for you?\n[CALLER] Half the parking lot on Floor 1 is dark \u2014 multiple lights out.\n[AGENT] Mhm. Is it the whole lot or one area?\n[CALLER] The back row is all out.\n[AGENT] Nobody in our vendor list matches everything you need. Let me kick this over to the on-call PM.\n[CALLER] You know, okay, please hurry.",
+      "ai_prediction": {
+        "category": "GROUNDS_EXTERIOR",
+        "subcategory": "parking_lighting",
+        "risk_level": "LOW",
+        "dispatched_vendor_id": "v_008",
+        "dispatched_emergency_services": false,
+        "needs_human_review": false,
+        "needs_clarification": false,
+        "confidence_category": 0.9,
+        "confidence_subcategory": 0.9,
+        "validator_reasons": [
+          "auto_resolve:no_flags_fired"
+        ],
+        "risk_reasons": [
+          "base_risk:LOW"
+        ],
+        "retrieved_record_ids": [
+          "TKT-2024-07416",
+          "TKT-2024-00300",
+          "TKT-2024-03423",
+          "TKT-2024-02253",
+          "TKT-2023-05306",
+          "TKT-2024-08121",
+          "TKT-2023-05675",
+          "TKT-2023-05342"
+        ]
+      },
+      "human_override": null,
+      "final_decision": {
+        "category": "GROUNDS_EXTERIOR",
+        "subcategory": "parking_lighting",
+        "risk_level": "LOW",
+        "dispatched_vendor_id": "v_008",
+        "dispatched_emergency_services": false,
+        "needs_human_review": false,
+        "needs_clarification": false,
+        "confidence_category": 0.9,
+        "confidence_subcategory": 0.9,
+        "validator_reasons": [
+          "auto_resolve:no_flags_fired"
+        ],
+        "risk_reasons": [
+          "base_risk:LOW"
+        ],
+        "retrieved_record_ids": [
+          "TKT-2024-07416",
+          "TKT-2024-00300",
+          "TKT-2024-03423",
+          "TKT-2024-02253",
+          "TKT-2023-05306",
+          "TKT-2024-08121",
+          "TKT-2023-05675",
+          "TKT-2023-05342"
+        ]
+      }
+    },
+    "transcript_id": "EVAL-0657"
+  },
+  {
+    "category": "LIFE_SAFETY",
+    "subcategory": "slip_trip",
+    "risk_level": "LOW",
+    "needs_human_review": false,
+    "needs_clarification": false,
+    "building_name": "Brookfield Retail Center",
+    "address": "2200 Brookfield Rd",
+    "floor": "Floor 3",
+    "dispatched_vendor_id": "v_023",
+    "dispatched_emergency_services": false,
+    "call_summary": "Slip/trip hazard reported at Brookfield Retail Center, Floor 3. LOW risk. Dispatched Sparkle Commercial Cleaning.",
+    "trainer_log": {
+      "full_transcript": "[AGENT] CBRE maintenance line, this is Priya \u2014 what do you need?\n[CALLER] There's a puddle in the main walkway, hold on, pretty big.\n[AGENT] Understood. Is the area blocked off?\n[CALLER] No one's fallen yet.\n[AGENT] What's your building, floor, suite?\n[CALLER] Brookfield Retail Center, Floor 3, Suite 308.\n[AGENT] Got the ticket open. Vendor should make it out during business hours.\n[CALLER] I mean, okay.",
+      "ai_prediction": {
+        "category": "LIFE_SAFETY",
+        "subcategory": "slip_trip",
+        "risk_level": "LOW",
+        "dispatched_vendor_id": "v_023",
+        "dispatched_emergency_services": false,
+        "needs_human_review": false,
+        "needs_clarification": false,
+        "confidence_category": 0.95,
+        "confidence_subcategory": 0.95,
+        "validator_reasons": [
+          "auto_resolve:no_flags_fired"
+        ],
+        "risk_reasons": [
+          "base_risk:LOW"
+        ],
+        "retrieved_record_ids": [
+          "TKT-2022-02047",
+          "TKT-2024-04125",
+          "TKT-2024-02850",
+          "TKT-2022-09133",
+          "TKT-2023-08288",
+          "TKT-2024-08490",
+          "TKT-2022-05467",
+          "TKT-2023-09716"
+        ]
+      },
+      "human_override": null,
+      "final_decision": {
+        "category": "LIFE_SAFETY",
+        "subcategory": "slip_trip",
+        "risk_level": "LOW",
+        "dispatched_vendor_id": "v_023",
+        "dispatched_emergency_services": false,
+        "needs_human_review": false,
+        "needs_clarification": false,
+        "confidence_category": 0.95,
+        "confidence_subcategory": 0.95,
+        "validator_reasons": [
+          "auto_resolve:no_flags_fired"
+        ],
+        "risk_reasons": [
+          "base_risk:LOW"
+        ],
+        "retrieved_record_ids": [
+          "TKT-2022-02047",
+          "TKT-2024-04125",
+          "TKT-2024-02850",
+          "TKT-2022-09133",
+          "TKT-2023-08288",
+          "TKT-2024-08490",
+          "TKT-2022-05467",
+          "TKT-2023-09716"
+        ]
+      }
+    },
+    "transcript_id": "EVAL-0664"
+  },
+  {
+    "category": "ELEVATOR",
+    "subcategory": "malfunction",
+    "risk_level": "MEDIUM",
+    "needs_human_review": true,
+    "needs_clarification": false,
+    "building_name": "Meridian Business Park",
+    "address": "1500 Meridian Ave",
+    "floor": "Floor 4",
+    "dispatched_vendor_id": "v_017",
+    "dispatched_emergency_services": false,
+    "call_summary": "Equipment malfunction reported at Meridian Business Park, Floor 4. MEDIUM risk. Flagged for review. Valley Elevator Service dispatched pending approval.",
+    "trainer_log": {
+      "full_transcript": "[AGENT] CBRE facilities, Marcus speaking. How can I help?\n[CALLER] Someone was in the elevator when it stopped, uh, but they already walked out. Doors are open.\n[AGENT] Okay \u2014 can you confirm there's no actual fire or injury right now?\n[CALLER] No, they're out of the car. It's just stuck empty.\n[AGENT] Can you confirm the building and floor?\n[CALLER] Meridian Business Park, like, Floor 4, Suite 401.\n[AGENT] Sending a tech your way now. You'll hear from them en route.",
+      "ai_prediction": {
+        "category": "ELEVATOR",
+        "subcategory": "malfunction",
+        "risk_level": "MEDIUM",
+        "dispatched_vendor_id": "v_017",
+        "dispatched_emergency_services": false,
+        "needs_human_review": true,
+        "needs_clarification": false,
+        "confidence_category": 0.95,
+        "confidence_subcategory": 0.95,
+        "validator_reasons": [
+          "trap_cascade_subcategory:malfunction(high-audit cell at HIGH/EMERGENCY \u2014 possible under-classification)"
+        ],
+        "risk_reasons": [
+          "base_risk:MEDIUM"
+        ],
+        "retrieved_record_ids": [
+          "TKT-2024-02223",
+          "TKT-2023-03455",
+          "TKT-2022-08311",
+          "TKT-2022-09286",
+          "TKT-2022-01663",
+          "TKT-2022-05482",
+          "TKT-2023-05729",
+          "TKT-2024-09141"
+        ]
+      },
+      "human_override": null,
+      "final_decision": {
+        "category": "ELEVATOR",
+        "subcategory": "malfunction",
+        "risk_level": "MEDIUM",
+        "dispatched_vendor_id": "v_017",
+        "dispatched_emergency_services": false,
+        "needs_human_review": true,
+        "needs_clarification": false,
+        "confidence_category": 0.95,
+        "confidence_subcategory": 0.95,
+        "validator_reasons": [
+          "trap_cascade_subcategory:malfunction(high-audit cell at HIGH/EMERGENCY \u2014 possible under-classification)"
+        ],
+        "risk_reasons": [
+          "base_risk:MEDIUM"
+        ],
+        "retrieved_record_ids": [
+          "TKT-2024-02223",
+          "TKT-2023-03455",
+          "TKT-2022-08311",
+          "TKT-2022-09286",
+          "TKT-2022-01663",
+          "TKT-2022-05482",
+          "TKT-2023-05729",
+          "TKT-2024-09141"
+        ]
+      }
+    },
+    "transcript_id": "EVAL-0667"
+  },
+  {
+    "category": "JANITORIAL",
+    "subcategory": "restroom_supplies",
+    "risk_level": "LOW",
+    "needs_human_review": false,
+    "needs_clarification": true,
+    "building_name": "Eastlake Medical Plaza",
+    "address": "820 Eastlake Pkwy",
+    "floor": "Floor 2",
+    "dispatched_vendor_id": "v_025",
+    "dispatched_emergency_services": false,
+    "call_summary": "Restroom supply issue reported at Eastlake Medical Plaza, Floor 2. LOW risk. Dispatched ProClean Facility Services.",
+    "trainer_log": {
+      "full_transcript": "[AGENT] Dispatch, what do you need?\n[CALLER] Soap dispenser in the women's room on Floor 8 is empty again.\n[AGENT] I want to make sure I have the right location \u2014 Eastlake Medical Plaza only has 6 floors. Can you confirm the floor?\n[CALLER] Sorry, oh sorry \u2014 I meant Floor 2. I'm a little flustered.\n[AGENT] Alright, I'll send a vendor over. You'll get a text once they're rolling.",
+      "ai_prediction": {
+        "category": "JANITORIAL",
+        "subcategory": "restroom_supplies",
+        "risk_level": "LOW",
+        "dispatched_vendor_id": "v_025",
+        "dispatched_emergency_services": false,
+        "needs_human_review": false,
+        "needs_clarification": true,
+        "confidence_category": 0.95,
+        "confidence_subcategory": 0.95,
+        "validator_reasons": [
+          "auto_resolve:no_flags_fired"
+        ],
+        "risk_reasons": [
+          "base_risk:LOW",
+          "sensitive_building:medical",
+          "capped_at_LOW:historical_max for subcategory=restroom_supplies"
+        ],
+        "retrieved_record_ids": [
+          "TKT-2022-03352",
+          "TKT-2022-05032",
+          "TKT-2024-09666",
+          "TKT-2023-08510",
+          "TKT-2024-05607",
+          "TKT-2023-00128",
+          "TKT-2022-06385",
+          "TKT-2023-08564"
+        ]
+      },
+      "human_override": null,
+      "final_decision": {
+        "category": "JANITORIAL",
+        "subcategory": "restroom_supplies",
+        "risk_level": "LOW",
+        "dispatched_vendor_id": "v_025",
+        "dispatched_emergency_services": false,
+        "needs_human_review": false,
+        "needs_clarification": true,
+        "confidence_category": 0.95,
+        "confidence_subcategory": 0.95,
+        "validator_reasons": [
+          "auto_resolve:no_flags_fired"
+        ],
+        "risk_reasons": [
+          "base_risk:LOW",
+          "sensitive_building:medical",
+          "capped_at_LOW:historical_max for subcategory=restroom_supplies"
+        ],
+        "retrieved_record_ids": [
+          "TKT-2022-03352",
+          "TKT-2022-05032",
+          "TKT-2024-09666",
+          "TKT-2023-08510",
+          "TKT-2024-05607",
+          "TKT-2023-00128",
+          "TKT-2022-06385",
+          "TKT-2023-08564"
+        ]
+      }
+    },
+    "transcript_id": "EVAL-0668"
+  },
+  {
+    "category": "PEST_SPECIALTY",
+    "subcategory": "infestation",
+    "risk_level": "LOW",
+    "needs_human_review": false,
+    "needs_clarification": true,
+    "building_name": "Westpark Professional Center",
+    "address": "700 Westpark Dr",
+    "floor": "Floor 2",
+    "dispatched_vendor_id": "v_030",
+    "dispatched_emergency_services": false,
+    "call_summary": "Pest infestation reported at Westpark Professional Center, Floor 2. LOW risk. Dispatched Westside Pest Control.",
+    "trainer_log": {
+      "full_transcript": "[AGENT] CBRE maintenance line, this is Priya \u2014 what do you need?\n[CALLER] There's an issue with infestation.\n[AGENT] What kind of pest?\n[CALLER] Seeing one or two a day for a week.\n[AGENT] Which building and floor are you at?\n[CALLER] Westpark Professional Center, Floor 2.\n[AGENT] Got the ticket open. Vendor should make it out during business hours.",
+      "ai_prediction": {
+        "category": "PEST_SPECIALTY",
+        "subcategory": "infestation",
+        "risk_level": "LOW",
+        "dispatched_vendor_id": "v_030",
+        "dispatched_emergency_services": false,
+        "needs_human_review": false,
+        "needs_clarification": true,
+        "confidence_category": 0.95,
+        "confidence_subcategory": 0.95,
+        "validator_reasons": [
+          "auto_resolve:no_flags_fired"
+        ],
+        "risk_reasons": [
+          "base_risk:LOW"
+        ],
+        "retrieved_record_ids": [
+          "TKT-2024-05604",
+          "TKT-2024-04998",
+          "TKT-2024-05955",
+          "TKT-2024-06924",
+          "TKT-2024-00189",
+          "TKT-2022-02389",
+          "TKT-2023-08021",
+          "TKT-2023-06446"
+        ]
+      },
+      "human_override": null,
+      "final_decision": {
+        "category": "PEST_SPECIALTY",
+        "subcategory": "infestation",
+        "risk_level": "LOW",
+        "dispatched_vendor_id": "v_030",
+        "dispatched_emergency_services": false,
+        "needs_human_review": false,
+        "needs_clarification": true,
+        "confidence_category": 0.95,
+        "confidence_subcategory": 0.95,
+        "validator_reasons": [
+          "auto_resolve:no_flags_fired"
+        ],
+        "risk_reasons": [
+          "base_risk:LOW"
+        ],
+        "retrieved_record_ids": [
+          "TKT-2024-05604",
+          "TKT-2024-04998",
+          "TKT-2024-05955",
+          "TKT-2024-06924",
+          "TKT-2024-00189",
+          "TKT-2022-02389",
+          "TKT-2023-08021",
+          "TKT-2023-06446"
+        ]
+      }
+    },
+    "transcript_id": "EVAL-0671"
+  },
+  {
+    "category": "DOORS_ACCESS",
+    "subcategory": "door_mechanical",
+    "risk_level": "LOW",
+    "needs_human_review": false,
+    "needs_clarification": false,
+    "building_name": null,
+    "address": null,
+    "floor": "Floor 8",
+    "dispatched_vendor_id": "v_010",
+    "dispatched_emergency_services": false,
+    "call_summary": "Mechanical door issue reported at Floor 8. LOW risk. Dispatched All-Site Facilities Co.",
+    "trainer_log": {
+      "full_transcript": "[AGENT] CBRE maintenance \u2014 what's going on?\n[CALLER] Handle on the conference room door on Floor 8 in Suite 801 came off.\n[AGENT] Okay, I see. Can the door be secured?\n[CALLER] It's an interior door to the suite.\n[AGENT] Alright, I've put a ticket in \u2014 vendor will swing by during business hours.\n[CALLER] [background: hvac hum] Um, okay.",
+      "ai_prediction": {
+        "category": "DOORS_ACCESS",
+        "subcategory": "door_mechanical",
+        "risk_level": "LOW",
+        "dispatched_vendor_id": "v_010",
+        "dispatched_emergency_services": false,
+        "needs_human_review": false,
+        "needs_clarification": false,
+        "confidence_category": 0.95,
+        "confidence_subcategory": 0.95,
+        "validator_reasons": [
+          "auto_resolve:no_flags_fired"
+        ],
+        "risk_reasons": [
+          "base_risk:LOW"
+        ],
+        "retrieved_record_ids": [
+          "TKT-2022-08599",
+          "TKT-2024-01140",
+          "TKT-2024-01089",
+          "TKT-2023-08012",
+          "TKT-2023-01742",
+          "TKT-2024-04578",
+          "TKT-2024-06825",
+          "TKT-2024-01185"
+        ]
+      },
+      "human_override": null,
+      "final_decision": {
+        "category": "DOORS_ACCESS",
+        "subcategory": "door_mechanical",
+        "risk_level": "LOW",
+        "dispatched_vendor_id": "v_010",
+        "dispatched_emergency_services": false,
+        "needs_human_review": false,
+        "needs_clarification": false,
+        "confidence_category": 0.95,
+        "confidence_subcategory": 0.95,
+        "validator_reasons": [
+          "auto_resolve:no_flags_fired"
+        ],
+        "risk_reasons": [
+          "base_risk:LOW"
+        ],
+        "retrieved_record_ids": [
+          "TKT-2022-08599",
+          "TKT-2024-01140",
+          "TKT-2024-01089",
+          "TKT-2023-08012",
+          "TKT-2023-01742",
+          "TKT-2024-04578",
+          "TKT-2024-06825",
+          "TKT-2024-01185"
+        ]
+      }
+    },
+    "transcript_id": "EVAL-0674"
+  },
+  {
+    "category": "SECURITY",
+    "subcategory": "suspicious_person",
+    "risk_level": "MEDIUM",
+    "needs_human_review": true,
+    "needs_clarification": false,
+    "building_name": "Bayshore Commons",
+    "address": "1900 Bayshore Blvd",
+    "floor": "Floor 3",
+    "dispatched_vendor_id": "v_027",
+    "dispatched_emergency_services": false,
+    "call_summary": "Suspicious person reported reported at Bayshore Commons, Floor 3. MEDIUM risk. Flagged for review. Elite Protective Services dispatched pending approval.",
+    "trainer_log": {
+      "full_transcript": "[AGENT] Hi, CBRE facilities. What can I do for you?\n[CALLER] Guy asking employees for their badge numbers \u2014 something's off.\n[AGENT] Alright. Are they still there?\n[CALLER] Hold on, he's just standing there, not doing anything overt.\n[AGENT] Which building and floor are you at?\n[CALLER] Bayshore Commons, Floor 3, Suite 307.\n[AGENT] Tricky one \u2014 I'll involve the PM and get a tech dispatched at the same time.",
+      "ai_prediction": {
+        "category": "SECURITY",
+        "subcategory": "suspicious_person",
+        "risk_level": "MEDIUM",
+        "dispatched_vendor_id": "v_027",
+        "dispatched_emergency_services": false,
+        "needs_human_review": true,
+        "needs_clarification": false,
+        "confidence_category": 0.95,
+        "confidence_subcategory": 0.95,
+        "validator_reasons": [
+          "trap_cascade_subcategory:suspicious_person(high-audit cell at HIGH/EMERGENCY \u2014 possible under-classification)"
+        ],
+        "risk_reasons": [
+          "base_risk:MEDIUM"
+        ],
+        "retrieved_record_ids": [
+          "TKT-2023-01982",
+          "TKT-2022-00265",
+          "TKT-2023-05603",
+          "TKT-2023-01727",
+          "TKT-2024-08589",
+          "TKT-2024-03681",
+          "TKT-2024-07068",
+          "TKT-2023-07718"
+        ]
+      },
+      "human_override": null,
+      "final_decision": {
+        "category": "SECURITY",
+        "subcategory": "suspicious_person",
+        "risk_level": "MEDIUM",
+        "dispatched_vendor_id": "v_027",
+        "dispatched_emergency_services": false,
+        "needs_human_review": true,
+        "needs_clarification": false,
+        "confidence_category": 0.95,
+        "confidence_subcategory": 0.95,
+        "validator_reasons": [
+          "trap_cascade_subcategory:suspicious_person(high-audit cell at HIGH/EMERGENCY \u2014 possible under-classification)"
+        ],
+        "risk_reasons": [
+          "base_risk:MEDIUM"
+        ],
+        "retrieved_record_ids": [
+          "TKT-2023-01982",
+          "TKT-2022-00265",
+          "TKT-2023-05603",
+          "TKT-2023-01727",
+          "TKT-2024-08589",
+          "TKT-2024-03681",
+          "TKT-2024-07068",
+          "TKT-2023-07718"
+        ]
+      }
+    },
+    "transcript_id": "EVAL-0692"
+  },
+  {
+    "category": "JANITORIAL",
+    "subcategory": "waste_odor",
+    "risk_level": "LOW",
+    "needs_human_review": false,
+    "needs_clarification": false,
+    "building_name": "La Jolla Professional Suites",
+    "address": "9400 La Jolla Village Dr",
+    "floor": "Floor 3",
+    "dispatched_vendor_id": "v_025",
+    "dispatched_emergency_services": false,
+    "call_summary": "Waste/odor issue reported at La Jolla Professional Suites, Floor 3. LOW risk. Dispatched ProClean Facility Services.",
+    "trainer_log": {
+      "full_transcript": "[AGENT] CBRE maintenance line, what do you need?\n[CALLER] Hi, hold on, Bad garbage smell in the hallway outside the main trash.\n[AGENT] Okay. How bad is the smell?\n[CALLER] Just near the breakroom.\n[AGENT] Can you tell me the building, floor, and suite?\n[CALLER] Sorry, la Jolla Professional Suites, Floor 3, Suite 302.\n[AGENT] Okay, ticket's logged. Someone'll come out during business hours.",
+      "ai_prediction": {
+        "category": "JANITORIAL",
+        "subcategory": "waste_odor",
+        "risk_level": "LOW",
+        "dispatched_vendor_id": "v_025",
+        "dispatched_emergency_services": false,
+        "needs_human_review": false,
+        "needs_clarification": false,
+        "confidence_category": 0.9,
+        "confidence_subcategory": 0.9,
+        "validator_reasons": [
+          "auto_resolve:no_flags_fired"
+        ],
+        "risk_reasons": [
+          "base_risk:LOW"
+        ],
+        "retrieved_record_ids": [
+          "TKT-2022-09856",
+          "TKT-2022-03841",
+          "TKT-2022-01990",
+          "TKT-2022-02917",
+          "TKT-2022-00820",
+          "TKT-2024-00477",
+          "TKT-2023-09704",
+          "TKT-2022-07060"
+        ]
+      },
+      "human_override": null,
+      "final_decision": {
+        "category": "JANITORIAL",
+        "subcategory": "waste_odor",
+        "risk_level": "LOW",
+        "dispatched_vendor_id": "v_025",
+        "dispatched_emergency_services": false,
+        "needs_human_review": false,
+        "needs_clarification": false,
+        "confidence_category": 0.9,
+        "confidence_subcategory": 0.9,
+        "validator_reasons": [
+          "auto_resolve:no_flags_fired"
+        ],
+        "risk_reasons": [
+          "base_risk:LOW"
+        ],
+        "retrieved_record_ids": [
+          "TKT-2022-09856",
+          "TKT-2022-03841",
+          "TKT-2022-01990",
+          "TKT-2022-02917",
+          "TKT-2022-00820",
+          "TKT-2024-00477",
+          "TKT-2023-09704",
+          "TKT-2022-07060"
+        ]
+      }
+    },
+    "transcript_id": "EVAL-0694"
+  },
+  {
+    "category": "PLUMBING",
+    "subcategory": "pipe_leak",
+    "risk_level": "HIGH",
+    "needs_human_review": true,
+    "needs_clarification": false,
+    "building_name": "Brookfield Retail Center",
+    "address": "2200 Brookfield Rd",
+    "floor": "Floor 2",
+    "dispatched_vendor_id": "v_002",
+    "dispatched_emergency_services": false,
+    "call_summary": "Pipe leak reported at Brookfield Retail Center, Floor 2. HIGH risk. Flagged for review. Metro Drain & Pipe dispatched pending approval.",
+    "trainer_log": {
+      "full_transcript": "[AGENT] CBRE facilities, Marcus speaking. How can I help?\n[CALLER] There's something leaking, I think it's water.\n[AGENT] Okay, can you describe what you're seeing or smelling?\n[CALLER] It's coming out pretty fast now, filling up the floor.\n[AGENT] How large is the leak \u2014 dripping or pouring?\n[CALLER] Water's pooling \u2014 maybe a foot across?\n[AGENT] Which building and floor are you at?\n[CALLER] Brookfield Retail Center, Floor 2, Suite 208.\n[AGENT] Alright \u2014 sending a vendor over and giving the PM a heads-up.",
+      "ai_prediction": {
+        "category": "PLUMBING",
+        "subcategory": "pipe_leak",
+        "risk_level": "HIGH",
+        "dispatched_vendor_id": "v_002",
+        "dispatched_emergency_services": false,
+        "needs_human_review": true,
+        "needs_clarification": false,
+        "confidence_category": 0.95,
+        "confidence_subcategory": 0.95,
+        "validator_reasons": [
+          "high_band:always_pause"
+        ],
+        "risk_reasons": [
+          "base_risk:HIGH",
+          "soft_cue:flooding"
+        ],
+        "retrieved_record_ids": [
+          "TKT-2023-06353",
+          "TKT-2023-01511",
+          "TKT-2024-09768",
+          "TKT-2022-00526",
+          "TKT-2023-07484",
+          "TKT-2024-09915",
+          "TKT-2022-07615",
+          "TKT-2023-06098"
+        ]
+      },
+      "human_override": null,
+      "final_decision": {
+        "category": "PLUMBING",
+        "subcategory": "pipe_leak",
+        "risk_level": "HIGH",
+        "dispatched_vendor_id": "v_002",
+        "dispatched_emergency_services": false,
+        "needs_human_review": true,
+        "needs_clarification": false,
+        "confidence_category": 0.95,
+        "confidence_subcategory": 0.95,
+        "validator_reasons": [
+          "high_band:always_pause"
+        ],
+        "risk_reasons": [
+          "base_risk:HIGH",
+          "soft_cue:flooding"
+        ],
+        "retrieved_record_ids": [
+          "TKT-2023-06353",
+          "TKT-2023-01511",
+          "TKT-2024-09768",
+          "TKT-2022-00526",
+          "TKT-2023-07484",
+          "TKT-2024-09915",
+          "TKT-2022-07615",
+          "TKT-2023-06098"
+        ]
+      }
+    },
+    "transcript_id": "EVAL-0695"
+  },
+  {
+    "category": "HVAC",
+    "subcategory": "refrigerant",
+    "risk_level": "LOW",
+    "needs_human_review": false,
+    "needs_clarification": false,
+    "building_name": "Pacific Ridge Medical Plaza",
+    "address": "3200 Pacific Coast Hwy",
+    "floor": "Floor 8",
+    "dispatched_vendor_id": "v_014",
+    "dispatched_emergency_services": false,
+    "call_summary": "Refrigerant issue reported at Pacific Ridge Medical Plaza, Floor 8. LOW risk. Dispatched MediCool HVAC Systems.",
+    "trainer_log": {
+      "full_transcript": "[AGENT] Dispatch, what do you need?\n[CALLER] Hey, Chiller is making a hissing sound, AC performance dropping.\n[AGENT] Okay. Is the unit still running?\n[CALLER] Still running but not cold.\n[AGENT] Where exactly \u2014 which suite?\n[CALLER] Pacific Ridge Medical Plaza, Floor 8, Suite 804.\n[AGENT] Okay, ticket's logged. Someone'll come out during business hours.\n[CALLER] [door closing] Hold on, okay.",
+      "ai_prediction": {
+        "category": "HVAC",
+        "subcategory": "refrigerant",
+        "risk_level": "LOW",
+        "dispatched_vendor_id": "v_014",
+        "dispatched_emergency_services": false,
+        "needs_human_review": false,
+        "needs_clarification": false,
+        "confidence_category": 0.9,
+        "confidence_subcategory": 0.9,
+        "validator_reasons": [
+          "auto_resolve:no_flags_fired"
+        ],
+        "risk_reasons": [
+          "base_risk:LOW",
+          "sensitive_building:medical",
+          "capped_at_LOW:historical_max for subcategory=refrigerant"
+        ],
+        "retrieved_record_ids": [
+          "TKT-2023-05033",
+          "TKT-2024-00651",
+          "TKT-2024-04170",
+          "TKT-2024-04833",
+          "TKT-2022-04639",
+          "TKT-2022-04675",
+          "TKT-2024-03852",
+          "TKT-2023-03221"
+        ]
+      },
+      "human_override": null,
+      "final_decision": {
+        "category": "HVAC",
+        "subcategory": "refrigerant",
+        "risk_level": "LOW",
+        "dispatched_vendor_id": "v_014",
+        "dispatched_emergency_services": false,
+        "needs_human_review": false,
+        "needs_clarification": false,
+        "confidence_category": 0.9,
+        "confidence_subcategory": 0.9,
+        "validator_reasons": [
+          "auto_resolve:no_flags_fired"
+        ],
+        "risk_reasons": [
+          "base_risk:LOW",
+          "sensitive_building:medical",
+          "capped_at_LOW:historical_max for subcategory=refrigerant"
+        ],
+        "retrieved_record_ids": [
+          "TKT-2023-05033",
+          "TKT-2024-00651",
+          "TKT-2024-04170",
+          "TKT-2024-04833",
+          "TKT-2022-04639",
+          "TKT-2022-04675",
+          "TKT-2024-03852",
+          "TKT-2023-03221"
+        ]
+      }
+    },
+    "transcript_id": "EVAL-0700"
+  },
+  {
+    "category": "DOORS_ACCESS",
+    "subcategory": "access_control",
+    "risk_level": "LOW",
+    "needs_human_review": false,
+    "needs_clarification": true,
+    "building_name": "Metro Center Offices",
+    "address": "650 Metro Center Way",
+    "floor": "Floor 7",
+    "dispatched_vendor_id": "v_020",
+    "dispatched_emergency_services": false,
+    "call_summary": "Access control issue reported at Metro Center Offices, Floor 7. LOW risk. Dispatched SecurePass Access Systems.",
+    "trainer_log": {
+      "full_transcript": "[AGENT] CBRE dispatch \u2014 go ahead.\n[CALLER] I mean, there's an issue with access control.\n[AGENT] Can people still get in through another entrance?\n[CALLER] It's just the main entrance reader.\n[AGENT] Where exactly \u2014 which suite?\n[CALLER] Metro Center Offices, Floor 7, Suite 703.\n[AGENT] Alright, I've put a ticket in \u2014 vendor will swing by during business hours.",
+      "ai_prediction": {
+        "category": "DOORS_ACCESS",
+        "subcategory": "access_control",
+        "risk_level": "LOW",
+        "dispatched_vendor_id": "v_020",
+        "dispatched_emergency_services": false,
+        "needs_human_review": false,
+        "needs_clarification": true,
+        "confidence_category": 0.95,
+        "confidence_subcategory": 0.95,
+        "validator_reasons": [
+          "auto_resolve:no_flags_fired"
+        ],
+        "risk_reasons": [
+          "base_risk:LOW"
+        ],
+        "retrieved_record_ids": [
+          "TKT-2022-06742",
+          "TKT-2022-05827",
+          "TKT-2023-07865",
+          "TKT-2022-05233",
+          "TKT-2024-04359",
+          "TKT-2024-07713",
+          "TKT-2023-07835",
+          "TKT-2022-04831"
+        ]
+      },
+      "human_override": null,
+      "final_decision": {
+        "category": "DOORS_ACCESS",
+        "subcategory": "access_control",
+        "risk_level": "LOW",
+        "dispatched_vendor_id": "v_020",
+        "dispatched_emergency_services": false,
+        "needs_human_review": false,
+        "needs_clarification": true,
+        "confidence_category": 0.95,
+        "confidence_subcategory": 0.95,
+        "validator_reasons": [
+          "auto_resolve:no_flags_fired"
+        ],
+        "risk_reasons": [
+          "base_risk:LOW"
+        ],
+        "retrieved_record_ids": [
+          "TKT-2022-06742",
+          "TKT-2022-05827",
+          "TKT-2023-07865",
+          "TKT-2022-05233",
+          "TKT-2024-04359",
+          "TKT-2024-07713",
+          "TKT-2023-07835",
+          "TKT-2022-04831"
+        ]
+      }
+    },
+    "transcript_id": "EVAL-0702"
+  },
+  {
+    "category": "PLUMBING",
+    "subcategory": "drainage_backup",
+    "risk_level": "LOW",
+    "needs_human_review": false,
+    "needs_clarification": false,
+    "building_name": null,
+    "address": null,
+    "floor": "Floor 6",
+    "dispatched_vendor_id": "v_004",
+    "dispatched_emergency_services": false,
+    "call_summary": "Drainage backup reported at Floor 6. LOW risk. Dispatched Regency Commercial Plumbing.",
+    "trainer_log": {
+      "full_transcript": "[AGENT] CBRE maintenance line, what do you need?\n[CALLER] Hi there, sorry, Sink in the restroom on Floor 6 in Suite 603 won't drain properly.\n[AGENT] Mhm. Is it overflowing or just running?\n[CALLER] It's overflowing a little, but slow.\n[AGENT] Okay, ticket's logged. Someone'll come out during business hours.\n[CALLER] Alright, appreciate it.",
+      "ai_prediction": {
+        "category": "PLUMBING",
+        "subcategory": "drainage_backup",
+        "risk_level": "LOW",
+        "dispatched_vendor_id": "v_004",
+        "dispatched_emergency_services": false,
+        "needs_human_review": false,
+        "needs_clarification": false,
+        "confidence_category": 0.9,
+        "confidence_subcategory": 0.9,
+        "validator_reasons": [
+          "auto_resolve:no_flags_fired"
+        ],
+        "risk_reasons": [
+          "base_risk:LOW"
+        ],
+        "retrieved_record_ids": [
+          "TKT-2023-03968",
+          "TKT-2024-02400",
+          "TKT-2023-02699",
+          "TKT-2024-05934",
+          "TKT-2023-04442",
+          "TKT-2023-00302",
+          "TKT-2022-04963",
+          "TKT-2023-00164"
+        ]
+      },
+      "human_override": null,
+      "final_decision": {
+        "category": "PLUMBING",
+        "subcategory": "drainage_backup",
+        "risk_level": "LOW",
+        "dispatched_vendor_id": "v_004",
+        "dispatched_emergency_services": false,
+        "needs_human_review": false,
+        "needs_clarification": false,
+        "confidence_category": 0.9,
+        "confidence_subcategory": 0.9,
+        "validator_reasons": [
+          "auto_resolve:no_flags_fired"
+        ],
+        "risk_reasons": [
+          "base_risk:LOW"
+        ],
+        "retrieved_record_ids": [
+          "TKT-2023-03968",
+          "TKT-2024-02400",
+          "TKT-2023-02699",
+          "TKT-2024-05934",
+          "TKT-2023-04442",
+          "TKT-2023-00302",
+          "TKT-2022-04963",
+          "TKT-2023-00164"
+        ]
+      }
+    },
+    "transcript_id": "EVAL-0708"
+  },
+  {
+    "category": "DOORS_ACCESS",
+    "subcategory": "door_mechanical",
+    "risk_level": "LOW",
+    "needs_human_review": false,
+    "needs_clarification": false,
+    "building_name": "Northgate Logistics Hub",
+    "address": "7500 Northgate Way",
+    "floor": "Ground Floor",
+    "dispatched_vendor_id": "v_010",
+    "dispatched_emergency_services": false,
+    "call_summary": "Mechanical door issue reported at Northgate Logistics Hub, Ground Floor. LOW risk. Dispatched All-Site Facilities Co.",
+    "trainer_log": {
+      "full_transcript": "[AGENT] CBRE facilities \u2014 how can I help?\n[CALLER] You know, hi, Handle on the conference room door came off.\n[AGENT] Understood. Can the door be secured?\n[CALLER] Uh, it's an interior door to the suite.\n[AGENT] Which building, floor, and suite are you in?\n[CALLER] Northgate Logistics Hub, Ground Floor.\n[AGENT] Alright, I've put a ticket in \u2014 vendor will swing by during business hours.",
+      "ai_prediction": {
+        "category": "DOORS_ACCESS",
+        "subcategory": "door_mechanical",
+        "risk_level": "LOW",
+        "dispatched_vendor_id": "v_010",
+        "dispatched_emergency_services": false,
+        "needs_human_review": false,
+        "needs_clarification": false,
+        "confidence_category": 0.95,
+        "confidence_subcategory": 0.95,
+        "validator_reasons": [
+          "auto_resolve:no_flags_fired"
+        ],
+        "risk_reasons": [
+          "base_risk:LOW"
+        ],
+        "retrieved_record_ids": [
+          "TKT-2022-08599",
+          "TKT-2023-08012",
+          "TKT-2024-01089",
+          "TKT-2024-01140",
+          "TKT-2023-01742",
+          "TKT-2024-04578",
+          "TKT-2024-01185",
+          "TKT-2023-03227"
+        ]
+      },
+      "human_override": null,
+      "final_decision": {
+        "category": "DOORS_ACCESS",
+        "subcategory": "door_mechanical",
+        "risk_level": "LOW",
+        "dispatched_vendor_id": "v_010",
+        "dispatched_emergency_services": false,
+        "needs_human_review": false,
+        "needs_clarification": false,
+        "confidence_category": 0.95,
+        "confidence_subcategory": 0.95,
+        "validator_reasons": [
+          "auto_resolve:no_flags_fired"
+        ],
+        "risk_reasons": [
+          "base_risk:LOW"
+        ],
+        "retrieved_record_ids": [
+          "TKT-2022-08599",
+          "TKT-2023-08012",
+          "TKT-2024-01089",
+          "TKT-2024-01140",
+          "TKT-2023-01742",
+          "TKT-2024-04578",
+          "TKT-2024-01185",
+          "TKT-2023-03227"
+        ]
+      }
+    },
+    "transcript_id": "EVAL-0713"
+  },
+  {
+    "category": "HVAC",
+    "subcategory": "air_quality",
+    "risk_level": "MEDIUM",
+    "needs_human_review": true,
+    "needs_clarification": true,
+    "building_name": "La Jolla Professional Suites",
+    "address": "9400 La Jolla Village Dr",
+    "floor": "Floor 4",
+    "dispatched_vendor_id": "v_014",
+    "dispatched_emergency_services": false,
+    "call_summary": "Air quality concern reported at La Jolla Professional Suites, Floor 4. MEDIUM risk. Flagged for review. MediCool HVAC Systems dispatched pending approval.",
+    "trainer_log": {
+      "full_transcript": "[AGENT] CBRE maintenance line, this is Priya \u2014 what do you need?\n[CALLER] [muffled voices nearby] You know, two people on our floor on Floor 13 got headaches from a weird smell in the air.\n[AGENT] I want to make sure I have the right location \u2014 La Jolla Professional Suites only has 10 floors. Can you confirm the floor?\n[CALLER] Oh sorry \u2014 I meant Floor 4. I'm actually quite a bit flustered.\n[AGENT] I'll get a vendor rolling and let the property manager know.",
+      "ai_prediction": {
+        "category": "HVAC",
+        "subcategory": "air_quality",
+        "risk_level": "MEDIUM",
+        "dispatched_vendor_id": "v_014",
+        "dispatched_emergency_services": false,
+        "needs_human_review": true,
+        "needs_clarification": true,
+        "confidence_category": 0.95,
+        "confidence_subcategory": 0.95,
+        "validator_reasons": [
+          "trap_prone_subcategory:air_quality(over_escalation_rate=19%)"
+        ],
+        "risk_reasons": [
+          "base_risk:MEDIUM"
+        ],
+        "retrieved_record_ids": [
+          "TKT-2022-09628",
+          "TKT-2023-02228",
+          "TKT-2022-04507",
+          "TKT-2023-07133",
+          "TKT-2023-03584",
+          "TKT-2023-07025",
+          "TKT-2022-07066",
+          "TKT-2024-03192"
+        ]
+      },
+      "human_override": null,
+      "final_decision": {
+        "category": "HVAC",
+        "subcategory": "air_quality",
+        "risk_level": "MEDIUM",
+        "dispatched_vendor_id": "v_014",
+        "dispatched_emergency_services": false,
+        "needs_human_review": true,
+        "needs_clarification": true,
+        "confidence_category": 0.95,
+        "confidence_subcategory": 0.95,
+        "validator_reasons": [
+          "trap_prone_subcategory:air_quality(over_escalation_rate=19%)"
+        ],
+        "risk_reasons": [
+          "base_risk:MEDIUM"
+        ],
+        "retrieved_record_ids": [
+          "TKT-2022-09628",
+          "TKT-2023-02228",
+          "TKT-2022-04507",
+          "TKT-2023-07133",
+          "TKT-2023-03584",
+          "TKT-2023-07025",
+          "TKT-2022-07066",
+          "TKT-2024-03192"
+        ]
+      }
+    },
+    "transcript_id": "EVAL-0717"
+  },
+  {
+    "category": "ELEVATOR",
+    "subcategory": "entrapment",
+    "risk_level": "EMERGENCY",
+    "needs_human_review": true,
+    "needs_clarification": false,
+    "building_name": "Summit Office Towers",
+    "address": "800 Summit Blvd",
+    "floor": "Floor 4",
+    "dispatched_vendor_id": null,
+    "dispatched_emergency_services": true,
+    "call_summary": "Person trapped reported at Summit Office Towers, Floor 4. EMERGENCY risk. Emergency services dispatched.",
+    "trainer_log": {
+      "full_transcript": "[AGENT] CBRE facilities, Marcus speaking. How can I help?\n[CALLER] Hey, Elevator at Summit Office Towers on Floor 4 in Suite 401 jammed between floors, I can hear someone banging inside.\n[AGENT] Okay. Are they responding?\n[CALLER] Doors are closed, between floors three and four.\n[AGENT] Bumping this up to the on-call supervisor \u2014 vendor's going out as we speak.\n[CALLER] Thanks, bye.",
+      "ai_prediction": {
+        "category": "ELEVATOR",
+        "subcategory": "entrapment",
+        "risk_level": "EMERGENCY",
+        "dispatched_vendor_id": null,
+        "dispatched_emergency_services": true,
+        "needs_human_review": true,
+        "needs_clarification": false,
+        "confidence_category": 0.95,
+        "confidence_subcategory": 0.95,
+        "validator_reasons": [
+          "emergency_band:always_pause",
+          "emergency_dispatch:entrapment:hazard_cue_confirmed"
+        ],
+        "risk_reasons": [
+          "base_risk:EMERGENCY",
+          "hard_cue:trapped",
+          "capped_at_EMERGENCY:historical_max for subcategory=entrapment"
+        ],
+        "retrieved_record_ids": [
+          "TKT-2023-08972",
+          "TKT-2024-02442",
+          "TKT-2023-06026",
+          "TKT-2023-01571",
+          "TKT-2023-00695",
+          "TKT-2024-08640",
+          "TKT-2023-03836",
+          "TKT-2023-03107"
+        ]
+      },
+      "human_override": null,
+      "final_decision": {
+        "category": "ELEVATOR",
+        "subcategory": "entrapment",
+        "risk_level": "EMERGENCY",
+        "dispatched_vendor_id": null,
+        "dispatched_emergency_services": true,
+        "needs_human_review": true,
+        "needs_clarification": false,
+        "confidence_category": 0.95,
+        "confidence_subcategory": 0.95,
+        "validator_reasons": [
+          "emergency_band:always_pause",
+          "emergency_dispatch:entrapment:hazard_cue_confirmed"
+        ],
+        "risk_reasons": [
+          "base_risk:EMERGENCY",
+          "hard_cue:trapped",
+          "capped_at_EMERGENCY:historical_max for subcategory=entrapment"
+        ],
+        "retrieved_record_ids": [
+          "TKT-2023-08972",
+          "TKT-2024-02442",
+          "TKT-2023-06026",
+          "TKT-2023-01571",
+          "TKT-2023-00695",
+          "TKT-2024-08640",
+          "TKT-2023-03836",
+          "TKT-2023-03107"
+        ]
+      }
+    },
+    "transcript_id": "EVAL-0718"
+  },
+  {
+    "category": "DOORS_ACCESS",
+    "subcategory": "glass_damage",
+    "risk_level": "MEDIUM",
+    "needs_human_review": false,
+    "needs_clarification": false,
+    "building_name": "One Commerce Center",
+    "address": "1 Commerce Way",
+    "floor": "Floor 7",
+    "dispatched_vendor_id": "v_019",
+    "dispatched_emergency_services": false,
+    "call_summary": "Glass damage reported at One Commerce Center, Floor 7. MEDIUM risk. Dispatched Clear View Glazing.",
+    "trainer_log": {
+      "full_transcript": "[AGENT] CBRE facilities \u2014 how can I help?\n[CALLER] Hi there, There's a big crack in the storefront glass \u2014 don't think it was there yesterday.\n[AGENT] Alright. Can the opening be secured?\n[CALLER] No injuries.\n[AGENT] Which building and floor are you at?\n[CALLER] One Commerce Center, I mean, Floor 7, Suite 706.\n[AGENT] I'll send a vendor out and loop in the PM.\n[CALLER] Sorry, thank you.",
+      "ai_prediction": {
+        "category": "DOORS_ACCESS",
+        "subcategory": "glass_damage",
+        "risk_level": "MEDIUM",
+        "dispatched_vendor_id": "v_019",
+        "dispatched_emergency_services": false,
+        "needs_human_review": false,
+        "needs_clarification": false,
+        "confidence_category": 0.95,
+        "confidence_subcategory": 0.95,
+        "validator_reasons": [
+          "auto_resolve:no_flags_fired"
+        ],
+        "risk_reasons": [
+          "base_risk:MEDIUM"
+        ],
+        "retrieved_record_ids": [
+          "TKT-2024-09426",
+          "TKT-2024-03420",
+          "TKT-2023-03818",
+          "TKT-2022-02464",
+          "TKT-2022-05863",
+          "TKT-2023-02354",
+          "TKT-2022-06502",
+          "TKT-2024-07473"
+        ]
+      },
+      "human_override": null,
+      "final_decision": {
+        "category": "DOORS_ACCESS",
+        "subcategory": "glass_damage",
+        "risk_level": "MEDIUM",
+        "dispatched_vendor_id": "v_019",
+        "dispatched_emergency_services": false,
+        "needs_human_review": false,
+        "needs_clarification": false,
+        "confidence_category": 0.95,
+        "confidence_subcategory": 0.95,
+        "validator_reasons": [
+          "auto_resolve:no_flags_fired"
+        ],
+        "risk_reasons": [
+          "base_risk:MEDIUM"
+        ],
+        "retrieved_record_ids": [
+          "TKT-2024-09426",
+          "TKT-2024-03420",
+          "TKT-2023-03818",
+          "TKT-2022-02464",
+          "TKT-2022-05863",
+          "TKT-2023-02354",
+          "TKT-2022-06502",
+          "TKT-2024-07473"
+        ]
+      }
+    },
+    "transcript_id": "EVAL-0722"
+  },
+  {
+    "category": "SECURITY",
+    "subcategory": "active_threat",
+    "risk_level": "EMERGENCY",
+    "needs_human_review": true,
+    "needs_clarification": true,
+    "building_name": "Valley Medical Center",
+    "address": "150 Valley Health Blvd",
+    "floor": "Floor 3",
+    "dispatched_vendor_id": "v_027",
+    "dispatched_emergency_services": false,
+    "call_summary": "Active threat reported at Valley Medical Center, Floor 3. EMERGENCY risk. Flagged for review. Elite Protective Services dispatched pending approval.",
+    "trainer_log": {
+      "full_transcript": "[AGENT] CBRE maintenance \u2014 what's going on?\n[CALLER] There's an issue with active threat.\n[AGENT] Do you have a description?\n[CALLER] No injuries here.\n[AGENT] Which building, floor, and suite are you in?\n[CALLER] Hold on, valley Medical Center, Floor 3, Suite 306.\n[AGENT] I'm calling 911 right now \u2014 please evacuate if it's safe to do so.",
+      "ai_prediction": {
+        "category": "SECURITY",
+        "subcategory": "active_threat",
+        "risk_level": "EMERGENCY",
+        "dispatched_vendor_id": "v_027",
+        "dispatched_emergency_services": false,
+        "needs_human_review": true,
+        "needs_clarification": true,
+        "confidence_category": 0.95,
+        "confidence_subcategory": 0.95,
+        "validator_reasons": [
+          "emergency_band:always_pause",
+          "life_safety_no_autodispatch:no_hazard_cue"
+        ],
+        "risk_reasons": [
+          "base_risk:EMERGENCY",
+          "sensitive_building:medical",
+          "capped_at_EMERGENCY:historical_max for subcategory=active_threat"
+        ],
+        "retrieved_record_ids": [
+          "TKT-2023-08903",
+          "TKT-2023-05684",
+          "TKT-2023-05216",
+          "TKT-2023-01076",
+          "TKT-2022-09601",
+          "TKT-2023-05288",
+          "TKT-2024-06933",
+          "TKT-2023-08402"
+        ]
+      },
+      "human_override": null,
+      "final_decision": {
+        "category": "SECURITY",
+        "subcategory": "active_threat",
+        "risk_level": "EMERGENCY",
+        "dispatched_vendor_id": "v_027",
+        "dispatched_emergency_services": false,
+        "needs_human_review": true,
+        "needs_clarification": true,
+        "confidence_category": 0.95,
+        "confidence_subcategory": 0.95,
+        "validator_reasons": [
+          "emergency_band:always_pause",
+          "life_safety_no_autodispatch:no_hazard_cue"
+        ],
+        "risk_reasons": [
+          "base_risk:EMERGENCY",
+          "sensitive_building:medical",
+          "capped_at_EMERGENCY:historical_max for subcategory=active_threat"
+        ],
+        "retrieved_record_ids": [
+          "TKT-2023-08903",
+          "TKT-2023-05684",
+          "TKT-2023-05216",
+          "TKT-2023-01076",
+          "TKT-2022-09601",
+          "TKT-2023-05288",
+          "TKT-2024-06933",
+          "TKT-2023-08402"
+        ]
+      }
+    },
+    "transcript_id": "EVAL-0727"
+  },
+  {
+    "category": "PEST_SPECIALTY",
+    "subcategory": "infestation",
+    "risk_level": "LOW",
+    "needs_human_review": false,
+    "needs_clarification": false,
+    "building_name": "Seaside Professional Center",
+    "address": "350 Ocean View Ave",
+    "floor": "Floor 4",
+    "dispatched_vendor_id": "v_030",
+    "dispatched_emergency_services": false,
+    "call_summary": "Pest infestation reported at Seaside Professional Center, Floor 4. LOW risk. Dispatched Westside Pest Control.",
+    "trainer_log": {
+      "full_transcript": "[AGENT] CBRE maintenance line, what do you need?\n[CALLER] Good afternoon, Ants all over the counter in the kitchenette.\n[AGENT] Mhm. What kind of pest?\n[CALLER] Like, there's droppings behind the trash bins.\n[AGENT] Where exactly \u2014 which suite?\n[CALLER] Seaside Professional Center, Floor 4, Suite 404.\n[AGENT] Alright, I'll send a vendor over. You'll get a text once they're rolling.\n[CALLER] Sorry, thank you.",
+      "ai_prediction": {
+        "category": "PEST_SPECIALTY",
+        "subcategory": "infestation",
+        "risk_level": "LOW",
+        "dispatched_vendor_id": "v_030",
+        "dispatched_emergency_services": false,
+        "needs_human_review": false,
+        "needs_clarification": false,
+        "confidence_category": 0.95,
+        "confidence_subcategory": 0.95,
+        "validator_reasons": [
+          "auto_resolve:no_flags_fired"
+        ],
+        "risk_reasons": [
+          "base_risk:LOW"
+        ],
+        "retrieved_record_ids": [
+          "TKT-2023-08177",
+          "TKT-2024-08823",
+          "TKT-2024-06219",
+          "TKT-2023-08936",
+          "TKT-2023-00860",
+          "TKT-2023-06182",
+          "TKT-2022-05215",
+          "TKT-2023-09878"
+        ]
+      },
+      "human_override": null,
+      "final_decision": {
+        "category": "PEST_SPECIALTY",
+        "subcategory": "infestation",
+        "risk_level": "LOW",
+        "dispatched_vendor_id": "v_030",
+        "dispatched_emergency_services": false,
+        "needs_human_review": false,
+        "needs_clarification": false,
+        "confidence_category": 0.95,
+        "confidence_subcategory": 0.95,
+        "validator_reasons": [
+          "auto_resolve:no_flags_fired"
+        ],
+        "risk_reasons": [
+          "base_risk:LOW"
+        ],
+        "retrieved_record_ids": [
+          "TKT-2023-08177",
+          "TKT-2024-08823",
+          "TKT-2024-06219",
+          "TKT-2023-08936",
+          "TKT-2023-00860",
+          "TKT-2023-06182",
+          "TKT-2022-05215",
+          "TKT-2023-09878"
+        ]
+      }
+    },
+    "transcript_id": "EVAL-0744"
+  },
+  {
+    "category": "LIFE_SAFETY",
+    "subcategory": "gas_chemical",
+    "risk_level": "EMERGENCY",
+    "needs_human_review": true,
+    "needs_clarification": false,
+    "building_name": "Lakewood Plaza",
+    "address": "550 Lakewood Center Mall",
+    "floor": "Floor 1",
+    "dispatched_vendor_id": null,
+    "dispatched_emergency_services": true,
+    "call_summary": "Gas or chemical hazard reported at Lakewood Plaza, Floor 1. EMERGENCY risk. Emergency services dispatched.",
+    "trainer_log": {
+      "full_transcript": "[AGENT] CBRE facilities, this is Sam. What's going on?\n[CALLER] Hey, Propane smell in the kitchen, we shut off the main.\n[AGENT] Understood. Did you see a container or source?\n[CALLER] I saw a small bottle on its side.\n[AGENT] Where exactly \u2014 which suite?\n[CALLER] Lakewood Plaza, Floor 1, Suite 106.\n[AGENT] Did you see a container or source?\n[CALLER] Smells like rotten eggs \u2014 pretty strong.\n[AGENT] Dialing 911 now and pushing a vendor out at the same time.\n[CALLER] Okay.",
+      "ai_prediction": {
+        "category": "LIFE_SAFETY",
+        "subcategory": "gas_chemical",
+        "risk_level": "EMERGENCY",
+        "dispatched_vendor_id": null,
+        "dispatched_emergency_services": true,
+        "needs_human_review": true,
+        "needs_clarification": false,
+        "confidence_category": 0.95,
+        "confidence_subcategory": 0.95,
+        "validator_reasons": [
+          "emergency_band:always_pause",
+          "emergency_dispatch:gas_chemical:hazard_cue_confirmed"
+        ],
+        "risk_reasons": [
+          "base_risk:EMERGENCY",
+          "hard_cue:gas leak",
+          "capped_at_EMERGENCY:historical_max for subcategory=gas_chemical"
+        ],
+        "retrieved_record_ids": [
+          "TKT-2022-01186",
+          "TKT-2022-04411",
+          "TKT-2024-04602",
+          "TKT-2024-06876",
+          "TKT-2024-03123",
+          "TKT-2023-06917",
+          "TKT-2024-09132",
+          "TKT-2023-08843"
+        ]
+      },
+      "human_override": null,
+      "final_decision": {
+        "category": "LIFE_SAFETY",
+        "subcategory": "gas_chemical",
+        "risk_level": "EMERGENCY",
+        "dispatched_vendor_id": null,
+        "dispatched_emergency_services": true,
+        "needs_human_review": true,
+        "needs_clarification": false,
+        "confidence_category": 0.95,
+        "confidence_subcategory": 0.95,
+        "validator_reasons": [
+          "emergency_band:always_pause",
+          "emergency_dispatch:gas_chemical:hazard_cue_confirmed"
+        ],
+        "risk_reasons": [
+          "base_risk:EMERGENCY",
+          "hard_cue:gas leak",
+          "capped_at_EMERGENCY:historical_max for subcategory=gas_chemical"
+        ],
+        "retrieved_record_ids": [
+          "TKT-2022-01186",
+          "TKT-2022-04411",
+          "TKT-2024-04602",
+          "TKT-2024-06876",
+          "TKT-2024-03123",
+          "TKT-2023-06917",
+          "TKT-2024-09132",
+          "TKT-2023-08843"
+        ]
+      }
+    },
+    "transcript_id": "EVAL-0745"
+  },
+  {
+    "category": "ELEVATOR",
+    "subcategory": "malfunction",
+    "risk_level": "MEDIUM",
+    "needs_human_review": true,
+    "needs_clarification": false,
+    "building_name": "Brookfield Retail Center",
+    "address": "2200 Brookfield Rd",
+    "floor": "Floor 3",
+    "dispatched_vendor_id": "v_016",
+    "dispatched_emergency_services": false,
+    "call_summary": "Equipment malfunction reported at Brookfield Retail Center, Floor 3. MEDIUM risk. Flagged for review. Skyline Elevator Co dispatched pending approval.",
+    "trainer_log": {
+      "full_transcript": "[AGENT] Maintenance, what's the situation?\n[CALLER] I mean, elevator seems broken, not sure if anyone's in it.\n[AGENT] Okay, can you describe what you're seeing or smelling?\n[CALLER] Sorry, not moving at all.\n[AGENT] Is the car moving at all?\n[CALLER] Doors open, car hasn't left the lobby.\n[AGENT] Can you confirm the building and floor?\n[CALLER] Like, brookfield Retail Center, Floor 3, Suite 305.\n[AGENT] Tech is on the way. You'll get a text once they're rolling.",
+      "ai_prediction": {
+        "category": "ELEVATOR",
+        "subcategory": "malfunction",
+        "risk_level": "MEDIUM",
+        "dispatched_vendor_id": "v_016",
+        "dispatched_emergency_services": false,
+        "needs_human_review": true,
+        "needs_clarification": false,
+        "confidence_category": 0.9,
+        "confidence_subcategory": 0.9,
+        "validator_reasons": [
+          "trap_cascade_subcategory:malfunction(high-audit cell at HIGH/EMERGENCY \u2014 possible under-classification)"
+        ],
+        "risk_reasons": [
+          "base_risk:MEDIUM"
+        ],
+        "retrieved_record_ids": [
+          "TKT-2022-07741",
+          "TKT-2024-03417",
+          "TKT-2023-07646",
+          "TKT-2024-06018",
+          "TKT-2024-02205",
+          "TKT-2024-01425",
+          "TKT-2024-02826",
+          "TKT-2024-01560"
+        ]
+      },
+      "human_override": null,
+      "final_decision": {
+        "category": "ELEVATOR",
+        "subcategory": "malfunction",
+        "risk_level": "MEDIUM",
+        "dispatched_vendor_id": "v_016",
+        "dispatched_emergency_services": false,
+        "needs_human_review": true,
+        "needs_clarification": false,
+        "confidence_category": 0.9,
+        "confidence_subcategory": 0.9,
+        "validator_reasons": [
+          "trap_cascade_subcategory:malfunction(high-audit cell at HIGH/EMERGENCY \u2014 possible under-classification)"
+        ],
+        "risk_reasons": [
+          "base_risk:MEDIUM"
+        ],
+        "retrieved_record_ids": [
+          "TKT-2022-07741",
+          "TKT-2024-03417",
+          "TKT-2023-07646",
+          "TKT-2024-06018",
+          "TKT-2024-02205",
+          "TKT-2024-01425",
+          "TKT-2024-02826",
+          "TKT-2024-01560"
+        ]
+      }
+    },
+    "transcript_id": "EVAL-0749"
+  },
+  {
+    "category": "HVAC",
+    "subcategory": "air_quality",
+    "risk_level": "MEDIUM",
+    "needs_human_review": true,
+    "needs_clarification": false,
+    "building_name": "Harbor Point Tower",
+    "address": "250 Harbor Dr",
+    "floor": "Floor 15",
+    "dispatched_vendor_id": "v_014",
+    "dispatched_emergency_services": false,
+    "call_summary": "Air quality concern reported at Harbor Point Tower, Floor 15. MEDIUM risk. Flagged for review. MediCool HVAC Systems dispatched pending approval.",
+    "trainer_log": {
+      "full_transcript": "[AGENT] Hi, CBRE facilities. What can I do for you?\n[CALLER] Strong chemical smell in the hallway, like cleaning fluid \u2014 the janitor just mopped with bleach solution.\n[AGENT] Okay \u2014 can you confirm there's no actual fire or injury right now?\n[CALLER] Uh, no, just the smell \u2014 no one's hurt, just annoying.\n[AGENT] Can you confirm the building and floor?\n[CALLER] Harbor Point Tower, um, Floor 15, Suite 1506.\n[AGENT] I'll get a vendor rolling and let the property manager know.",
+      "ai_prediction": {
+        "category": "HVAC",
+        "subcategory": "air_quality",
+        "risk_level": "MEDIUM",
+        "dispatched_vendor_id": "v_014",
+        "dispatched_emergency_services": false,
+        "needs_human_review": true,
+        "needs_clarification": false,
+        "confidence_category": 0.95,
+        "confidence_subcategory": 0.95,
+        "validator_reasons": [
+          "trap_prone_subcategory:air_quality(over_escalation_rate=19%)"
+        ],
+        "risk_reasons": [
+          "base_risk:MEDIUM"
+        ],
+        "retrieved_record_ids": [
+          "TKT-2023-00554",
+          "TKT-2024-08193",
+          "TKT-2022-07963",
+          "TKT-2022-07075",
+          "TKT-2023-02927",
+          "TKT-2023-01952",
+          "TKT-2023-01151",
+          "TKT-2023-02570"
+        ]
+      },
+      "human_override": null,
+      "final_decision": {
+        "category": "HVAC",
+        "subcategory": "air_quality",
+        "risk_level": "MEDIUM",
+        "dispatched_vendor_id": "v_014",
+        "dispatched_emergency_services": false,
+        "needs_human_review": true,
+        "needs_clarification": false,
+        "confidence_category": 0.95,
+        "confidence_subcategory": 0.95,
+        "validator_reasons": [
+          "trap_prone_subcategory:air_quality(over_escalation_rate=19%)"
+        ],
+        "risk_reasons": [
+          "base_risk:MEDIUM"
+        ],
+        "retrieved_record_ids": [
+          "TKT-2023-00554",
+          "TKT-2024-08193",
+          "TKT-2022-07963",
+          "TKT-2022-07075",
+          "TKT-2023-02927",
+          "TKT-2023-01952",
+          "TKT-2023-01151",
+          "TKT-2023-02570"
+        ]
+      }
+    },
+    "transcript_id": "EVAL-0752"
+  },
+  {
+    "category": "ELECTRICAL",
+    "subcategory": "lighting",
+    "risk_level": "LOW",
+    "needs_human_review": false,
+    "needs_clarification": false,
+    "building_name": "Summit Office Towers",
+    "address": "800 Summit Blvd",
+    "floor": "Floor 14",
+    "dispatched_vendor_id": "v_010",
+    "dispatched_emergency_services": false,
+    "call_summary": "Lighting failure reported at Summit Office Towers, Floor 14. LOW risk. Dispatched All-Site Facilities Co.",
+    "trainer_log": {
+      "full_transcript": "[AGENT] CBRE dispatch \u2014 go ahead.\n[CALLER] [muffled voices nearby] Hi there, Overhead fluorescent light is flickering badly.\n[AGENT] Alright. Is it one fixture or multiple?\n[CALLER] Like, four fixtures in the hallway.\n[AGENT] Where exactly \u2014 which suite?\n[CALLER] Summit Office Towers, Floor 14.\n[AGENT] Alright, I've put a ticket in \u2014 vendor will swing by during business hours.\n[CALLER] Okay, I mean, please hurry.",
+      "ai_prediction": {
+        "category": "ELECTRICAL",
+        "subcategory": "lighting",
+        "risk_level": "LOW",
+        "dispatched_vendor_id": "v_010",
+        "dispatched_emergency_services": false,
+        "needs_human_review": false,
+        "needs_clarification": false,
+        "confidence_category": 0.95,
+        "confidence_subcategory": 0.95,
+        "validator_reasons": [
+          "auto_resolve:no_flags_fired"
+        ],
+        "risk_reasons": [
+          "base_risk:LOW"
+        ],
+        "retrieved_record_ids": [
+          "TKT-2022-09040",
+          "TKT-2022-07648",
+          "TKT-2024-04419",
+          "TKT-2024-00897",
+          "TKT-2023-07181",
+          "TKT-2023-03215",
+          "TKT-2023-02204",
+          "TKT-2022-04633"
+        ]
+      },
+      "human_override": null,
+      "final_decision": {
+        "category": "ELECTRICAL",
+        "subcategory": "lighting",
+        "risk_level": "LOW",
+        "dispatched_vendor_id": "v_010",
+        "dispatched_emergency_services": false,
+        "needs_human_review": false,
+        "needs_clarification": false,
+        "confidence_category": 0.95,
+        "confidence_subcategory": 0.95,
+        "validator_reasons": [
+          "auto_resolve:no_flags_fired"
+        ],
+        "risk_reasons": [
+          "base_risk:LOW"
+        ],
+        "retrieved_record_ids": [
+          "TKT-2022-09040",
+          "TKT-2022-07648",
+          "TKT-2024-04419",
+          "TKT-2024-00897",
+          "TKT-2023-07181",
+          "TKT-2023-03215",
+          "TKT-2023-02204",
+          "TKT-2022-04633"
+        ]
+      }
+    },
+    "transcript_id": "EVAL-0761"
+  },
+  {
+    "category": "ELECTRICAL",
+    "subcategory": "panel_hazard",
+    "risk_level": "EMERGENCY",
+    "needs_human_review": true,
+    "needs_clarification": false,
+    "building_name": "Meridian Business Park",
+    "address": "1500 Meridian Ave",
+    "floor": "Floor 1",
+    "dispatched_vendor_id": null,
+    "dispatched_emergency_services": false,
+    "call_summary": "Electrical panel hazard reported at Meridian Business Park, Floor 1. EMERGENCY risk. Escalated to human review \u2014 no qualified vendor available.",
+    "trainer_log": {
+      "full_transcript": "[AGENT] CBRE dispatch, talk to me.\n[CALLER] I mean, the outlet is hot to the touch and smells like melted plastic.\n[AGENT] Okay, I see. Have you shut off power to that circuit?\n[CALLER] Nobody's near it, I told everyone to back away.\n[AGENT] Where exactly \u2014 which suite?\n[CALLER] Meridian Business Park, Floor 1, Suite 210.\n[AGENT] Pulling in the supervisor and dispatching a vendor right now.\n[CALLER] Okay.",
+      "ai_prediction": {
+        "category": "ELECTRICAL",
+        "subcategory": "panel_hazard",
+        "risk_level": "EMERGENCY",
+        "dispatched_vendor_id": null,
+        "dispatched_emergency_services": false,
+        "needs_human_review": true,
+        "needs_clarification": false,
+        "confidence_category": 0.95,
+        "confidence_subcategory": 0.95,
+        "validator_reasons": [
+          "emergency_band:always_pause",
+          "life_safety_no_autodispatch:no_hazard_cue"
+        ],
+        "risk_reasons": [
+          "base_risk:EMERGENCY"
+        ],
+        "retrieved_record_ids": [
+          "TKT-2023-04196",
+          "TKT-2023-03122",
+          "TKT-2022-08641",
+          "TKT-2023-00026",
+          "TKT-2023-07337",
+          "TKT-2022-01414",
+          "TKT-2024-07755",
+          "TKT-2024-07923"
+        ]
+      },
+      "human_override": null,
+      "final_decision": {
+        "category": "ELECTRICAL",
+        "subcategory": "panel_hazard",
+        "risk_level": "EMERGENCY",
+        "dispatched_vendor_id": null,
+        "dispatched_emergency_services": false,
+        "needs_human_review": true,
+        "needs_clarification": false,
+        "confidence_category": 0.95,
+        "confidence_subcategory": 0.95,
+        "validator_reasons": [
+          "emergency_band:always_pause",
+          "life_safety_no_autodispatch:no_hazard_cue"
+        ],
+        "risk_reasons": [
+          "base_risk:EMERGENCY"
+        ],
+        "retrieved_record_ids": [
+          "TKT-2023-04196",
+          "TKT-2023-03122",
+          "TKT-2022-08641",
+          "TKT-2023-00026",
+          "TKT-2023-07337",
+          "TKT-2022-01414",
+          "TKT-2024-07755",
+          "TKT-2024-07923"
+        ]
+      }
+    },
+    "transcript_id": "EVAL-0762"
+  },
+  {
+    "category": "ELECTRICAL",
+    "subcategory": "lighting",
+    "risk_level": "LOW",
+    "needs_human_review": false,
+    "needs_clarification": false,
+    "building_name": "Lakewood Plaza",
+    "address": "550 Lakewood Center Mall",
+    "floor": "Floor 2",
+    "dispatched_vendor_id": "v_010",
+    "dispatched_emergency_services": false,
+    "call_summary": "Lighting failure reported at Lakewood Plaza, Floor 2. LOW risk. Dispatched All-Site Facilities Co.",
+    "trainer_log": {
+      "full_transcript": "[AGENT] CBRE dispatch \u2014 go ahead.\n[CALLER] Good afternoon, The hallway light is out - can't see the doorways.\n[AGENT] Mhm. Is it one fixture or multiple?\n[CALLER] Flickering, kind of strobing.\n[AGENT] Can you confirm the building and floor?\n[CALLER] Lakewood Plaza, Floor 2, Suite 209.\n[AGENT] Hmm, none of our vendors are quite the right fit \u2014 let me bump this up to the on-call PM so they can handle it directly.\n[CALLER] Okay, please hurry.",
+      "ai_prediction": {
+        "category": "ELECTRICAL",
+        "subcategory": "lighting",
+        "risk_level": "LOW",
+        "dispatched_vendor_id": "v_010",
+        "dispatched_emergency_services": false,
+        "needs_human_review": false,
+        "needs_clarification": false,
+        "confidence_category": 0.95,
+        "confidence_subcategory": 0.95,
+        "validator_reasons": [
+          "auto_resolve:no_flags_fired"
+        ],
+        "risk_reasons": [
+          "base_risk:LOW"
+        ],
+        "retrieved_record_ids": [
+          "TKT-2024-01584",
+          "TKT-2023-03776",
+          "TKT-2022-06532",
+          "TKT-2023-03671",
+          "TKT-2024-01398",
+          "TKT-2023-01097",
+          "TKT-2024-08067",
+          "TKT-2024-09948"
+        ]
+      },
+      "human_override": null,
+      "final_decision": {
+        "category": "ELECTRICAL",
+        "subcategory": "lighting",
+        "risk_level": "LOW",
+        "dispatched_vendor_id": "v_010",
+        "dispatched_emergency_services": false,
+        "needs_human_review": false,
+        "needs_clarification": false,
+        "confidence_category": 0.95,
+        "confidence_subcategory": 0.95,
+        "validator_reasons": [
+          "auto_resolve:no_flags_fired"
+        ],
+        "risk_reasons": [
+          "base_risk:LOW"
+        ],
+        "retrieved_record_ids": [
+          "TKT-2024-01584",
+          "TKT-2023-03776",
+          "TKT-2022-06532",
+          "TKT-2023-03671",
+          "TKT-2024-01398",
+          "TKT-2023-01097",
+          "TKT-2024-08067",
+          "TKT-2024-09948"
+        ]
+      }
+    },
+    "transcript_id": "EVAL-0768"
+  },
+  {
+    "category": "PLUMBING",
+    "subcategory": "restroom_fixture",
+    "risk_level": "LOW",
+    "needs_human_review": false,
+    "needs_clarification": false,
+    "building_name": "Tower One at Tech Park",
+    "address": "3000 Innovation Way",
+    "floor": "Floor 14",
+    "dispatched_vendor_id": "v_002",
+    "dispatched_emergency_services": false,
+    "call_summary": "Restroom fixture issue reported at Tower One at Tech Park, Floor 14. LOW risk. Dispatched Metro Drain & Pipe.",
+    "trainer_log": {
+      "full_transcript": "[AGENT] CBRE maintenance line, this is Priya \u2014 what do you need?\n[CALLER] Good morning, hold on, Sink in the restroom won't drain properly.\n[AGENT] Got it. Is it overflowing or just running?\n[CALLER] Just running continuously.\n[AGENT] Which building and floor are you at?\n[CALLER] Tower One at Tech Park, Floor 14, Suite 1401.\n[AGENT] Okay, I'll line that up now. Confirmation text will come through shortly.\n[CALLER] Thank you.",
+      "ai_prediction": {
+        "category": "PLUMBING",
+        "subcategory": "restroom_fixture",
+        "risk_level": "LOW",
+        "dispatched_vendor_id": "v_002",
+        "dispatched_emergency_services": false,
+        "needs_human_review": false,
+        "needs_clarification": false,
+        "confidence_category": 0.95,
+        "confidence_subcategory": 0.95,
+        "validator_reasons": [
+          "auto_resolve:no_flags_fired"
+        ],
+        "risk_reasons": [
+          "base_risk:LOW"
+        ],
+        "retrieved_record_ids": [
+          "TKT-2023-07211",
+          "TKT-2024-07662",
+          "TKT-2022-06007",
+          "TKT-2023-00233",
+          "TKT-2024-09354",
+          "TKT-2022-02386",
+          "TKT-2022-08431",
+          "TKT-2024-01410"
+        ]
+      },
+      "human_override": null,
+      "final_decision": {
+        "category": "PLUMBING",
+        "subcategory": "restroom_fixture",
+        "risk_level": "LOW",
+        "dispatched_vendor_id": "v_002",
+        "dispatched_emergency_services": false,
+        "needs_human_review": false,
+        "needs_clarification": false,
+        "confidence_category": 0.95,
+        "confidence_subcategory": 0.95,
+        "validator_reasons": [
+          "auto_resolve:no_flags_fired"
+        ],
+        "risk_reasons": [
+          "base_risk:LOW"
+        ],
+        "retrieved_record_ids": [
+          "TKT-2023-07211",
+          "TKT-2024-07662",
+          "TKT-2022-06007",
+          "TKT-2023-00233",
+          "TKT-2024-09354",
+          "TKT-2022-02386",
+          "TKT-2022-08431",
+          "TKT-2024-01410"
+        ]
+      }
+    },
+    "transcript_id": "EVAL-0771"
+  },
+  {
+    "category": "SECURITY",
+    "subcategory": "unauthorized_access",
+    "risk_level": "HIGH",
+    "needs_human_review": true,
+    "needs_clarification": false,
+    "building_name": "Metro Center Offices",
+    "address": "650 Metro Center Way",
+    "floor": "Floor 8",
+    "dispatched_vendor_id": "v_027",
+    "dispatched_emergency_services": false,
+    "call_summary": "Unauthorized access reported at Metro Center Offices, Floor 8. HIGH risk. Flagged for review. Elite Protective Services dispatched pending approval.",
+    "trainer_log": {
+      "full_transcript": "[AGENT] Maintenance, what's the situation?\n[CALLER] Good morning, Unauthorized person in the server room on Floor 8 in Suite 803, I just saw them.\n[AGENT] Mhm. Do you have a description?\n[CALLER] He's still in the back corridor.\n[AGENT] Are they still on-site?\n[CALLER] He's still in the back corridor.\n[AGENT] Pulling in the supervisor and dispatching a vendor right now.\n[CALLER] Thank you.",
+      "ai_prediction": {
+        "category": "SECURITY",
+        "subcategory": "unauthorized_access",
+        "risk_level": "HIGH",
+        "dispatched_vendor_id": "v_027",
+        "dispatched_emergency_services": false,
+        "needs_human_review": true,
+        "needs_clarification": false,
+        "confidence_category": 0.95,
+        "confidence_subcategory": 0.95,
+        "validator_reasons": [
+          "high_band:always_pause"
+        ],
+        "risk_reasons": [
+          "base_risk:HIGH"
+        ],
+        "retrieved_record_ids": [
+          "TKT-2024-06600",
+          "TKT-2023-07052",
+          "TKT-2023-03677",
+          "TKT-2024-07407",
+          "TKT-2023-01805",
+          "TKT-2022-07756",
+          "TKT-2022-09184",
+          "TKT-2022-09475"
+        ]
+      },
+      "human_override": null,
+      "final_decision": {
+        "category": "SECURITY",
+        "subcategory": "unauthorized_access",
+        "risk_level": "HIGH",
+        "dispatched_vendor_id": "v_027",
+        "dispatched_emergency_services": false,
+        "needs_human_review": true,
+        "needs_clarification": false,
+        "confidence_category": 0.95,
+        "confidence_subcategory": 0.95,
+        "validator_reasons": [
+          "high_band:always_pause"
+        ],
+        "risk_reasons": [
+          "base_risk:HIGH"
+        ],
+        "retrieved_record_ids": [
+          "TKT-2024-06600",
+          "TKT-2023-07052",
+          "TKT-2023-03677",
+          "TKT-2024-07407",
+          "TKT-2023-01805",
+          "TKT-2022-07756",
+          "TKT-2022-09184",
+          "TKT-2022-09475"
+        ]
+      }
+    },
+    "transcript_id": "EVAL-0779"
+  },
+  {
+    "category": "JANITORIAL",
+    "subcategory": "waste_odor",
+    "risk_level": "LOW",
+    "needs_human_review": false,
+    "needs_clarification": false,
+    "building_name": "Capitol Mall Tower",
+    "address": "400 Capitol Mall",
+    "floor": "Floor 20",
+    "dispatched_vendor_id": "v_024",
+    "dispatched_emergency_services": false,
+    "call_summary": "Waste/odor issue reported at Capitol Mall Tower, Floor 20. LOW risk. Dispatched Bay Area Cleaning Solutions.",
+    "trainer_log": {
+      "full_transcript": "[AGENT] CBRE facilities, Marcus speaking. How can I help?\n[CALLER] Smoke alarm beeped once and there's smoke \u2014 but it was just burnt toast in the toaster, no fire.\n[AGENT] Okay \u2014 can you confirm there's no actual fire or injury right now?\n[CALLER] No fire, just the burnt smell.\n[AGENT] Where exactly \u2014 which suite?\n[CALLER] Um, capitol Mall Tower, Floor 20, Suite 2004.\n[AGENT] Alright, I'll send a vendor over. You'll get a text once they're rolling.",
+      "ai_prediction": {
+        "category": "JANITORIAL",
+        "subcategory": "waste_odor",
+        "risk_level": "LOW",
+        "dispatched_vendor_id": "v_024",
+        "dispatched_emergency_services": false,
+        "needs_human_review": false,
+        "needs_clarification": false,
+        "confidence_category": 0.95,
+        "confidence_subcategory": 0.95,
+        "validator_reasons": [
+          "auto_resolve:no_flags_fired"
+        ],
+        "risk_reasons": [
+          "base_risk:LOW",
+          "hard_cue:smoke",
+          "capped_at_LOW:historical_max for subcategory=waste_odor"
+        ],
+        "retrieved_record_ids": [
+          "TKT-2022-05209",
+          "TKT-2022-03682",
+          "TKT-2022-01846",
+          "TKT-2024-01575",
+          "TKT-2024-03702",
+          "TKT-2022-06064",
+          "TKT-2024-02877",
+          "TKT-2024-01983"
+        ]
+      },
+      "human_override": null,
+      "final_decision": {
+        "category": "JANITORIAL",
+        "subcategory": "waste_odor",
+        "risk_level": "LOW",
+        "dispatched_vendor_id": "v_024",
+        "dispatched_emergency_services": false,
+        "needs_human_review": false,
+        "needs_clarification": false,
+        "confidence_category": 0.95,
+        "confidence_subcategory": 0.95,
+        "validator_reasons": [
+          "auto_resolve:no_flags_fired"
+        ],
+        "risk_reasons": [
+          "base_risk:LOW",
+          "hard_cue:smoke",
+          "capped_at_LOW:historical_max for subcategory=waste_odor"
+        ],
+        "retrieved_record_ids": [
+          "TKT-2022-05209",
+          "TKT-2022-03682",
+          "TKT-2022-01846",
+          "TKT-2024-01575",
+          "TKT-2024-03702",
+          "TKT-2022-06064",
+          "TKT-2024-02877",
+          "TKT-2024-01983"
+        ]
+      }
+    },
+    "transcript_id": "EVAL-0788"
+  },
+  {
+    "category": "JANITORIAL",
+    "subcategory": "restroom_supplies",
+    "risk_level": "LOW",
+    "needs_human_review": false,
+    "needs_clarification": false,
+    "building_name": "Sierra Vista Medical Office",
+    "address": "750 Sierra Vista Ave",
+    "floor": "Rooftop",
+    "dispatched_vendor_id": "v_025",
+    "dispatched_emergency_services": false,
+    "call_summary": "Restroom supply issue reported at Sierra Vista Medical Office, Rooftop. LOW risk. Dispatched ProClean Facility Services.",
+    "trainer_log": {
+      "full_transcript": "[AGENT] CBRE maintenance line, what do you need?\n[CALLER] The restroom's out of stuff.\n[AGENT] Okay, can you describe what you're seeing or smelling?\n[CALLER] Women's room on three.\n[AGENT] Which restroom \u2014 men's, women's, or family?\n[CALLER] Just TP \u2014 the rest is fine.\n[AGENT] Can you tell me the building, floor, and suite?\n[CALLER] Uh, sierra Vista Medical Office, Rooftop.\n[AGENT] Okay, ticket's logged. Someone'll come out during business hours.",
+      "ai_prediction": {
+        "category": "JANITORIAL",
+        "subcategory": "restroom_supplies",
+        "risk_level": "LOW",
+        "dispatched_vendor_id": "v_025",
+        "dispatched_emergency_services": false,
+        "needs_human_review": false,
+        "needs_clarification": false,
+        "confidence_category": 0.95,
+        "confidence_subcategory": 0.95,
+        "validator_reasons": [
+          "auto_resolve:no_flags_fired"
+        ],
+        "risk_reasons": [
+          "base_risk:LOW",
+          "sensitive_building:medical",
+          "capped_at_LOW:historical_max for subcategory=restroom_supplies"
+        ],
+        "retrieved_record_ids": [
+          "TKT-2022-08467",
+          "TKT-2022-04618",
+          "TKT-2024-02238",
+          "TKT-2023-08306",
+          "TKT-2022-06448",
+          "TKT-2022-05617",
+          "TKT-2022-01720",
+          "TKT-2024-00984"
+        ]
+      },
+      "human_override": null,
+      "final_decision": {
+        "category": "JANITORIAL",
+        "subcategory": "restroom_supplies",
+        "risk_level": "LOW",
+        "dispatched_vendor_id": "v_025",
+        "dispatched_emergency_services": false,
+        "needs_human_review": false,
+        "needs_clarification": false,
+        "confidence_category": 0.95,
+        "confidence_subcategory": 0.95,
+        "validator_reasons": [
+          "auto_resolve:no_flags_fired"
+        ],
+        "risk_reasons": [
+          "base_risk:LOW",
+          "sensitive_building:medical",
+          "capped_at_LOW:historical_max for subcategory=restroom_supplies"
+        ],
+        "retrieved_record_ids": [
+          "TKT-2022-08467",
+          "TKT-2022-04618",
+          "TKT-2024-02238",
+          "TKT-2023-08306",
+          "TKT-2022-06448",
+          "TKT-2022-05617",
+          "TKT-2022-01720",
+          "TKT-2024-00984"
+        ]
+      }
+    },
+    "transcript_id": "EVAL-0805"
+  },
+  {
+    "category": "JANITORIAL",
+    "subcategory": "waste_odor",
+    "risk_level": "LOW",
+    "needs_human_review": false,
+    "needs_clarification": false,
+    "building_name": "Civic Center Tower",
+    "address": "300 Civic Center Dr",
+    "floor": "Floor 14",
+    "dispatched_vendor_id": "v_025",
+    "dispatched_emergency_services": false,
+    "call_summary": "Waste/odor issue reported at Civic Center Tower, Floor 14. LOW risk. Dispatched ProClean Facility Services.",
+    "trainer_log": {
+      "full_transcript": "[AGENT] CBRE maintenance \u2014 what's going on?\n[CALLER] Good afternoon, um, Bad garbage smell in the hallway on Floor 14 in Suite 1408 outside the main trash.\n[AGENT] Alright. How bad is the smell?\n[CALLER] Just near the breakroom.\n[AGENT] Alright, I've put a ticket in \u2014 vendor will swing by during business hours.\n[CALLER] Okay.",
+      "ai_prediction": {
+        "category": "JANITORIAL",
+        "subcategory": "waste_odor",
+        "risk_level": "LOW",
+        "dispatched_vendor_id": "v_025",
+        "dispatched_emergency_services": false,
+        "needs_human_review": false,
+        "needs_clarification": false,
+        "confidence_category": 0.95,
+        "confidence_subcategory": 0.95,
+        "validator_reasons": [
+          "auto_resolve:no_flags_fired"
+        ],
+        "risk_reasons": [
+          "base_risk:LOW"
+        ],
+        "retrieved_record_ids": [
+          "TKT-2022-01990",
+          "TKT-2022-03841",
+          "TKT-2022-09856",
+          "TKT-2022-02917",
+          "TKT-2024-00477",
+          "TKT-2022-00820",
+          "TKT-2023-09704",
+          "TKT-2022-07060"
+        ]
+      },
+      "human_override": null,
+      "final_decision": {
+        "category": "JANITORIAL",
+        "subcategory": "waste_odor",
+        "risk_level": "LOW",
+        "dispatched_vendor_id": "v_025",
+        "dispatched_emergency_services": false,
+        "needs_human_review": false,
+        "needs_clarification": false,
+        "confidence_category": 0.95,
+        "confidence_subcategory": 0.95,
+        "validator_reasons": [
+          "auto_resolve:no_flags_fired"
+        ],
+        "risk_reasons": [
+          "base_risk:LOW"
+        ],
+        "retrieved_record_ids": [
+          "TKT-2022-01990",
+          "TKT-2022-03841",
+          "TKT-2022-09856",
+          "TKT-2022-02917",
+          "TKT-2024-00477",
+          "TKT-2022-00820",
+          "TKT-2023-09704",
+          "TKT-2022-07060"
+        ]
+      }
+    },
+    "transcript_id": "EVAL-0811"
+  },
+  {
+    "category": "HVAC",
+    "subcategory": "air_quality",
+    "risk_level": "MEDIUM",
+    "needs_human_review": true,
+    "needs_clarification": false,
+    "building_name": "El Monte Distribution Center",
+    "address": "8000 Valley Blvd",
+    "floor": "Mezzanine",
+    "dispatched_vendor_id": "v_012",
+    "dispatched_emergency_services": false,
+    "call_summary": "Air quality concern reported at El Monte Distribution Center, Mezzanine. MEDIUM risk. Flagged for review. Pacific HVAC Services dispatched pending approval.",
+    "trainer_log": {
+      "full_transcript": "[AGENT] Maintenance, what's the situation?\n[CALLER] Hello, Strong chemical smell throughout the suite. People are coughing.\n[AGENT] Understood. Does it smell like gas or sulfur?\n[CALLER] Two people just went home from headaches.\n[AGENT] Where exactly \u2014 which suite?\n[CALLER] El Monte Distribution Center, hold on, Mezzanine.\n[AGENT] I'll get a vendor rolling and let the property manager know.\n[CALLER] Um, okay.",
+      "ai_prediction": {
+        "category": "HVAC",
+        "subcategory": "air_quality",
+        "risk_level": "MEDIUM",
+        "dispatched_vendor_id": "v_012",
+        "dispatched_emergency_services": false,
+        "needs_human_review": true,
+        "needs_clarification": false,
+        "confidence_category": 0.95,
+        "confidence_subcategory": 0.95,
+        "validator_reasons": [
+          "trap_prone_subcategory:air_quality(over_escalation_rate=19%)"
+        ],
+        "risk_reasons": [
+          "base_risk:MEDIUM"
+        ],
+        "retrieved_record_ids": [
+          "TKT-2023-05210",
+          "TKT-2023-09953",
+          "TKT-2023-01883",
+          "TKT-2023-02567",
+          "TKT-2023-03332",
+          "TKT-2024-09588",
+          "TKT-2023-01151",
+          "TKT-2022-07075"
+        ]
+      },
+      "human_override": null,
+      "final_decision": {
+        "category": "HVAC",
+        "subcategory": "air_quality",
+        "risk_level": "MEDIUM",
+        "dispatched_vendor_id": "v_012",
+        "dispatched_emergency_services": false,
+        "needs_human_review": true,
+        "needs_clarification": false,
+        "confidence_category": 0.95,
+        "confidence_subcategory": 0.95,
+        "validator_reasons": [
+          "trap_prone_subcategory:air_quality(over_escalation_rate=19%)"
+        ],
+        "risk_reasons": [
+          "base_risk:MEDIUM"
+        ],
+        "retrieved_record_ids": [
+          "TKT-2023-05210",
+          "TKT-2023-09953",
+          "TKT-2023-01883",
+          "TKT-2023-02567",
+          "TKT-2023-03332",
+          "TKT-2024-09588",
+          "TKT-2023-01151",
+          "TKT-2022-07075"
+        ]
+      }
+    },
+    "transcript_id": "EVAL-0840"
+  },
+  {
+    "category": "JANITORIAL",
+    "subcategory": "waste_odor",
+    "risk_level": "LOW",
+    "needs_human_review": false,
+    "needs_clarification": false,
+    "building_name": "Bayshore Commons",
+    "address": "1900 Bayshore Blvd",
+    "floor": "Rooftop",
+    "dispatched_vendor_id": "v_024",
+    "dispatched_emergency_services": false,
+    "call_summary": "Waste/odor issue reported at Bayshore Commons, Rooftop. LOW risk. Dispatched Bay Area Cleaning Solutions.",
+    "trainer_log": {
+      "full_transcript": "[AGENT] Dispatch, what do you need?\n[CALLER] We see smoke, but it's from someone's candle being too close to a vent \u2014 already put out.\n[AGENT] Okay \u2014 can you confirm there's no actual fire or injury right now?\n[CALLER] No fire, just the burnt smell.\n[AGENT] Can you tell me the building, floor, and suite?\n[CALLER] Sorry, bayshore Commons, Rooftop.\n[AGENT] Okay, ticket's logged. Someone'll come out during business hours.",
+      "ai_prediction": {
+        "category": "JANITORIAL",
+        "subcategory": "waste_odor",
+        "risk_level": "LOW",
+        "dispatched_vendor_id": "v_024",
+        "dispatched_emergency_services": false,
+        "needs_human_review": false,
+        "needs_clarification": false,
+        "confidence_category": 0.95,
+        "confidence_subcategory": 0.95,
+        "validator_reasons": [
+          "auto_resolve:no_flags_fired"
+        ],
+        "risk_reasons": [
+          "base_risk:LOW",
+          "hard_cue:smoke",
+          "capped_at_LOW:historical_max for subcategory=waste_odor"
+        ],
+        "retrieved_record_ids": [
+          "TKT-2024-03702",
+          "TKT-2024-02913",
+          "TKT-2022-03682",
+          "TKT-2023-06860",
+          "TKT-2023-00527",
+          "TKT-2023-09584",
+          "TKT-2022-00154",
+          "TKT-2022-05299"
+        ]
+      },
+      "human_override": null,
+      "final_decision": {
+        "category": "JANITORIAL",
+        "subcategory": "waste_odor",
+        "risk_level": "LOW",
+        "dispatched_vendor_id": "v_024",
+        "dispatched_emergency_services": false,
+        "needs_human_review": false,
+        "needs_clarification": false,
+        "confidence_category": 0.95,
+        "confidence_subcategory": 0.95,
+        "validator_reasons": [
+          "auto_resolve:no_flags_fired"
+        ],
+        "risk_reasons": [
+          "base_risk:LOW",
+          "hard_cue:smoke",
+          "capped_at_LOW:historical_max for subcategory=waste_odor"
+        ],
+        "retrieved_record_ids": [
+          "TKT-2024-03702",
+          "TKT-2024-02913",
+          "TKT-2022-03682",
+          "TKT-2023-06860",
+          "TKT-2023-00527",
+          "TKT-2023-09584",
+          "TKT-2022-00154",
+          "TKT-2022-05299"
+        ]
+      }
+    },
+    "transcript_id": "EVAL-0844"
+  },
+  {
+    "category": "SECURITY",
+    "subcategory": "unauthorized_access",
+    "risk_level": "HIGH",
+    "needs_human_review": true,
+    "needs_clarification": false,
+    "building_name": null,
+    "address": null,
+    "floor": "Floor 2",
+    "dispatched_vendor_id": "v_027",
+    "dispatched_emergency_services": false,
+    "call_summary": "Unauthorized access reported at Floor 2. HIGH risk. Flagged for review. Elite Protective Services dispatched pending approval.",
+    "trainer_log": {
+      "full_transcript": "[AGENT] CBRE maintenance line, what do you need?\n[CALLER] Hello, Back door on Floor 2 in Suite 202 was pried \u2014 there's damage to the frame, and someone's inside.\n[AGENT] Got it. Do you have a description?\n[CALLER] No one hurt yet.\n[AGENT] I want a second pair of eyes on this. I'll bring the PM in and send a tech out.\n[CALLER] Okay.",
+      "ai_prediction": {
+        "category": "SECURITY",
+        "subcategory": "unauthorized_access",
+        "risk_level": "HIGH",
+        "dispatched_vendor_id": "v_027",
+        "dispatched_emergency_services": false,
+        "needs_human_review": true,
+        "needs_clarification": false,
+        "confidence_category": 0.95,
+        "confidence_subcategory": 0.95,
+        "validator_reasons": [
+          "high_band:always_pause"
+        ],
+        "risk_reasons": [
+          "base_risk:HIGH"
+        ],
+        "retrieved_record_ids": [
+          "TKT-2022-06226",
+          "TKT-2023-06965",
+          "TKT-2022-05842",
+          "TKT-2023-02288",
+          "TKT-2024-00777",
+          "TKT-2024-07794",
+          "TKT-2023-04496",
+          "TKT-2022-02380"
+        ]
+      },
+      "human_override": null,
+      "final_decision": {
+        "category": "SECURITY",
+        "subcategory": "unauthorized_access",
+        "risk_level": "HIGH",
+        "dispatched_vendor_id": "v_027",
+        "dispatched_emergency_services": false,
+        "needs_human_review": true,
+        "needs_clarification": false,
+        "confidence_category": 0.95,
+        "confidence_subcategory": 0.95,
+        "validator_reasons": [
+          "high_band:always_pause"
+        ],
+        "risk_reasons": [
+          "base_risk:HIGH"
+        ],
+        "retrieved_record_ids": [
+          "TKT-2022-06226",
+          "TKT-2023-06965",
+          "TKT-2022-05842",
+          "TKT-2023-02288",
+          "TKT-2024-00777",
+          "TKT-2024-07794",
+          "TKT-2023-04496",
+          "TKT-2022-02380"
+        ]
+      }
+    },
+    "transcript_id": "EVAL-0846"
+  },
+  {
+    "category": "JANITORIAL",
+    "subcategory": "waste_odor",
+    "risk_level": "LOW",
+    "needs_human_review": false,
+    "needs_clarification": false,
+    "building_name": "Airport Business Center",
+    "address": "9200 Airport Blvd",
+    "floor": "Floor 5",
+    "dispatched_vendor_id": "v_023",
+    "dispatched_emergency_services": false,
+    "call_summary": "Waste/odor issue reported at Airport Business Center, Floor 5. LOW risk. Dispatched Sparkle Commercial Cleaning.",
+    "trainer_log": {
+      "full_transcript": "[AGENT] Maintenance, what's the situation?\n[CALLER] I mean, there's something that smells really bad.\n[AGENT] Okay, can you describe what you're seeing or smelling?\n[CALLER] Hold on, just near the breakroom.\n[AGENT] Is it affecting the whole floor or just one area?\n[CALLER] Pretty bad \u2014 can't really ignore it.\n[AGENT] Can you confirm the building and floor?\n[CALLER] Airport Business Center, Floor 5, Suite 503.\n[AGENT] Got the ticket open. Vendor should make it out during business hours.",
+      "ai_prediction": {
+        "category": "JANITORIAL",
+        "subcategory": "waste_odor",
+        "risk_level": "LOW",
+        "dispatched_vendor_id": "v_023",
+        "dispatched_emergency_services": false,
+        "needs_human_review": false,
+        "needs_clarification": false,
+        "confidence_category": 0.95,
+        "confidence_subcategory": 0.95,
+        "validator_reasons": [
+          "auto_resolve:no_flags_fired"
+        ],
+        "risk_reasons": [
+          "base_risk:LOW"
+        ],
+        "retrieved_record_ids": [
+          "TKT-2024-03612",
+          "TKT-2023-07553",
+          "TKT-2022-04771",
+          "TKT-2023-01829",
+          "TKT-2024-04554",
+          "TKT-2022-03037",
+          "TKT-2024-01794",
+          "TKT-2022-03841"
+        ]
+      },
+      "human_override": null,
+      "final_decision": {
+        "category": "JANITORIAL",
+        "subcategory": "waste_odor",
+        "risk_level": "LOW",
+        "dispatched_vendor_id": "v_023",
+        "dispatched_emergency_services": false,
+        "needs_human_review": false,
+        "needs_clarification": false,
+        "confidence_category": 0.95,
+        "confidence_subcategory": 0.95,
+        "validator_reasons": [
+          "auto_resolve:no_flags_fired"
+        ],
+        "risk_reasons": [
+          "base_risk:LOW"
+        ],
+        "retrieved_record_ids": [
+          "TKT-2024-03612",
+          "TKT-2023-07553",
+          "TKT-2022-04771",
+          "TKT-2023-01829",
+          "TKT-2024-04554",
+          "TKT-2022-03037",
+          "TKT-2024-01794",
+          "TKT-2022-03841"
+        ]
+      }
+    },
+    "transcript_id": "EVAL-0848"
+  },
+  {
+    "category": "HVAC",
+    "subcategory": "controls_bms",
+    "risk_level": "LOW",
+    "needs_human_review": false,
+    "needs_clarification": false,
+    "building_name": "Shoreline Tech Campus",
+    "address": "2500 Shoreline Blvd",
+    "floor": "Floor 5",
+    "dispatched_vendor_id": "v_013",
+    "dispatched_emergency_services": false,
+    "call_summary": "Building controls issue reported at Shoreline Tech Campus, Floor 5. LOW risk. Dispatched CoolZone HVAC.",
+    "trainer_log": {
+      "full_transcript": "[AGENT] Hi, CBRE facilities. What can I do for you?\n[CALLER] [door closing] Hi there, BMS is showing alarms for our zone.\n[AGENT] Okay. Is the thermostat display blank or showing something?\n[CALLER] Sorry, says 'zone 4 comm loss' or something.\n[AGENT] Where exactly \u2014 which suite?\n[CALLER] Shoreline Tech Campus, Floor 5, Suite 507.\n[AGENT] Got the ticket open. Vendor should make it out during business hours.\n[CALLER] Okay.",
+      "ai_prediction": {
+        "category": "HVAC",
+        "subcategory": "controls_bms",
+        "risk_level": "LOW",
+        "dispatched_vendor_id": "v_013",
+        "dispatched_emergency_services": false,
+        "needs_human_review": false,
+        "needs_clarification": false,
+        "confidence_category": 0.9,
+        "confidence_subcategory": 0.9,
+        "validator_reasons": [
+          "auto_resolve:no_flags_fired"
+        ],
+        "risk_reasons": [
+          "base_risk:LOW"
+        ],
+        "retrieved_record_ids": [
+          "TKT-2023-09197",
+          "TKT-2022-01003",
+          "TKT-2022-04261",
+          "TKT-2022-00706",
+          "TKT-2022-05854",
+          "TKT-2023-07352",
+          "TKT-2022-01981",
+          "TKT-2024-00246"
+        ]
+      },
+      "human_override": null,
+      "final_decision": {
+        "category": "HVAC",
+        "subcategory": "controls_bms",
+        "risk_level": "LOW",
+        "dispatched_vendor_id": "v_013",
+        "dispatched_emergency_services": false,
+        "needs_human_review": false,
+        "needs_clarification": false,
+        "confidence_category": 0.9,
+        "confidence_subcategory": 0.9,
+        "validator_reasons": [
+          "auto_resolve:no_flags_fired"
+        ],
+        "risk_reasons": [
+          "base_risk:LOW"
+        ],
+        "retrieved_record_ids": [
+          "TKT-2023-09197",
+          "TKT-2022-01003",
+          "TKT-2022-04261",
+          "TKT-2022-00706",
+          "TKT-2022-05854",
+          "TKT-2023-07352",
+          "TKT-2022-01981",
+          "TKT-2024-00246"
+        ]
+      }
+    },
+    "transcript_id": "EVAL-0849"
+  },
+  {
+    "category": "DOORS_ACCESS",
+    "subcategory": "glass_damage",
+    "risk_level": "MEDIUM",
+    "needs_human_review": false,
+    "needs_clarification": false,
+    "building_name": "Harbor Point Tower",
+    "address": "250 Harbor Dr",
+    "floor": "Floor 16",
+    "dispatched_vendor_id": "v_019",
+    "dispatched_emergency_services": false,
+    "call_summary": "Glass damage reported at Harbor Point Tower, Floor 16. MEDIUM risk. Dispatched Clear View Glazing.",
+    "trainer_log": {
+      "full_transcript": "[AGENT] CBRE maintenance line, this is Priya \u2014 what do you need?\n[CALLER] Hold on, hello, Glass panel has a big crack running across it.\n[AGENT] Okay. Is anyone injured?\n[CALLER] No injuries.\n[AGENT] What's your building, floor, suite?\n[CALLER] Harbor Point Tower, Floor 16, Suite 1608.\n[AGENT] Tech is on the way. You'll get a text once they're rolling.\n[CALLER] Got it, thanks.",
+      "ai_prediction": {
+        "category": "DOORS_ACCESS",
+        "subcategory": "glass_damage",
+        "risk_level": "MEDIUM",
+        "dispatched_vendor_id": "v_019",
+        "dispatched_emergency_services": false,
+        "needs_human_review": false,
+        "needs_clarification": false,
+        "confidence_category": 0.95,
+        "confidence_subcategory": 0.95,
+        "validator_reasons": [
+          "auto_resolve:no_flags_fired"
+        ],
+        "risk_reasons": [
+          "base_risk:MEDIUM"
+        ],
+        "retrieved_record_ids": [
+          "TKT-2023-08168",
+          "TKT-2024-04743",
+          "TKT-2023-00731",
+          "TKT-2022-06625",
+          "TKT-2023-00245",
+          "TKT-2023-03659",
+          "TKT-2024-07473",
+          "TKT-2023-02018"
+        ]
+      },
+      "human_override": null,
+      "final_decision": {
+        "category": "DOORS_ACCESS",
+        "subcategory": "glass_damage",
+        "risk_level": "MEDIUM",
+        "dispatched_vendor_id": "v_019",
+        "dispatched_emergency_services": false,
+        "needs_human_review": false,
+        "needs_clarification": false,
+        "confidence_category": 0.95,
+        "confidence_subcategory": 0.95,
+        "validator_reasons": [
+          "auto_resolve:no_flags_fired"
+        ],
+        "risk_reasons": [
+          "base_risk:MEDIUM"
+        ],
+        "retrieved_record_ids": [
+          "TKT-2023-08168",
+          "TKT-2024-04743",
+          "TKT-2023-00731",
+          "TKT-2022-06625",
+          "TKT-2023-00245",
+          "TKT-2023-03659",
+          "TKT-2024-07473",
+          "TKT-2023-02018"
+        ]
+      }
+    },
+    "transcript_id": "EVAL-0851"
+  },
+  {
+    "category": "PLUMBING",
+    "subcategory": "drainage_backup",
+    "risk_level": "LOW",
+    "needs_human_review": false,
+    "needs_clarification": false,
+    "building_name": "Pacific Financial Tower",
+    "address": "555 Pacific Ave",
+    "floor": "Floor 1",
+    "dispatched_vendor_id": "v_004",
+    "dispatched_emergency_services": false,
+    "call_summary": "Drainage backup reported at Pacific Financial Tower, Floor 1. LOW risk. Dispatched Regency Commercial Plumbing.",
+    "trainer_log": {
+      "full_transcript": "[AGENT] CBRE maintenance line, what do you need?\n[CALLER] Hey, Sewer smell coming from the drain; water is not going down.\n[AGENT] Got it. Is there a strong sewer smell?\n[CALLER] Water's coming up on the floor tiles.\n[AGENT] Where exactly \u2014 which suite?\n[CALLER] Pacific Financial Tower, I mean, Floor 1.\n[AGENT] Okay, ticket's logged. Someone'll come out during business hours.",
+      "ai_prediction": {
+        "category": "PLUMBING",
+        "subcategory": "drainage_backup",
+        "risk_level": "LOW",
+        "dispatched_vendor_id": "v_004",
+        "dispatched_emergency_services": false,
+        "needs_human_review": false,
+        "needs_clarification": false,
+        "confidence_category": 0.95,
+        "confidence_subcategory": 0.95,
+        "validator_reasons": [
+          "auto_resolve:no_flags_fired"
+        ],
+        "risk_reasons": [
+          "base_risk:LOW"
+        ],
+        "retrieved_record_ids": [
+          "TKT-2023-07628",
+          "TKT-2024-09279",
+          "TKT-2024-00423",
+          "TKT-2024-02136",
+          "TKT-2023-07721",
+          "TKT-2022-02212",
+          "TKT-2023-08081",
+          "TKT-2023-09404"
+        ]
+      },
+      "human_override": null,
+      "final_decision": {
+        "category": "PLUMBING",
+        "subcategory": "drainage_backup",
+        "risk_level": "LOW",
+        "dispatched_vendor_id": "v_004",
+        "dispatched_emergency_services": false,
+        "needs_human_review": false,
+        "needs_clarification": false,
+        "confidence_category": 0.95,
+        "confidence_subcategory": 0.95,
+        "validator_reasons": [
+          "auto_resolve:no_flags_fired"
+        ],
+        "risk_reasons": [
+          "base_risk:LOW"
+        ],
+        "retrieved_record_ids": [
+          "TKT-2023-07628",
+          "TKT-2024-09279",
+          "TKT-2024-00423",
+          "TKT-2024-02136",
+          "TKT-2023-07721",
+          "TKT-2022-02212",
+          "TKT-2023-08081",
+          "TKT-2023-09404"
+        ]
+      }
+    },
+    "transcript_id": "EVAL-0855"
+  },
+  {
+    "category": "LIFE_SAFETY",
+    "subcategory": "fire_smoke",
+    "risk_level": "EMERGENCY",
+    "needs_human_review": true,
+    "needs_clarification": false,
+    "building_name": null,
+    "address": null,
+    "floor": "Floor 6",
+    "dispatched_vendor_id": null,
+    "dispatched_emergency_services": true,
+    "call_summary": "Fire/smoke detected reported at Floor 6. EMERGENCY risk. Emergency services dispatched.",
+    "trainer_log": {
+      "full_transcript": "[AGENT] CBRE maintenance line, this is Priya \u2014 what do you need?\n[CALLER] Good morning, like, Small fire in the trash bin on Floor 6 in Suite 604, flames visible.\n[AGENT] Okay. Can you describe what you're seeing \u2014 flames or just smoke?\n[CALLER] Yes, people are out.\n[AGENT] Can you describe what you're seeing \u2014 flames or just smoke?\n[CALLER] Just smoke right now, sorry, no flames visible.\n[AGENT] 911 is going out now and I'm alerting building ops \u2014 stay with me on the line if you can.",
+      "ai_prediction": {
+        "category": "LIFE_SAFETY",
+        "subcategory": "fire_smoke",
+        "risk_level": "EMERGENCY",
+        "dispatched_vendor_id": null,
+        "dispatched_emergency_services": true,
+        "needs_human_review": true,
+        "needs_clarification": false,
+        "confidence_category": 0.95,
+        "confidence_subcategory": 0.95,
+        "validator_reasons": [
+          "emergency_band:always_pause",
+          "emergency_dispatch:fire_smoke:hazard_cue_confirmed"
+        ],
+        "risk_reasons": [
+          "base_risk:EMERGENCY",
+          "hard_cue:fire",
+          "hard_cue:smoke",
+          "capped_at_EMERGENCY:historical_max for subcategory=fire_smoke"
+        ],
+        "retrieved_record_ids": [
+          "TKT-2022-09595",
+          "TKT-2023-07763",
+          "TKT-2024-04929",
+          "TKT-2023-07700",
+          "TKT-2023-06425",
+          "TKT-2022-05671",
+          "TKT-2023-06329",
+          "TKT-2024-02544"
+        ]
+      },
+      "human_override": null,
+      "final_decision": {
+        "category": "LIFE_SAFETY",
+        "subcategory": "fire_smoke",
+        "risk_level": "EMERGENCY",
+        "dispatched_vendor_id": null,
+        "dispatched_emergency_services": true,
+        "needs_human_review": true,
+        "needs_clarification": false,
+        "confidence_category": 0.95,
+        "confidence_subcategory": 0.95,
+        "validator_reasons": [
+          "emergency_band:always_pause",
+          "emergency_dispatch:fire_smoke:hazard_cue_confirmed"
+        ],
+        "risk_reasons": [
+          "base_risk:EMERGENCY",
+          "hard_cue:fire",
+          "hard_cue:smoke",
+          "capped_at_EMERGENCY:historical_max for subcategory=fire_smoke"
+        ],
+        "retrieved_record_ids": [
+          "TKT-2022-09595",
+          "TKT-2023-07763",
+          "TKT-2024-04929",
+          "TKT-2023-07700",
+          "TKT-2023-06425",
+          "TKT-2022-05671",
+          "TKT-2023-06329",
+          "TKT-2024-02544"
+        ]
+      }
+    },
+    "transcript_id": "EVAL-0857"
+  },
+  {
+    "category": "HVAC",
+    "subcategory": "no_heating",
+    "risk_level": "LOW",
+    "needs_human_review": false,
+    "needs_clarification": true,
+    "building_name": "Capitol Mall Tower",
+    "address": "400 Capitol Mall",
+    "floor": "Floor 3",
+    "dispatched_vendor_id": "v_014",
+    "dispatched_emergency_services": false,
+    "call_summary": "No heating reported at Capitol Mall Tower, Floor 3. LOW risk. Dispatched MediCool HVAC Systems.",
+    "trainer_log": {
+      "full_transcript": "[AGENT] CBRE facilities \u2014 how can I help?\n[CALLER] There's an issue with no heating.\n[AGENT] Are any vulnerable people \u2014 elderly or infants?\n[CALLER] Got a client meeting coming in, this is bad.\n[AGENT] Can you confirm the building and floor?\n[CALLER] Capitol Mall Tower, Floor 3.\n[AGENT] Got it. I'll get someone out as soon as I can \u2014 should hear back within the hour.",
+      "ai_prediction": {
+        "category": "HVAC",
+        "subcategory": "no_heating",
+        "risk_level": "LOW",
+        "dispatched_vendor_id": "v_014",
+        "dispatched_emergency_services": false,
+        "needs_human_review": false,
+        "needs_clarification": true,
+        "confidence_category": 0.95,
+        "confidence_subcategory": 0.95,
+        "validator_reasons": [
+          "auto_resolve:no_flags_fired"
+        ],
+        "risk_reasons": [
+          "base_risk:LOW"
+        ],
+        "retrieved_record_ids": [
+          "TKT-2024-01821",
+          "TKT-2023-09539",
+          "TKT-2023-08456",
+          "TKT-2024-04323",
+          "TKT-2022-08185",
+          "TKT-2022-08740",
+          "TKT-2022-08947",
+          "TKT-2024-04488"
+        ]
+      },
+      "human_override": null,
+      "final_decision": {
+        "category": "HVAC",
+        "subcategory": "no_heating",
+        "risk_level": "LOW",
+        "dispatched_vendor_id": "v_014",
+        "dispatched_emergency_services": false,
+        "needs_human_review": false,
+        "needs_clarification": true,
+        "confidence_category": 0.95,
+        "confidence_subcategory": 0.95,
+        "validator_reasons": [
+          "auto_resolve:no_flags_fired"
+        ],
+        "risk_reasons": [
+          "base_risk:LOW"
+        ],
+        "retrieved_record_ids": [
+          "TKT-2024-01821",
+          "TKT-2023-09539",
+          "TKT-2023-08456",
+          "TKT-2024-04323",
+          "TKT-2022-08185",
+          "TKT-2022-08740",
+          "TKT-2022-08947",
+          "TKT-2024-04488"
+        ]
+      }
+    },
+    "transcript_id": "EVAL-0858"
+  },
+  {
+    "category": "ELEVATOR",
+    "subcategory": "entrapment",
+    "risk_level": "EMERGENCY",
+    "needs_human_review": true,
+    "needs_clarification": false,
+    "building_name": "Crossroads Business Park",
+    "address": "3300 Crossroads Pkwy",
+    "floor": "Floor 5",
+    "dispatched_vendor_id": "v_016",
+    "dispatched_emergency_services": true,
+    "call_summary": "Person trapped reported at Crossroads Business Park, Floor 5. EMERGENCY risk. Emergency services dispatched.",
+    "trainer_log": {
+      "full_transcript": "[AGENT] Dispatch, what do you need?\n[CALLER] The elevator's acting weird with someone in it.\n[AGENT] Okay, can you describe what you're seeing or smelling?\n[CALLER] Doors are closed, between floors three and four.\n[AGENT] Are they between floors?\n[CALLER] Doors are closed, between floors three and four.\n[AGENT] Can you tell me the building, floor, and suite?\n[CALLER] Crossroads Business Park, I mean, Floor 5, Suite 506.\n[AGENT] Dialing 911 now and pushing a vendor out at the same time.",
+      "ai_prediction": {
+        "category": "ELEVATOR",
+        "subcategory": "entrapment",
+        "risk_level": "EMERGENCY",
+        "dispatched_vendor_id": "v_016",
+        "dispatched_emergency_services": true,
+        "needs_human_review": true,
+        "needs_clarification": false,
+        "confidence_category": 0.95,
+        "confidence_subcategory": 0.95,
+        "validator_reasons": [
+          "emergency_band:always_pause",
+          "emergency_dispatch:entrapment:hazard_cue_confirmed"
+        ],
+        "risk_reasons": [
+          "base_risk:EMERGENCY",
+          "hard_cue:trapped",
+          "capped_at_EMERGENCY:historical_max for subcategory=entrapment"
+        ],
+        "retrieved_record_ids": [
+          "TKT-2023-09029",
+          "TKT-2024-02268",
+          "TKT-2023-05237",
+          "TKT-2022-00952",
+          "TKT-2022-07741",
+          "TKT-2023-04817",
+          "TKT-2024-08394",
+          "TKT-2023-06665"
+        ]
+      },
+      "human_override": null,
+      "final_decision": {
+        "category": "ELEVATOR",
+        "subcategory": "entrapment",
+        "risk_level": "EMERGENCY",
+        "dispatched_vendor_id": "v_016",
+        "dispatched_emergency_services": true,
+        "needs_human_review": true,
+        "needs_clarification": false,
+        "confidence_category": 0.95,
+        "confidence_subcategory": 0.95,
+        "validator_reasons": [
+          "emergency_band:always_pause",
+          "emergency_dispatch:entrapment:hazard_cue_confirmed"
+        ],
+        "risk_reasons": [
+          "base_risk:EMERGENCY",
+          "hard_cue:trapped",
+          "capped_at_EMERGENCY:historical_max for subcategory=entrapment"
+        ],
+        "retrieved_record_ids": [
+          "TKT-2023-09029",
+          "TKT-2024-02268",
+          "TKT-2023-05237",
+          "TKT-2022-00952",
+          "TKT-2022-07741",
+          "TKT-2023-04817",
+          "TKT-2024-08394",
+          "TKT-2023-06665"
+        ]
+      }
+    },
+    "transcript_id": "EVAL-0860"
+  },
+  {
+    "category": "ELECTRICAL",
+    "subcategory": "panel_hazard",
+    "risk_level": "EMERGENCY",
+    "needs_human_review": true,
+    "needs_clarification": false,
+    "building_name": "University Research Park",
+    "address": "5000 Research Dr",
+    "floor": "Floor 8",
+    "dispatched_vendor_id": "v_008",
+    "dispatched_emergency_services": false,
+    "call_summary": "Electrical panel hazard reported at University Research Park, Floor 8. EMERGENCY risk. Flagged for review. Rapid Response Electricians dispatched pending approval.",
+    "trainer_log": {
+      "full_transcript": "[AGENT] CBRE dispatch, talk to me.\n[CALLER] Good morning, The outlet at University Research Park on Floor 8 in Suite 805 is hot to the touch and smells like melted plastic.\n[AGENT] Okay. Do you see any smoke?\n[CALLER] Sorry, nobody's near it, I told everyone to back away.\n[AGENT] Do you see any smoke?\n[CALLER] No, I haven't touched the breakers.\n[AGENT] Pulling in the supervisor and dispatching a vendor right now.\n[CALLER] Got it, sorry, thanks.",
+      "ai_prediction": {
+        "category": "ELECTRICAL",
+        "subcategory": "panel_hazard",
+        "risk_level": "EMERGENCY",
+        "dispatched_vendor_id": "v_008",
+        "dispatched_emergency_services": false,
+        "needs_human_review": true,
+        "needs_clarification": false,
+        "confidence_category": 0.95,
+        "confidence_subcategory": 0.95,
+        "validator_reasons": [
+          "emergency_band:always_pause",
+          "life_safety_no_autodispatch:no_hazard_cue"
+        ],
+        "risk_reasons": [
+          "base_risk:EMERGENCY"
+        ],
+        "retrieved_record_ids": [
+          "TKT-2023-03122",
+          "TKT-2022-08641",
+          "TKT-2023-00026",
+          "TKT-2024-02055",
+          "TKT-2022-06100",
+          "TKT-2023-05933",
+          "TKT-2023-04895",
+          "TKT-2023-07337"
+        ]
+      },
+      "human_override": null,
+      "final_decision": {
+        "category": "ELECTRICAL",
+        "subcategory": "panel_hazard",
+        "risk_level": "EMERGENCY",
+        "dispatched_vendor_id": "v_008",
+        "dispatched_emergency_services": false,
+        "needs_human_review": true,
+        "needs_clarification": false,
+        "confidence_category": 0.95,
+        "confidence_subcategory": 0.95,
+        "validator_reasons": [
+          "emergency_band:always_pause",
+          "life_safety_no_autodispatch:no_hazard_cue"
+        ],
+        "risk_reasons": [
+          "base_risk:EMERGENCY"
+        ],
+        "retrieved_record_ids": [
+          "TKT-2023-03122",
+          "TKT-2022-08641",
+          "TKT-2023-00026",
+          "TKT-2024-02055",
+          "TKT-2022-06100",
+          "TKT-2023-05933",
+          "TKT-2023-04895",
+          "TKT-2023-07337"
+        ]
+      }
+    },
+    "transcript_id": "EVAL-0868"
+  },
+  {
+    "category": "JANITORIAL",
+    "subcategory": "waste_odor",
+    "risk_level": "LOW",
+    "needs_human_review": false,
+    "needs_clarification": false,
+    "building_name": "Torrance Gateway Center",
+    "address": "3500 Carson St",
+    "floor": "Floor 8",
+    "dispatched_vendor_id": "v_023",
+    "dispatched_emergency_services": false,
+    "call_summary": "Waste/odor issue reported at Torrance Gateway Center, Floor 8. LOW risk. Dispatched Sparkle Commercial Cleaning.",
+    "trainer_log": {
+      "full_transcript": "[AGENT] Maintenance, what's the situation?\n[CALLER] Uh, hi there, Kitchen trash at Torrance Gateway Center on Floor 8 hasn't been emptied, the whole area smells.\n[AGENT] Okay. How bad is the smell?\n[CALLER] Just near the breakroom.\n[AGENT] Got the ticket open. Vendor should make it out during business hours.",
+      "ai_prediction": {
+        "category": "JANITORIAL",
+        "subcategory": "waste_odor",
+        "risk_level": "LOW",
+        "dispatched_vendor_id": "v_023",
+        "dispatched_emergency_services": false,
+        "needs_human_review": false,
+        "needs_clarification": false,
+        "confidence_category": 0.9,
+        "confidence_subcategory": 0.9,
+        "validator_reasons": [
+          "auto_resolve:no_flags_fired"
+        ],
+        "risk_reasons": [
+          "base_risk:LOW"
+        ],
+        "retrieved_record_ids": [
+          "TKT-2024-04092",
+          "TKT-2022-06580",
+          "TKT-2023-03602",
+          "TKT-2022-06865",
+          "TKT-2023-03401",
+          "TKT-2022-03907",
+          "TKT-2023-06002",
+          "TKT-2023-03965"
+        ]
+      },
+      "human_override": null,
+      "final_decision": {
+        "category": "JANITORIAL",
+        "subcategory": "waste_odor",
+        "risk_level": "LOW",
+        "dispatched_vendor_id": "v_023",
+        "dispatched_emergency_services": false,
+        "needs_human_review": false,
+        "needs_clarification": false,
+        "confidence_category": 0.9,
+        "confidence_subcategory": 0.9,
+        "validator_reasons": [
+          "auto_resolve:no_flags_fired"
+        ],
+        "risk_reasons": [
+          "base_risk:LOW"
+        ],
+        "retrieved_record_ids": [
+          "TKT-2024-04092",
+          "TKT-2022-06580",
+          "TKT-2023-03602",
+          "TKT-2022-06865",
+          "TKT-2023-03401",
+          "TKT-2022-03907",
+          "TKT-2023-06002",
+          "TKT-2023-03965"
+        ]
+      }
+    },
+    "transcript_id": "EVAL-0876"
+  },
+  {
+    "category": "JANITORIAL",
+    "subcategory": "waste_odor",
+    "risk_level": "LOW",
+    "needs_human_review": false,
+    "needs_clarification": false,
+    "building_name": "Seaside Professional Center",
+    "address": "350 Ocean View Ave",
+    "floor": "Rooftop",
+    "dispatched_vendor_id": "v_023",
+    "dispatched_emergency_services": false,
+    "call_summary": "Waste/odor issue reported at Seaside Professional Center, Rooftop. LOW risk. Dispatched Sparkle Commercial Cleaning.",
+    "trainer_log": {
+      "full_transcript": "[AGENT] Maintenance, what's the situation?\n[CALLER] Smoke alarm beeped once and there's smoke \u2014 but it was just burnt toast in the toaster, you know, no fire.\n[AGENT] Okay \u2014 can you confirm there's no actual fire or injury right now?\n[CALLER] No fire, just the burnt smell.\n[AGENT] Which building and floor are you at?\n[CALLER] Hold on, seaside Professional Center, Rooftop.\n[AGENT] Got the ticket open. Vendor should make it out during business hours.",
+      "ai_prediction": {
+        "category": "JANITORIAL",
+        "subcategory": "waste_odor",
+        "risk_level": "LOW",
+        "dispatched_vendor_id": "v_023",
+        "dispatched_emergency_services": false,
+        "needs_human_review": false,
+        "needs_clarification": false,
+        "confidence_category": 0.95,
+        "confidence_subcategory": 0.95,
+        "validator_reasons": [
+          "auto_resolve:no_flags_fired"
+        ],
+        "risk_reasons": [
+          "base_risk:LOW",
+          "hard_cue:smoke",
+          "capped_at_LOW:historical_max for subcategory=waste_odor"
+        ],
+        "retrieved_record_ids": [
+          "TKT-2022-05209",
+          "TKT-2022-03682",
+          "TKT-2022-01846",
+          "TKT-2024-01575",
+          "TKT-2024-03702",
+          "TKT-2022-06064",
+          "TKT-2024-02877",
+          "TKT-2024-01983"
+        ]
+      },
+      "human_override": null,
+      "final_decision": {
+        "category": "JANITORIAL",
+        "subcategory": "waste_odor",
+        "risk_level": "LOW",
+        "dispatched_vendor_id": "v_023",
+        "dispatched_emergency_services": false,
+        "needs_human_review": false,
+        "needs_clarification": false,
+        "confidence_category": 0.95,
+        "confidence_subcategory": 0.95,
+        "validator_reasons": [
+          "auto_resolve:no_flags_fired"
+        ],
+        "risk_reasons": [
+          "base_risk:LOW",
+          "hard_cue:smoke",
+          "capped_at_LOW:historical_max for subcategory=waste_odor"
+        ],
+        "retrieved_record_ids": [
+          "TKT-2022-05209",
+          "TKT-2022-03682",
+          "TKT-2022-01846",
+          "TKT-2024-01575",
+          "TKT-2024-03702",
+          "TKT-2022-06064",
+          "TKT-2024-02877",
+          "TKT-2024-01983"
+        ]
+      }
+    },
+    "transcript_id": "EVAL-0886"
+  },
+  {
+    "category": "SECURITY",
+    "subcategory": "unauthorized_access",
+    "risk_level": "HIGH",
+    "needs_human_review": true,
+    "needs_clarification": false,
+    "building_name": "Redwood Corporate Plaza",
+    "address": "2400 Redwood Hwy",
+    "floor": "Rooftop",
+    "dispatched_vendor_id": "v_027",
+    "dispatched_emergency_services": false,
+    "call_summary": "Unauthorized access reported at Redwood Corporate Plaza, Rooftop. HIGH risk. Flagged for review. Elite Protective Services dispatched pending approval.",
+    "trainer_log": {
+      "full_transcript": "[AGENT] CBRE dispatch \u2014 go ahead.\n[CALLER] Hi there, Someone forced open the door, they got in.\n[AGENT] Mhm. Do you have a description?\n[CALLER] Wearing a tan uniform, looks like a delivery person but no tag.\n[AGENT] Which building and floor are you at?\n[CALLER] Redwood Corporate Plaza, Rooftop.\n[AGENT] Are they still on-site?\n[CALLER] Wearing a tan uniform, looks like a delivery person but no tag.\n[AGENT] Escalating to my supervisor and sending a vendor out right now.\n[CALLER] Alright, appreciate it.",
+      "ai_prediction": {
+        "category": "SECURITY",
+        "subcategory": "unauthorized_access",
+        "risk_level": "HIGH",
+        "dispatched_vendor_id": "v_027",
+        "dispatched_emergency_services": false,
+        "needs_human_review": true,
+        "needs_clarification": false,
+        "confidence_category": 0.95,
+        "confidence_subcategory": 0.95,
+        "validator_reasons": [
+          "high_band:always_pause"
+        ],
+        "risk_reasons": [
+          "base_risk:HIGH"
+        ],
+        "retrieved_record_ids": [
+          "TKT-2022-07900",
+          "TKT-2024-04902",
+          "TKT-2024-03021",
+          "TKT-2023-01544",
+          "TKT-2022-07240",
+          "TKT-2024-00003",
+          "TKT-2022-02557",
+          "TKT-2024-02160"
+        ]
+      },
+      "human_override": null,
+      "final_decision": {
+        "category": "SECURITY",
+        "subcategory": "unauthorized_access",
+        "risk_level": "HIGH",
+        "dispatched_vendor_id": "v_027",
+        "dispatched_emergency_services": false,
+        "needs_human_review": true,
+        "needs_clarification": false,
+        "confidence_category": 0.95,
+        "confidence_subcategory": 0.95,
+        "validator_reasons": [
+          "high_band:always_pause"
+        ],
+        "risk_reasons": [
+          "base_risk:HIGH"
+        ],
+        "retrieved_record_ids": [
+          "TKT-2022-07900",
+          "TKT-2024-04902",
+          "TKT-2024-03021",
+          "TKT-2023-01544",
+          "TKT-2022-07240",
+          "TKT-2024-00003",
+          "TKT-2022-02557",
+          "TKT-2024-02160"
+        ]
+      }
+    },
+    "transcript_id": "EVAL-0897"
+  },
+  {
+    "category": "SECURITY",
+    "subcategory": "suspicious_person",
+    "risk_level": "MEDIUM",
+    "needs_human_review": true,
+    "needs_clarification": false,
+    "building_name": "Shoreline Tech Campus",
+    "address": "2500 Shoreline Blvd",
+    "floor": "Floor 4",
+    "dispatched_vendor_id": "v_027",
+    "dispatched_emergency_services": false,
+    "call_summary": "Suspicious person reported reported at Shoreline Tech Campus, Floor 4. MEDIUM risk. Flagged for review. Elite Protective Services dispatched pending approval.",
+    "trainer_log": {
+      "full_transcript": "[AGENT] CBRE dispatch, talk to me.\n[CALLER] Um, good morning, There's a person loitering at Shoreline Tech Campus on Floor 4 in Suite 408 who doesn't have a badge.\n[AGENT] Okay. Are they being aggressive?\n[CALLER] He's just standing there, not doing anything overt.\n[AGENT] Can you describe them?\n[CALLER] Yeah, still there by the elevators.\n[AGENT] Tricky one \u2014 I'll involve the PM and get a tech dispatched at the same time.\n[AGENT] Nobody in our vendor list matches everything you need. Let me kick this over to the on-call PM.\n[CALLER] Okay, please hurry.",
+      "ai_prediction": {
+        "category": "SECURITY",
+        "subcategory": "suspicious_person",
+        "risk_level": "MEDIUM",
+        "dispatched_vendor_id": "v_027",
+        "dispatched_emergency_services": false,
+        "needs_human_review": true,
+        "needs_clarification": false,
+        "confidence_category": 0.9,
+        "confidence_subcategory": 0.9,
+        "validator_reasons": [
+          "trap_cascade_subcategory:suspicious_person(high-audit cell at HIGH/EMERGENCY \u2014 possible under-classification)"
+        ],
+        "risk_reasons": [
+          "base_risk:MEDIUM"
+        ],
+        "retrieved_record_ids": [
+          "TKT-2022-09874",
+          "TKT-2023-04076",
+          "TKT-2023-05657",
+          "TKT-2022-03169",
+          "TKT-2023-07106",
+          "TKT-2024-00318",
+          "TKT-2022-02311",
+          "TKT-2023-05846"
+        ]
+      },
+      "human_override": null,
+      "final_decision": {
+        "category": "SECURITY",
+        "subcategory": "suspicious_person",
+        "risk_level": "MEDIUM",
+        "dispatched_vendor_id": "v_027",
+        "dispatched_emergency_services": false,
+        "needs_human_review": true,
+        "needs_clarification": false,
+        "confidence_category": 0.9,
+        "confidence_subcategory": 0.9,
+        "validator_reasons": [
+          "trap_cascade_subcategory:suspicious_person(high-audit cell at HIGH/EMERGENCY \u2014 possible under-classification)"
+        ],
+        "risk_reasons": [
+          "base_risk:MEDIUM"
+        ],
+        "retrieved_record_ids": [
+          "TKT-2022-09874",
+          "TKT-2023-04076",
+          "TKT-2023-05657",
+          "TKT-2022-03169",
+          "TKT-2023-07106",
+          "TKT-2024-00318",
+          "TKT-2022-02311",
+          "TKT-2023-05846"
+        ]
+      }
+    },
+    "transcript_id": "EVAL-0898"
+  },
+  {
+    "category": "HVAC",
+    "subcategory": "refrigerant",
+    "risk_level": "LOW",
+    "needs_human_review": false,
+    "needs_clarification": false,
+    "building_name": null,
+    "address": null,
+    "floor": "Floor 3",
+    "dispatched_vendor_id": "v_014",
+    "dispatched_emergency_services": false,
+    "call_summary": "Refrigerant issue reported at Floor 3. LOW risk. Dispatched MediCool HVAC Systems.",
+    "trainer_log": {
+      "full_transcript": "[AGENT] CBRE maintenance, this is Dana. What's going on?\n[CALLER] Hello, Chiller on Floor 3 is hissing and the cold air isn't very cold anymore.\n[AGENT] Understood. Is the unit still running?\n[CALLER] Performance dropped a lot since this morning.\n[AGENT] Got it. I'll get someone out as soon as I can \u2014 should hear back within the hour.\n[CALLER] Hold on, got it, thanks.",
+      "ai_prediction": {
+        "category": "HVAC",
+        "subcategory": "refrigerant",
+        "risk_level": "LOW",
+        "dispatched_vendor_id": "v_014",
+        "dispatched_emergency_services": false,
+        "needs_human_review": false,
+        "needs_clarification": false,
+        "confidence_category": 0.95,
+        "confidence_subcategory": 0.95,
+        "validator_reasons": [
+          "auto_resolve:no_flags_fired"
+        ],
+        "risk_reasons": [
+          "base_risk:LOW"
+        ],
+        "retrieved_record_ids": [
+          "TKT-2024-01890",
+          "TKT-2024-02445",
+          "TKT-2022-04039",
+          "TKT-2023-01688",
+          "TKT-2024-07977",
+          "TKT-2024-00699",
+          "TKT-2024-06807",
+          "TKT-2022-04636"
+        ]
+      },
+      "human_override": null,
+      "final_decision": {
+        "category": "HVAC",
+        "subcategory": "refrigerant",
+        "risk_level": "LOW",
+        "dispatched_vendor_id": "v_014",
+        "dispatched_emergency_services": false,
+        "needs_human_review": false,
+        "needs_clarification": false,
+        "confidence_category": 0.95,
+        "confidence_subcategory": 0.95,
+        "validator_reasons": [
+          "auto_resolve:no_flags_fired"
+        ],
+        "risk_reasons": [
+          "base_risk:LOW"
+        ],
+        "retrieved_record_ids": [
+          "TKT-2024-01890",
+          "TKT-2024-02445",
+          "TKT-2022-04039",
+          "TKT-2023-01688",
+          "TKT-2024-07977",
+          "TKT-2024-00699",
+          "TKT-2024-06807",
+          "TKT-2022-04636"
+        ]
+      }
+    },
+    "transcript_id": "EVAL-0905"
+  },
+  {
+    "category": "HVAC",
+    "subcategory": "air_quality",
+    "risk_level": "MEDIUM",
+    "needs_human_review": true,
+    "needs_clarification": false,
+    "building_name": "Torrance Gateway Center",
+    "address": "3500 Carson St",
+    "floor": "Floor 7",
+    "dispatched_vendor_id": "v_012",
+    "dispatched_emergency_services": false,
+    "call_summary": "Air quality concern reported at Torrance Gateway Center, Floor 7. MEDIUM risk. Flagged for review. Pacific HVAC Services dispatched pending approval.",
+    "trainer_log": {
+      "full_transcript": "[AGENT] Hi, CBRE facilities. What can I do for you?\n[CALLER] [background: hvac hum] Hold on, strong smell in the office.\n[AGENT] Does it smell like gas or sulfur?\n[CALLER] No, not sulfur \u2014 more like a cleaning solvent.\n[AGENT] Which building and floor are you at?\n[CALLER] Like, torrance Gateway Center, Floor 7.\n[AGENT] Tech is on the way. You'll get a text once they're rolling.",
+      "ai_prediction": {
+        "category": "HVAC",
+        "subcategory": "air_quality",
+        "risk_level": "MEDIUM",
+        "dispatched_vendor_id": "v_012",
+        "dispatched_emergency_services": false,
+        "needs_human_review": true,
+        "needs_clarification": false,
+        "confidence_category": 0.95,
+        "confidence_subcategory": 0.95,
+        "validator_reasons": [
+          "trap_prone_subcategory:air_quality(over_escalation_rate=19%)"
+        ],
+        "risk_reasons": [
+          "base_risk:MEDIUM"
+        ],
+        "retrieved_record_ids": [
+          "TKT-2023-02570",
+          "TKT-2023-00554",
+          "TKT-2023-01883",
+          "TKT-2024-09306",
+          "TKT-2024-08679",
+          "TKT-2024-03399",
+          "TKT-2023-09923",
+          "TKT-2024-07194"
+        ]
+      },
+      "human_override": null,
+      "final_decision": {
+        "category": "HVAC",
+        "subcategory": "air_quality",
+        "risk_level": "MEDIUM",
+        "dispatched_vendor_id": "v_012",
+        "dispatched_emergency_services": false,
+        "needs_human_review": true,
+        "needs_clarification": false,
+        "confidence_category": 0.95,
+        "confidence_subcategory": 0.95,
+        "validator_reasons": [
+          "trap_prone_subcategory:air_quality(over_escalation_rate=19%)"
+        ],
+        "risk_reasons": [
+          "base_risk:MEDIUM"
+        ],
+        "retrieved_record_ids": [
+          "TKT-2023-02570",
+          "TKT-2023-00554",
+          "TKT-2023-01883",
+          "TKT-2024-09306",
+          "TKT-2024-08679",
+          "TKT-2024-03399",
+          "TKT-2023-09923",
+          "TKT-2024-07194"
+        ]
+      }
+    },
+    "transcript_id": "EVAL-0930"
+  },
+  {
+    "category": "DOORS_ACCESS",
+    "subcategory": "door_mechanical",
+    "risk_level": "LOW",
+    "needs_human_review": false,
+    "needs_clarification": false,
+    "building_name": "Westpark Professional Center",
+    "address": "700 Westpark Dr",
+    "floor": "Floor 3",
+    "dispatched_vendor_id": "v_010",
+    "dispatched_emergency_services": false,
+    "call_summary": "Mechanical door issue reported at Westpark Professional Center, Floor 3. LOW risk. Dispatched All-Site Facilities Co.",
+    "trainer_log": {
+      "full_transcript": "[AGENT] CBRE facilities, this is Sam. What's going on?\n[CALLER] The door isn't working quite right.\n[AGENT] Okay, can you describe what you're seeing or smelling?\n[CALLER] You know, we can push it closed but it won't latch.\n[AGENT] Is this an exterior door?\n[CALLER] It's an interior door to the suite.\n[AGENT] Which building and floor are you at?\n[CALLER] Westpark Professional Center, I mean, Floor 3, Suite 302.\n[AGENT] Okay, ticket's logged. Someone'll come out during business hours.",
+      "ai_prediction": {
+        "category": "DOORS_ACCESS",
+        "subcategory": "door_mechanical",
+        "risk_level": "LOW",
+        "dispatched_vendor_id": "v_010",
+        "dispatched_emergency_services": false,
+        "needs_human_review": false,
+        "needs_clarification": false,
+        "confidence_category": 0.95,
+        "confidence_subcategory": 0.95,
+        "validator_reasons": [
+          "auto_resolve:no_flags_fired"
+        ],
+        "risk_reasons": [
+          "base_risk:LOW"
+        ],
+        "retrieved_record_ids": [
+          "TKT-2024-08961",
+          "TKT-2024-05319",
+          "TKT-2022-09364",
+          "TKT-2023-08816",
+          "TKT-2024-01773",
+          "TKT-2024-01494",
+          "TKT-2022-03289",
+          "TKT-2022-01306"
+        ]
+      },
+      "human_override": null,
+      "final_decision": {
+        "category": "DOORS_ACCESS",
+        "subcategory": "door_mechanical",
+        "risk_level": "LOW",
+        "dispatched_vendor_id": "v_010",
+        "dispatched_emergency_services": false,
+        "needs_human_review": false,
+        "needs_clarification": false,
+        "confidence_category": 0.95,
+        "confidence_subcategory": 0.95,
+        "validator_reasons": [
+          "auto_resolve:no_flags_fired"
+        ],
+        "risk_reasons": [
+          "base_risk:LOW"
+        ],
+        "retrieved_record_ids": [
+          "TKT-2024-08961",
+          "TKT-2024-05319",
+          "TKT-2022-09364",
+          "TKT-2023-08816",
+          "TKT-2024-01773",
+          "TKT-2024-01494",
+          "TKT-2022-03289",
+          "TKT-2022-01306"
+        ]
+      }
+    },
+    "transcript_id": "EVAL-0935"
+  },
+  {
+    "category": "HVAC",
+    "subcategory": "air_quality",
+    "risk_level": "MEDIUM",
+    "needs_human_review": true,
+    "needs_clarification": false,
+    "building_name": "One Commerce Center",
+    "address": "1 Commerce Way",
+    "floor": "Floor 6",
+    "dispatched_vendor_id": "v_014",
+    "dispatched_emergency_services": false,
+    "call_summary": "Air quality concern reported at One Commerce Center, Floor 6. MEDIUM risk. Flagged for review. MediCool HVAC Systems dispatched pending approval.",
+    "trainer_log": {
+      "full_transcript": "[AGENT] CBRE facilities, this is Sam. What's going on?\n[CALLER] The AC stopped working about an hour ago, it's getting hot.\n[AGENT] Understood. Are any servers or equipment at risk?\n[CALLER] Hmm \u2014 now that I pay attention, it's not just that the AC is out. There's a strange smell too.\n[AGENT] Got it \u2014 updating the ticket. Can you describe the smell?\n[CALLER] Um, no, not sulfur \u2014 more like a cleaning solvent.\n[AGENT] Can you confirm the building and floor?\n[CALLER] [pa announcement in background] I mean, one Commerce Center, Floor 6, Suite 604.\n[AGENT] Alright \u2014 sending a vendor over and giving the PM a heads-up.",
+      "ai_prediction": {
+        "category": "HVAC",
+        "subcategory": "air_quality",
+        "risk_level": "MEDIUM",
+        "dispatched_vendor_id": "v_014",
+        "dispatched_emergency_services": false,
+        "needs_human_review": true,
+        "needs_clarification": false,
+        "confidence_category": 0.95,
+        "confidence_subcategory": 0.95,
+        "validator_reasons": [
+          "trap_prone_subcategory:air_quality(over_escalation_rate=19%)"
+        ],
+        "risk_reasons": [
+          "base_risk:MEDIUM"
+        ],
+        "retrieved_record_ids": [
+          "TKT-2024-07419",
+          "TKT-2024-05469",
+          "TKT-2023-07307",
+          "TKT-2024-05580",
+          "TKT-2022-05920",
+          "TKT-2023-08141",
+          "TKT-2023-02384",
+          "TKT-2022-09532"
+        ]
+      },
+      "human_override": null,
+      "final_decision": {
+        "category": "HVAC",
+        "subcategory": "air_quality",
+        "risk_level": "MEDIUM",
+        "dispatched_vendor_id": "v_014",
+        "dispatched_emergency_services": false,
+        "needs_human_review": true,
+        "needs_clarification": false,
+        "confidence_category": 0.95,
+        "confidence_subcategory": 0.95,
+        "validator_reasons": [
+          "trap_prone_subcategory:air_quality(over_escalation_rate=19%)"
+        ],
+        "risk_reasons": [
+          "base_risk:MEDIUM"
+        ],
+        "retrieved_record_ids": [
+          "TKT-2024-07419",
+          "TKT-2024-05469",
+          "TKT-2023-07307",
+          "TKT-2024-05580",
+          "TKT-2022-05920",
+          "TKT-2023-08141",
+          "TKT-2023-02384",
+          "TKT-2022-09532"
+        ]
+      }
+    },
+    "transcript_id": "EVAL-0943"
+  },
+  {
+    "category": "DOORS_ACCESS",
+    "subcategory": "auto_door",
+    "risk_level": "LOW",
+    "needs_human_review": false,
+    "needs_clarification": false,
+    "building_name": "Brookfield Retail Center",
+    "address": "2200 Brookfield Rd",
+    "floor": "Floor 2",
+    "dispatched_vendor_id": "v_020",
+    "dispatched_emergency_services": false,
+    "call_summary": "Automatic door malfunction reported at Brookfield Retail Center, Floor 2. LOW risk. Dispatched SecurePass Access Systems.",
+    "trainer_log": {
+      "full_transcript": "[AGENT] CBRE facilities \u2014 how can I help?\n[CALLER] Uh, the main doors are being weird.\n[AGENT] Okay, can you describe what you're seeing or smelling?\n[CALLER] Yeah it's a fire exit.\n[AGENT] Is it stuck open or closed?\n[CALLER] Hold on, yeah it's a fire exit.\n[AGENT] Where exactly \u2014 which suite?\n[CALLER] Brookfield Retail Center, Floor 2, Suite 208.\n[AGENT] Alright, I've put a ticket in \u2014 vendor will swing by during business hours.",
+      "ai_prediction": {
+        "category": "DOORS_ACCESS",
+        "subcategory": "auto_door",
+        "risk_level": "LOW",
+        "dispatched_vendor_id": "v_020",
+        "dispatched_emergency_services": false,
+        "needs_human_review": false,
+        "needs_clarification": false,
+        "confidence_category": 0.9,
+        "confidence_subcategory": 0.9,
+        "validator_reasons": [
+          "auto_resolve:no_flags_fired"
+        ],
+        "risk_reasons": [
+          "base_risk:LOW",
+          "hard_cue:fire",
+          "capped_at_LOW:historical_max for subcategory=auto_door"
+        ],
+        "retrieved_record_ids": [
+          "TKT-2023-07127",
+          "TKT-2024-04365",
+          "TKT-2022-01669",
+          "TKT-2024-01485",
+          "TKT-2024-04290",
+          "TKT-2024-07866",
+          "TKT-2022-03619",
+          "TKT-2022-04654"
+        ]
+      },
+      "human_override": null,
+      "final_decision": {
+        "category": "DOORS_ACCESS",
+        "subcategory": "auto_door",
+        "risk_level": "LOW",
+        "dispatched_vendor_id": "v_020",
+        "dispatched_emergency_services": false,
+        "needs_human_review": false,
+        "needs_clarification": false,
+        "confidence_category": 0.9,
+        "confidence_subcategory": 0.9,
+        "validator_reasons": [
+          "auto_resolve:no_flags_fired"
+        ],
+        "risk_reasons": [
+          "base_risk:LOW",
+          "hard_cue:fire",
+          "capped_at_LOW:historical_max for subcategory=auto_door"
+        ],
+        "retrieved_record_ids": [
+          "TKT-2023-07127",
+          "TKT-2024-04365",
+          "TKT-2022-01669",
+          "TKT-2024-01485",
+          "TKT-2024-04290",
+          "TKT-2024-07866",
+          "TKT-2022-03619",
+          "TKT-2022-04654"
+        ]
+      }
+    },
+    "transcript_id": "EVAL-0944"
+  },
+  {
+    "category": "ELECTRICAL",
+    "subcategory": "low_voltage_data",
+    "risk_level": "LOW",
+    "needs_human_review": false,
+    "needs_clarification": true,
+    "building_name": "Brookfield Retail Center",
+    "address": "2200 Brookfield Rd",
+    "floor": "Floor 1",
+    "dispatched_vendor_id": "v_011",
+    "dispatched_emergency_services": false,
+    "call_summary": "Low-voltage/data issue reported at Brookfield Retail Center, Floor 1. LOW risk. Dispatched NetCom Low-Voltage Tech.",
+    "trainer_log": {
+      "full_transcript": "[AGENT] CBRE facilities \u2014 how can I help?\n[CALLER] I mean, there's an issue with low voltage data.\n[AGENT] Are any critical systems affected?\n[CALLER] Internet and phones both dead.\n[AGENT] Where exactly \u2014 which suite?\n[CALLER] Brookfield Retail Center, Floor 1, Suite 112.\n[AGENT] Got it. I'll get someone out as soon as I can \u2014 should hear back within the hour.",
+      "ai_prediction": {
+        "category": "ELECTRICAL",
+        "subcategory": "low_voltage_data",
+        "risk_level": "LOW",
+        "dispatched_vendor_id": "v_011",
+        "dispatched_emergency_services": false,
+        "needs_human_review": false,
+        "needs_clarification": true,
+        "confidence_category": 0.95,
+        "confidence_subcategory": 0.95,
+        "validator_reasons": [
+          "auto_resolve:no_flags_fired"
+        ],
+        "risk_reasons": [
+          "base_risk:LOW"
+        ],
+        "retrieved_record_ids": [
+          "TKT-2024-06066",
+          "TKT-2023-08978",
+          "TKT-2024-00939",
+          "TKT-2024-02487",
+          "TKT-2024-03726",
+          "TKT-2023-00035",
+          "TKT-2023-06386",
+          "TKT-2023-02858"
+        ]
+      },
+      "human_override": null,
+      "final_decision": {
+        "category": "ELECTRICAL",
+        "subcategory": "low_voltage_data",
+        "risk_level": "LOW",
+        "dispatched_vendor_id": "v_011",
+        "dispatched_emergency_services": false,
+        "needs_human_review": false,
+        "needs_clarification": true,
+        "confidence_category": 0.95,
+        "confidence_subcategory": 0.95,
+        "validator_reasons": [
+          "auto_resolve:no_flags_fired"
+        ],
+        "risk_reasons": [
+          "base_risk:LOW"
+        ],
+        "retrieved_record_ids": [
+          "TKT-2024-06066",
+          "TKT-2023-08978",
+          "TKT-2024-00939",
+          "TKT-2024-02487",
+          "TKT-2024-03726",
+          "TKT-2023-00035",
+          "TKT-2023-06386",
+          "TKT-2023-02858"
+        ]
+      }
+    },
+    "transcript_id": "EVAL-0947"
+  },
+  {
+    "category": "ELECTRICAL",
+    "subcategory": "power_outage",
+    "risk_level": "HIGH",
+    "needs_human_review": true,
+    "needs_clarification": false,
+    "building_name": "Central Tower",
+    "address": "700 S Grand Ave",
+    "floor": "Floor 28",
+    "dispatched_vendor_id": "v_008",
+    "dispatched_emergency_services": false,
+    "call_summary": "Power outage reported at Central Tower, Floor 28. HIGH risk. Flagged for review. Rapid Response Electricians dispatched pending approval.",
+    "trainer_log": {
+      "full_transcript": "[AGENT] CBRE facilities, this is Sam. What's going on?\n[CALLER] Hey, Lost power to about half our desks, the other half is fine.\n[AGENT] Got it. Is it the whole floor or just your suite?\n[CALLER] Whole floor, all the lights and outlets.\n[AGENT] Can you tell me the building, floor, and suite?\n[CALLER] Uh, central Tower, Floor 28, Suite 2210.\n[AGENT] Alright \u2014 sending a vendor over and giving the PM a heads-up.",
+      "ai_prediction": {
+        "category": "ELECTRICAL",
+        "subcategory": "power_outage",
+        "risk_level": "HIGH",
+        "dispatched_vendor_id": "v_008",
+        "dispatched_emergency_services": false,
+        "needs_human_review": true,
+        "needs_clarification": false,
+        "confidence_category": 0.95,
+        "confidence_subcategory": 0.95,
+        "validator_reasons": [
+          "high_band:always_pause"
+        ],
+        "risk_reasons": [
+          "base_risk:HIGH"
+        ],
+        "retrieved_record_ids": [
+          "TKT-2023-09464",
+          "TKT-2022-08080",
+          "TKT-2022-06757",
+          "TKT-2023-06806",
+          "TKT-2024-06777",
+          "TKT-2024-02376",
+          "TKT-2024-05322",
+          "TKT-2022-09358"
+        ]
+      },
+      "human_override": null,
+      "final_decision": {
+        "category": "ELECTRICAL",
+        "subcategory": "power_outage",
+        "risk_level": "HIGH",
+        "dispatched_vendor_id": "v_008",
+        "dispatched_emergency_services": false,
+        "needs_human_review": true,
+        "needs_clarification": false,
+        "confidence_category": 0.95,
+        "confidence_subcategory": 0.95,
+        "validator_reasons": [
+          "high_band:always_pause"
+        ],
+        "risk_reasons": [
+          "base_risk:HIGH"
+        ],
+        "retrieved_record_ids": [
+          "TKT-2023-09464",
+          "TKT-2022-08080",
+          "TKT-2022-06757",
+          "TKT-2023-06806",
+          "TKT-2024-06777",
+          "TKT-2024-02376",
+          "TKT-2024-05322",
+          "TKT-2022-09358"
+        ]
+      }
+    },
+    "transcript_id": "EVAL-0952"
+  },
+  {
+    "category": "GROUNDS_EXTERIOR",
+    "subcategory": "signage_fencing",
+    "risk_level": "LOW",
+    "needs_human_review": false,
+    "needs_clarification": false,
+    "building_name": "Torrance Gateway Center",
+    "address": "3500 Carson St",
+    "floor": "Floor 5",
+    "dispatched_vendor_id": "v_029",
+    "dispatched_emergency_services": false,
+    "call_summary": "Signage/fencing issue reported at Torrance Gateway Center, Floor 5. LOW risk. Dispatched Golden State Exterior Maintenance.",
+    "trainer_log": {
+      "full_transcript": "[AGENT] Hi, CBRE facilities. What can I do for you?\n[CALLER] Something outside fell over, looks bad.\n[AGENT] Okay, can you describe what you're seeing or smelling?\n[CALLER] Hold on, not blocking anything but it looks bad.\n[AGENT] Is it blocking access?\n[CALLER] The sign is propped up but could fall.\n[AGENT] Can you confirm the building and floor?\n[CALLER] Torrance Gateway Center, Floor 5, Suite 508.\n[AGENT] Got the ticket open. Vendor should make it out during business hours.",
+      "ai_prediction": {
+        "category": "GROUNDS_EXTERIOR",
+        "subcategory": "signage_fencing",
+        "risk_level": "LOW",
+        "dispatched_vendor_id": "v_029",
+        "dispatched_emergency_services": false,
+        "needs_human_review": false,
+        "needs_clarification": false,
+        "confidence_category": 0.95,
+        "confidence_subcategory": 0.95,
+        "validator_reasons": [
+          "auto_resolve:no_flags_fired"
+        ],
+        "risk_reasons": [
+          "base_risk:LOW"
+        ],
+        "retrieved_record_ids": [
+          "TKT-2023-01055",
+          "TKT-2022-00103",
+          "TKT-2022-06979",
+          "TKT-2022-00148",
+          "TKT-2024-02961",
+          "TKT-2023-08894",
+          "TKT-2024-07887",
+          "TKT-2023-01409"
+        ]
+      },
+      "human_override": null,
+      "final_decision": {
+        "category": "GROUNDS_EXTERIOR",
+        "subcategory": "signage_fencing",
+        "risk_level": "LOW",
+        "dispatched_vendor_id": "v_029",
+        "dispatched_emergency_services": false,
+        "needs_human_review": false,
+        "needs_clarification": false,
+        "confidence_category": 0.95,
+        "confidence_subcategory": 0.95,
+        "validator_reasons": [
+          "auto_resolve:no_flags_fired"
+        ],
+        "risk_reasons": [
+          "base_risk:LOW"
+        ],
+        "retrieved_record_ids": [
+          "TKT-2023-01055",
+          "TKT-2022-00103",
+          "TKT-2022-06979",
+          "TKT-2022-00148",
+          "TKT-2024-02961",
+          "TKT-2023-08894",
+          "TKT-2024-07887",
+          "TKT-2023-01409"
+        ]
+      }
+    },
+    "transcript_id": "EVAL-0953"
+  },
+  {
+    "category": "PLUMBING",
+    "subcategory": "roof_leak",
+    "risk_level": "MEDIUM",
+    "needs_human_review": true,
+    "needs_clarification": false,
+    "building_name": "Wilshire Grand Offices",
+    "address": "1100 Wilshire Blvd",
+    "floor": "Floor 27",
+    "dispatched_vendor_id": "v_005",
+    "dispatched_emergency_services": false,
+    "call_summary": "Roof leak reported at Wilshire Grand Offices, Floor 27. MEDIUM risk. Flagged for review. Bayside Roofing Co dispatched pending approval.",
+    "trainer_log": {
+      "full_transcript": "[AGENT] Hi, CBRE facilities. What can I do for you?\n[CALLER] Something's dripping from up top.\n[AGENT] Okay, can you describe what you're seeing or smelling?\n[CALLER] Yeah, it's been pouring for like an hour.\n[AGENT] Is the ceiling sagging?\n[CALLER] Yeah, it's been pouring for like an hour.\n[AGENT] Can you confirm the building and floor?\n[CALLER] Wilshire Grand Offices, Floor 27, Suite 2704.\n[AGENT] I'll get a vendor rolling and let the property manager know.",
+      "ai_prediction": {
+        "category": "PLUMBING",
+        "subcategory": "roof_leak",
+        "risk_level": "MEDIUM",
+        "dispatched_vendor_id": "v_005",
+        "dispatched_emergency_services": false,
+        "needs_human_review": true,
+        "needs_clarification": false,
+        "confidence_category": 0.95,
+        "confidence_subcategory": 0.95,
+        "validator_reasons": [
+          "trap_cascade_subcategory:roof_leak(high-audit cell at HIGH/EMERGENCY \u2014 possible under-classification)"
+        ],
+        "risk_reasons": [
+          "base_risk:MEDIUM",
+          "soft_cue:flooding",
+          "capped_at_MEDIUM:historical_max for subcategory=roof_leak"
+        ],
+        "retrieved_record_ids": [
+          "TKT-2022-08299",
+          "TKT-2022-05638",
+          "TKT-2024-05163",
+          "TKT-2024-06261",
+          "TKT-2024-07929",
+          "TKT-2023-04388",
+          "TKT-2024-09768",
+          "TKT-2022-00526"
+        ]
+      },
+      "human_override": null,
+      "final_decision": {
+        "category": "PLUMBING",
+        "subcategory": "roof_leak",
+        "risk_level": "MEDIUM",
+        "dispatched_vendor_id": "v_005",
+        "dispatched_emergency_services": false,
+        "needs_human_review": true,
+        "needs_clarification": false,
+        "confidence_category": 0.95,
+        "confidence_subcategory": 0.95,
+        "validator_reasons": [
+          "trap_cascade_subcategory:roof_leak(high-audit cell at HIGH/EMERGENCY \u2014 possible under-classification)"
+        ],
+        "risk_reasons": [
+          "base_risk:MEDIUM",
+          "soft_cue:flooding",
+          "capped_at_MEDIUM:historical_max for subcategory=roof_leak"
+        ],
+        "retrieved_record_ids": [
+          "TKT-2022-08299",
+          "TKT-2022-05638",
+          "TKT-2024-05163",
+          "TKT-2024-06261",
+          "TKT-2024-07929",
+          "TKT-2023-04388",
+          "TKT-2024-09768",
+          "TKT-2022-00526"
+        ]
+      }
+    },
+    "transcript_id": "EVAL-0959"
+  },
+  {
+    "category": "ELECTRICAL",
+    "subcategory": "low_voltage_data",
+    "risk_level": "LOW",
+    "needs_human_review": false,
+    "needs_clarification": false,
+    "building_name": "Ventura Harbor Center",
+    "address": "1550 Spinnaker Dr",
+    "floor": "Floor 2",
+    "dispatched_vendor_id": "v_011",
+    "dispatched_emergency_services": false,
+    "call_summary": "Low-voltage/data issue reported at Ventura Harbor Center, Floor 2. LOW risk. Dispatched NetCom Low-Voltage Tech.",
+    "trainer_log": {
+      "full_transcript": "[AGENT] CBRE facilities \u2014 how can I help?\n[CALLER] Phone system is dead in the suite.\n[AGENT] Mhm. Are any critical systems affected?\n[CALLER] Internet and phones both dead.\n[AGENT] Which building and floor are you at?\n[CALLER] Ventura Harbor Center, Floor 2, Suite 208.\n[AGENT] Alright, I've put a ticket in \u2014 vendor will swing by during business hours.",
+      "ai_prediction": {
+        "category": "ELECTRICAL",
+        "subcategory": "low_voltage_data",
+        "risk_level": "LOW",
+        "dispatched_vendor_id": "v_011",
+        "dispatched_emergency_services": false,
+        "needs_human_review": false,
+        "needs_clarification": false,
+        "confidence_category": 0.9,
+        "confidence_subcategory": 0.9,
+        "validator_reasons": [
+          "auto_resolve:no_flags_fired"
+        ],
+        "risk_reasons": [
+          "base_risk:LOW"
+        ],
+        "retrieved_record_ids": [
+          "TKT-2023-00410",
+          "TKT-2024-03648",
+          "TKT-2023-03644",
+          "TKT-2022-00232",
+          "TKT-2023-08528",
+          "TKT-2022-01930",
+          "TKT-2024-08922",
+          "TKT-2024-09276"
+        ]
+      },
+      "human_override": null,
+      "final_decision": {
+        "category": "ELECTRICAL",
+        "subcategory": "low_voltage_data",
+        "risk_level": "LOW",
+        "dispatched_vendor_id": "v_011",
+        "dispatched_emergency_services": false,
+        "needs_human_review": false,
+        "needs_clarification": false,
+        "confidence_category": 0.9,
+        "confidence_subcategory": 0.9,
+        "validator_reasons": [
+          "auto_resolve:no_flags_fired"
+        ],
+        "risk_reasons": [
+          "base_risk:LOW"
+        ],
+        "retrieved_record_ids": [
+          "TKT-2023-00410",
+          "TKT-2024-03648",
+          "TKT-2023-03644",
+          "TKT-2022-00232",
+          "TKT-2023-08528",
+          "TKT-2022-01930",
+          "TKT-2024-08922",
+          "TKT-2024-09276"
+        ]
+      }
+    },
+    "transcript_id": "EVAL-0961"
+  },
+  {
+    "category": "SECURITY",
+    "subcategory": "active_threat",
+    "risk_level": "EMERGENCY",
+    "needs_human_review": true,
+    "needs_clarification": false,
+    "building_name": "Canyon View Business Center",
+    "address": "4400 Canyon View Dr",
+    "floor": "Floor 1",
+    "dispatched_vendor_id": "v_027",
+    "dispatched_emergency_services": true,
+    "call_summary": "Active threat reported at Canyon View Business Center, Floor 1. EMERGENCY risk. Emergency services dispatched.",
+    "trainer_log": {
+      "full_transcript": "[AGENT] CBRE dispatch, talk to me.\n[CALLER] There's a person yelling threats on Floor 1, uh, I think they have a weapon.\n[AGENT] Where exactly \u2014 which suite?\n[CALLER] Canyon View Business Center, Floor 1.\n[AGENT] Dialing 911 now. Please leave the area if it's safe.",
+      "ai_prediction": {
+        "category": "SECURITY",
+        "subcategory": "active_threat",
+        "risk_level": "EMERGENCY",
+        "dispatched_vendor_id": "v_027",
+        "dispatched_emergency_services": true,
+        "needs_human_review": true,
+        "needs_clarification": false,
+        "confidence_category": 0.95,
+        "confidence_subcategory": 0.95,
+        "validator_reasons": [
+          "emergency_band:always_pause",
+          "emergency_dispatch:active_threat:hazard_cue_confirmed"
+        ],
+        "risk_reasons": [
+          "base_risk:EMERGENCY",
+          "hard_cue:have a weapon",
+          "capped_at_EMERGENCY:historical_max for subcategory=active_threat"
+        ],
+        "retrieved_record_ids": [
+          "TKT-2024-00717",
+          "TKT-2022-05836",
+          "TKT-2022-08038",
+          "TKT-2022-02197",
+          "TKT-2024-05022",
+          "TKT-2022-02245",
+          "TKT-2022-04213",
+          "TKT-2023-07544"
+        ]
+      },
+      "human_override": null,
+      "final_decision": {
+        "category": "SECURITY",
+        "subcategory": "active_threat",
+        "risk_level": "EMERGENCY",
+        "dispatched_vendor_id": "v_027",
+        "dispatched_emergency_services": true,
+        "needs_human_review": true,
+        "needs_clarification": false,
+        "confidence_category": 0.95,
+        "confidence_subcategory": 0.95,
+        "validator_reasons": [
+          "emergency_band:always_pause",
+          "emergency_dispatch:active_threat:hazard_cue_confirmed"
+        ],
+        "risk_reasons": [
+          "base_risk:EMERGENCY",
+          "hard_cue:have a weapon",
+          "capped_at_EMERGENCY:historical_max for subcategory=active_threat"
+        ],
+        "retrieved_record_ids": [
+          "TKT-2024-00717",
+          "TKT-2022-05836",
+          "TKT-2022-08038",
+          "TKT-2022-02197",
+          "TKT-2024-05022",
+          "TKT-2022-02245",
+          "TKT-2022-04213",
+          "TKT-2023-07544"
+        ]
+      }
+    },
+    "transcript_id": "EVAL-0967"
+  },
+  {
+    "category": "DOORS_ACCESS",
+    "subcategory": "access_control",
+    "risk_level": "LOW",
+    "needs_human_review": false,
+    "needs_clarification": true,
+    "building_name": "Airport Business Center",
+    "address": "9200 Airport Blvd",
+    "floor": "Floor 1",
+    "dispatched_vendor_id": "v_020",
+    "dispatched_emergency_services": false,
+    "call_summary": "Access control issue reported at Airport Business Center, Floor 1. LOW risk. Dispatched SecurePass Access Systems.",
+    "trainer_log": {
+      "full_transcript": "[AGENT] CBRE dispatch \u2014 go ahead.\n[CALLER] There's an issue with access control.\n[AGENT] Is it the main reader or a sub-area?\n[CALLER] [background: hvac hum] Sorry, we've got a side door still working.\n[AGENT] Where exactly \u2014 which suite?\n[CALLER] You know, airport Business Center, Floor 1.\n[AGENT] Alright, I've put a ticket in \u2014 vendor will swing by during business hours.",
+      "ai_prediction": {
+        "category": "DOORS_ACCESS",
+        "subcategory": "access_control",
+        "risk_level": "LOW",
+        "dispatched_vendor_id": "v_020",
+        "dispatched_emergency_services": false,
+        "needs_human_review": false,
+        "needs_clarification": true,
+        "confidence_category": 0.9,
+        "confidence_subcategory": 0.9,
+        "validator_reasons": [
+          "auto_resolve:no_flags_fired"
+        ],
+        "risk_reasons": [
+          "base_risk:LOW"
+        ],
+        "retrieved_record_ids": [
+          "TKT-2024-07446",
+          "TKT-2023-01034",
+          "TKT-2023-02252",
+          "TKT-2024-07314",
+          "TKT-2022-02833",
+          "TKT-2024-07566",
+          "TKT-2022-02839",
+          "TKT-2024-08406"
+        ]
+      },
+      "human_override": null,
+      "final_decision": {
+        "category": "DOORS_ACCESS",
+        "subcategory": "access_control",
+        "risk_level": "LOW",
+        "dispatched_vendor_id": "v_020",
+        "dispatched_emergency_services": false,
+        "needs_human_review": false,
+        "needs_clarification": true,
+        "confidence_category": 0.9,
+        "confidence_subcategory": 0.9,
+        "validator_reasons": [
+          "auto_resolve:no_flags_fired"
+        ],
+        "risk_reasons": [
+          "base_risk:LOW"
+        ],
+        "retrieved_record_ids": [
+          "TKT-2024-07446",
+          "TKT-2023-01034",
+          "TKT-2023-02252",
+          "TKT-2024-07314",
+          "TKT-2022-02833",
+          "TKT-2024-07566",
+          "TKT-2022-02839",
+          "TKT-2024-08406"
+        ]
+      }
+    },
+    "transcript_id": "EVAL-0969"
+  },
+  {
+    "category": "JANITORIAL",
+    "subcategory": "waste_odor",
+    "risk_level": "LOW",
+    "needs_human_review": false,
+    "needs_clarification": false,
+    "building_name": "Central Tower",
+    "address": "700 S Grand Ave",
+    "floor": "Floor 22",
+    "dispatched_vendor_id": "v_023",
+    "dispatched_emergency_services": false,
+    "call_summary": "Waste/odor issue reported at Central Tower, Floor 22. LOW risk. Dispatched Sparkle Commercial Cleaning.",
+    "trainer_log": {
+      "full_transcript": "[AGENT] CBRE maintenance line, this is Priya \u2014 what do you need?\n[CALLER] We see smoke, but it's from someone's candle being too close to a vent \u2014 already put out.\n[AGENT] Okay \u2014 can you confirm there's no actual fire or injury right now?\n[CALLER] No fire, just the burnt smell.\n[AGENT] Can you confirm the building and floor?\n[CALLER] Central Tower, Floor 22, Suite 2210.\n[AGENT] Got the ticket open. Vendor should make it out during business hours.",
+      "ai_prediction": {
+        "category": "JANITORIAL",
+        "subcategory": "waste_odor",
+        "risk_level": "LOW",
+        "dispatched_vendor_id": "v_023",
+        "dispatched_emergency_services": false,
+        "needs_human_review": false,
+        "needs_clarification": false,
+        "confidence_category": 0.95,
+        "confidence_subcategory": 0.95,
+        "validator_reasons": [
+          "auto_resolve:no_flags_fired"
+        ],
+        "risk_reasons": [
+          "base_risk:LOW",
+          "hard_cue:smoke",
+          "capped_at_LOW:historical_max for subcategory=waste_odor"
+        ],
+        "retrieved_record_ids": [
+          "TKT-2024-03702",
+          "TKT-2024-02913",
+          "TKT-2022-03682",
+          "TKT-2023-06860",
+          "TKT-2023-00527",
+          "TKT-2023-09584",
+          "TKT-2022-00154",
+          "TKT-2022-05299"
+        ]
+      },
+      "human_override": null,
+      "final_decision": {
+        "category": "JANITORIAL",
+        "subcategory": "waste_odor",
+        "risk_level": "LOW",
+        "dispatched_vendor_id": "v_023",
+        "dispatched_emergency_services": false,
+        "needs_human_review": false,
+        "needs_clarification": false,
+        "confidence_category": 0.95,
+        "confidence_subcategory": 0.95,
+        "validator_reasons": [
+          "auto_resolve:no_flags_fired"
+        ],
+        "risk_reasons": [
+          "base_risk:LOW",
+          "hard_cue:smoke",
+          "capped_at_LOW:historical_max for subcategory=waste_odor"
+        ],
+        "retrieved_record_ids": [
+          "TKT-2024-03702",
+          "TKT-2024-02913",
+          "TKT-2022-03682",
+          "TKT-2023-06860",
+          "TKT-2023-00527",
+          "TKT-2023-09584",
+          "TKT-2022-00154",
+          "TKT-2022-05299"
+        ]
+      }
+    },
+    "transcript_id": "EVAL-0974"
+  },
+  {
+    "category": "HVAC",
+    "subcategory": "no_cooling",
+    "risk_level": "LOW",
+    "needs_human_review": false,
+    "needs_clarification": false,
+    "building_name": "North Hollywood Arts Center",
+    "address": "5200 Lankershim Blvd",
+    "floor": "Floor 1",
+    "dispatched_vendor_id": "v_012",
+    "dispatched_emergency_services": false,
+    "call_summary": "No cooling reported at North Hollywood Arts Center, Floor 1. LOW risk. Dispatched Pacific HVAC Services.",
+    "trainer_log": {
+      "full_transcript": "[AGENT] CBRE maintenance line, this is Priya \u2014 what do you need?\n[CALLER] Hi, AC failure on our floor, multiple complaints.\n[AGENT] Okay, I see. What's the current temperature?\n[CALLER] It's 79 and climbing in here.\n[AGENT] Where exactly \u2014 which suite?\n[CALLER] North Hollywood Arts Center, Floor 1.\n[AGENT] Got the ticket open. Vendor should make it out during business hours.\n[CALLER] Got it, thanks.",
+      "ai_prediction": {
+        "category": "HVAC",
+        "subcategory": "no_cooling",
+        "risk_level": "LOW",
+        "dispatched_vendor_id": "v_012",
+        "dispatched_emergency_services": false,
+        "needs_human_review": false,
+        "needs_clarification": false,
+        "confidence_category": 0.95,
+        "confidence_subcategory": 0.95,
+        "validator_reasons": [
+          "auto_resolve:no_flags_fired"
+        ],
+        "risk_reasons": [
+          "base_risk:LOW"
+        ],
+        "retrieved_record_ids": [
+          "TKT-2024-05685",
+          "TKT-2022-00082",
+          "TKT-2023-03548",
+          "TKT-2022-09094",
+          "TKT-2023-01625",
+          "TKT-2022-06661",
+          "TKT-2023-00494",
+          "TKT-2022-01153"
+        ]
+      },
+      "human_override": null,
+      "final_decision": {
+        "category": "HVAC",
+        "subcategory": "no_cooling",
+        "risk_level": "LOW",
+        "dispatched_vendor_id": "v_012",
+        "dispatched_emergency_services": false,
+        "needs_human_review": false,
+        "needs_clarification": false,
+        "confidence_category": 0.95,
+        "confidence_subcategory": 0.95,
+        "validator_reasons": [
+          "auto_resolve:no_flags_fired"
+        ],
+        "risk_reasons": [
+          "base_risk:LOW"
+        ],
+        "retrieved_record_ids": [
+          "TKT-2024-05685",
+          "TKT-2022-00082",
+          "TKT-2023-03548",
+          "TKT-2022-09094",
+          "TKT-2023-01625",
+          "TKT-2022-06661",
+          "TKT-2023-00494",
+          "TKT-2022-01153"
+        ]
+      }
+    },
+    "transcript_id": "EVAL-0976"
+  },
+  {
+    "category": "JANITORIAL",
+    "subcategory": "restroom_supplies",
+    "risk_level": "LOW",
+    "needs_human_review": false,
+    "needs_clarification": false,
+    "building_name": "Olive Garden Business Center",
+    "address": "1400 Olive Ave",
+    "floor": "Rooftop",
+    "dispatched_vendor_id": "v_023",
+    "dispatched_emergency_services": false,
+    "call_summary": "Restroom supply issue reported at Olive Garden Business Center, Rooftop. LOW risk. Dispatched Sparkle Commercial Cleaning.",
+    "trainer_log": {
+      "full_transcript": "[AGENT] CBRE dispatch, talk to me.\n[CALLER] Hey, Restroom is out of toilet paper and paper towels.\n[AGENT] Understood. Is the whole facility out?\n[CALLER] Women's room on three.\n[AGENT] Which building and floor are you at?\n[CALLER] Olive Garden Business Center, Rooftop, Suite 305.\n[AGENT] Okay, I'll line that up now. Confirmation text will come through shortly.\n[CALLER] Alright, appreciate it.",
+      "ai_prediction": {
+        "category": "JANITORIAL",
+        "subcategory": "restroom_supplies",
+        "risk_level": "LOW",
+        "dispatched_vendor_id": "v_023",
+        "dispatched_emergency_services": false,
+        "needs_human_review": false,
+        "needs_clarification": false,
+        "confidence_category": 0.95,
+        "confidence_subcategory": 0.95,
+        "validator_reasons": [
+          "auto_resolve:no_flags_fired"
+        ],
+        "risk_reasons": [
+          "base_risk:LOW"
+        ],
+        "retrieved_record_ids": [
+          "TKT-2022-08467",
+          "TKT-2022-04618",
+          "TKT-2023-03878",
+          "TKT-2022-05617",
+          "TKT-2023-08306",
+          "TKT-2024-02238",
+          "TKT-2024-00984",
+          "TKT-2022-05257"
+        ]
+      },
+      "human_override": null,
+      "final_decision": {
+        "category": "JANITORIAL",
+        "subcategory": "restroom_supplies",
+        "risk_level": "LOW",
+        "dispatched_vendor_id": "v_023",
+        "dispatched_emergency_services": false,
+        "needs_human_review": false,
+        "needs_clarification": false,
+        "confidence_category": 0.95,
+        "confidence_subcategory": 0.95,
+        "validator_reasons": [
+          "auto_resolve:no_flags_fired"
+        ],
+        "risk_reasons": [
+          "base_risk:LOW"
+        ],
+        "retrieved_record_ids": [
+          "TKT-2022-08467",
+          "TKT-2022-04618",
+          "TKT-2023-03878",
+          "TKT-2022-05617",
+          "TKT-2023-08306",
+          "TKT-2024-02238",
+          "TKT-2024-00984",
+          "TKT-2022-05257"
+        ]
+      }
+    },
+    "transcript_id": "EVAL-0982"
+  },
+  {
+    "category": "ELECTRICAL",
+    "subcategory": "lighting",
+    "risk_level": "LOW",
+    "needs_human_review": false,
+    "needs_clarification": false,
+    "building_name": "Gateway Industrial Complex",
+    "address": "500 Industrial Blvd",
+    "floor": "Ground Floor",
+    "dispatched_vendor_id": "v_010",
+    "dispatched_emergency_services": false,
+    "call_summary": "Lighting failure reported at Gateway Industrial Complex, Ground Floor. LOW risk. Dispatched All-Site Facilities Co.",
+    "trainer_log": {
+      "full_transcript": "[AGENT] CBRE facilities, this is Sam. What's going on?\n[CALLER] Hello, hold on, Three ceiling lights burned out, it's getting dark.\n[AGENT] Okay. Is it flickering or fully out?\n[CALLER] Four fixtures in the hallway.\n[AGENT] Can you confirm the building and floor?\n[CALLER] Gateway Industrial Complex, I mean, Ground Floor.\n[AGENT] Alright, I'll send a vendor over. You'll get a text once they're rolling.\n[CALLER] Okay.",
+      "ai_prediction": {
+        "category": "ELECTRICAL",
+        "subcategory": "lighting",
+        "risk_level": "LOW",
+        "dispatched_vendor_id": "v_010",
+        "dispatched_emergency_services": false,
+        "needs_human_review": false,
+        "needs_clarification": false,
+        "confidence_category": 0.95,
+        "confidence_subcategory": 0.95,
+        "validator_reasons": [
+          "auto_resolve:no_flags_fired"
+        ],
+        "risk_reasons": [
+          "base_risk:LOW"
+        ],
+        "retrieved_record_ids": [
+          "TKT-2022-07174",
+          "TKT-2024-01770",
+          "TKT-2022-04258",
+          "TKT-2022-06106",
+          "TKT-2023-08762",
+          "TKT-2022-07783",
+          "TKT-2024-00894",
+          "TKT-2022-05566"
+        ]
+      },
+      "human_override": null,
+      "final_decision": {
+        "category": "ELECTRICAL",
+        "subcategory": "lighting",
+        "risk_level": "LOW",
+        "dispatched_vendor_id": "v_010",
+        "dispatched_emergency_services": false,
+        "needs_human_review": false,
+        "needs_clarification": false,
+        "confidence_category": 0.95,
+        "confidence_subcategory": 0.95,
+        "validator_reasons": [
+          "auto_resolve:no_flags_fired"
+        ],
+        "risk_reasons": [
+          "base_risk:LOW"
+        ],
+        "retrieved_record_ids": [
+          "TKT-2022-07174",
+          "TKT-2024-01770",
+          "TKT-2022-04258",
+          "TKT-2022-06106",
+          "TKT-2023-08762",
+          "TKT-2022-07783",
+          "TKT-2024-00894",
+          "TKT-2022-05566"
+        ]
+      }
+    },
+    "transcript_id": "EVAL-0984"
+  },
+  {
+    "category": "LIFE_SAFETY",
+    "subcategory": "fire_smoke",
+    "risk_level": "EMERGENCY",
+    "needs_human_review": true,
+    "needs_clarification": false,
+    "building_name": "North Hollywood Arts Center",
+    "address": "5200 Lankershim Blvd",
+    "floor": "Floor 4",
+    "dispatched_vendor_id": null,
+    "dispatched_emergency_services": true,
+    "call_summary": "Fire/smoke detected reported at North Hollywood Arts Center, Floor 4. EMERGENCY risk. Emergency services dispatched.",
+    "trainer_log": {
+      "full_transcript": "[AGENT] CBRE dispatch, talk to me.\n[CALLER] There's smoke coming from the electrical room, um, I can see it.\n[AGENT] Alright. Is there visible fire?\n[CALLER] Just smoke right now, no flames visible.\n[AGENT] Which building and floor are you at?\n[CALLER] North Hollywood Arts Center, Floor 4.\n[AGENT] Have you pulled the fire alarm?\n[CALLER] I see flames in the trash can.\n[AGENT] 911 is going out now and I'm alerting building ops \u2014 stay with me on the line if you can.\n[CALLER] Okay, please hurry.",
+      "ai_prediction": {
+        "category": "LIFE_SAFETY",
+        "subcategory": "fire_smoke",
+        "risk_level": "EMERGENCY",
+        "dispatched_vendor_id": null,
+        "dispatched_emergency_services": true,
+        "needs_human_review": true,
+        "needs_clarification": false,
+        "confidence_category": 0.95,
+        "confidence_subcategory": 0.95,
+        "validator_reasons": [
+          "emergency_band:always_pause",
+          "emergency_dispatch:fire_smoke:hazard_cue_confirmed"
+        ],
+        "risk_reasons": [
+          "base_risk:EMERGENCY",
+          "hard_cue:smoke",
+          "hard_cue:fire",
+          "capped_at_EMERGENCY:historical_max for subcategory=fire_smoke"
+        ],
+        "retrieved_record_ids": [
+          "TKT-2024-00591",
+          "TKT-2023-03845",
+          "TKT-2024-09399",
+          "TKT-2022-03664",
+          "TKT-2024-09357",
+          "TKT-2022-07018",
+          "TKT-2022-08095",
+          "TKT-2024-05535"
+        ]
+      },
+      "human_override": null,
+      "final_decision": {
+        "category": "LIFE_SAFETY",
+        "subcategory": "fire_smoke",
+        "risk_level": "EMERGENCY",
+        "dispatched_vendor_id": null,
+        "dispatched_emergency_services": true,
+        "needs_human_review": true,
+        "needs_clarification": false,
+        "confidence_category": 0.95,
+        "confidence_subcategory": 0.95,
+        "validator_reasons": [
+          "emergency_band:always_pause",
+          "emergency_dispatch:fire_smoke:hazard_cue_confirmed"
+        ],
+        "risk_reasons": [
+          "base_risk:EMERGENCY",
+          "hard_cue:smoke",
+          "hard_cue:fire",
+          "capped_at_EMERGENCY:historical_max for subcategory=fire_smoke"
+        ],
+        "retrieved_record_ids": [
+          "TKT-2024-00591",
+          "TKT-2023-03845",
+          "TKT-2024-09399",
+          "TKT-2022-03664",
+          "TKT-2024-09357",
+          "TKT-2022-07018",
+          "TKT-2022-08095",
+          "TKT-2024-05535"
+        ]
+      }
+    },
+    "transcript_id": "EVAL-0990"
+  }
+]


### PR DESCRIPTION
Re-baseline of dev set on the now-stacked main (PRs #68 + #69 + #70 all merged). Composite **87.95 → 90.88** (+2.93), false_911 still 0. Commits the predictions file and appends a history row in `eval_runs/README.md` so the next iteration has a deterministic reference.

No code changes.