### PR TITLE
submission: your_submission/agent.py shim for spec-template import path

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,17 @@ python evaluation/run_eval.py \
     --out predictions.json
 ```
 
+### Agent module path — two equivalent options
+
+Both `--agent` flags below resolve to the same `classify()` function. Either works for grading:
+
+```bash
+--agent agent.classify:classify          # native module path
+--agent your_submission.agent:classify   # spec-template path (your_submission/agent.py re-exports the same callable)
+```
+
+The `your_submission/agent.py` shim exists so the literal example command from the assignment brief runs without modification.
+
 The chroma store is gitignored — it's built on first run from
 [`operational/historical_records.json`](operational/historical_records.json)
 using the `text-embedding-3-small` model (configurable via `AGENT_EMBEDDING_MODEL`).

--- a/your_submission/__init__.py
+++ b/your_submission/__init__.py
@@ -1,0 +1,1 @@
+"""Submission-namespace shim — see your_submission/agent.py for the entrypoint."""

--- a/your_submission/agent.py
+++ b/your_submission/agent.py
@@ -1,0 +1,20 @@
+"""Spec-compliant entrypoint shim.
+
+The final-assignment brief shows the example grader command as:
+
+    python evaluation/run_eval.py \
+        --agent your_submission.agent:classify \
+        --eval evaluation/eval_transcripts_test.json
+
+This module exists solely so that literal command works. The real
+orchestrator is at `agent/classify.py`; this is a one-line re-export.
+
+Either of these `--agent` flags is equivalent and produces identical
+predictions:
+
+    --agent your_submission.agent:classify   # the spec's literal template
+    --agent agent.classify:classify          # the native module path
+"""
+from agent.classify import classify
+
+__all__ = ["classify"]


### PR DESCRIPTION
## Summary
Adds a tiny shim so the literal grader command from the assignment brief works without modification.

## What changed
- `your_submission/__init__.py` — empty namespace marker
- `your_submission/agent.py` — single-line re-export of `classify` from `agent.classify`
- `README.md` — adds an "Agent module path" note documenting that both paths work

## Why
The brief shows the example grader command as:
```
python evaluation/run_eval.py --agent your_submission.agent:classify --eval evaluation/eval_transcripts_test.json
```

Our agent lives at `agent/classify.py` (a package), not at a flat `agent.py`. Both are valid Python "modules," but the literal example command from the brief would `ModuleNotFoundError` against our layout. The shim removes that ambiguity at zero risk — it's purely additive, doesn't touch agent code, doesn't change any test, doesn't affect grader behavior beyond the import path.

## Verified
- `from your_submission.agent import classify` succeeds; `classify is agent.classify.classify == True`
- `make test-fast` still passes (every suite green: contract 14/14, determinism 5/5, security 19/19, etc.)
- The native path `--agent agent.classify:classify` continues to work unchanged

## Test plan
- [x] `python -c "from your_submission.agent import classify"` succeeds
- [x] Native import path still works
- [x] Full fast test suite green
- [ ] CI green on this PR