### PR TITLE
classify: subcategory disambiguation hints (power_outage / pipe_leak / refrigerant)

### DIFF
--- a/agent/nodes/classify.py
+++ b/agent/nodes/classify.py
@@ -278,9 +278,34 @@ location:        {building_name} / {floor} / {suite}
   lighting → GROUNDS_EXTERIOR/parking_lighting. The taxonomy splits indoor
   vs outdoor lighting fixtures across two different categories.
 
+- ELECTRICAL/lighting vs ELECTRICAL/power_outage: "lighting" is for problems
+  with specific FIXTURES (bulbs out, flickering, ballast hum, single fixture
+  dead). When ALL lights on a floor or wing go dark — or anything else
+  loses power simultaneously (outlets, equipment, screens) — that's a
+  power_outage, not a lighting issue. The distinguishing test: is the failure
+  scoped to lights specifically (→ lighting), or did multiple loads drop at
+  once on shared circuitry (→ power_outage)?
+
 - Roof or ceiling water intrusion (including ceiling tiles falling because of
   water) → PLUMBING/roof_leak. The cause is water from above. Falling tile is a
   symptom, not the category.
+
+- PLUMBING/roof_leak vs PLUMBING/pipe_leak: roof_leak is for water entering
+  from outside the building envelope (rain, weather, water drainage from
+  upstairs through floor/ceiling — i.e. NO identified internal source).
+  pipe_leak is for water escaping from a specific internal pipe, fixture,
+  valve, or fitting (sink, toilet, water heater, supply line, sprinkler
+  riser). When the caller names or describes a specific plumbing component
+  → pipe_leak. When the caller says "water from the ceiling" with no
+  identified plumbing source overhead → roof_leak.
+
+- HVAC/refrigerant vs HVAC/no_cooling: refrigerant is for evidence of
+  chemical-coolant escape — caller reports a chemical smell near the AC,
+  oily residue around the unit, hissing from refrigerant lines, or visible
+  ice/frost on the coil. no_cooling is for "the AC just isn't cooling"
+  with NO chemical signature — thermostat unresponsive, vent blowing warm
+  air, temperature creeping up. SMELL near an AC unit is the strongest
+  refrigerant signal; absence of smell + warm air = no_cooling.
 
 # OVER-ESCALATION GUARD (FINAL EMPHASIS — high-stakes; false alarms are heavily penalised)
 


### PR DESCRIPTION
## Summary
Three new LLM prompt hints targeting the recurring subcategory confusions visible in the run-g dev scoring:
- \`power_outage → lighting\` (1 case)
- \`roof_leak → pipe_leak\` (1 case)
- \`refrigerant → no_cooling\` (1 case)

Added as three new bullets in the existing TAXONOMY DISAMBIGUATION section of \`agent/nodes/classify.py\`'s prompt template. No code-path or contract changes.

## Expected lift
- Subcategory axis +1-2pp (3 of 6 confused cases targeted; 3/200 = 1.5pp if all hit)
- Composite +0.15 to +0.30 (subcategory weight is 15%)
- Mathematically caps at +0.45 even in best case (all 3 + new clean classification)

## Safety
- \`classify()\` body bytes unchanged (prompt lives in \`agent/nodes/classify.py\`, hash guard pins \`agent/classify.py\`'s orchestrator) — \`test_classify_unchanged\` still passes
- Cannot introduce false-911s (subcategory shift only; validator life-safety whitelist independently gates \`dispatched_emergency_services\`)
- Determinism intact (temperature 0 + seed 7)

## Risk
- LLM prompt brittleness — hints could over-fire on edge cases. The dev eval below is the test.

## Verification gate
**Merge if dev eval composite ≥ 92.4 (+0.1 over 92.33) AND no axis regression > 1pp AND false_911 = 0.**

Sachit will run the dev eval from his terminal in the cbre-prompt-hints worktree:
\`\`\`bash
cd ../cbre-prompt-hints
.venv/bin/python evaluation/run_eval.py \\
  --agent agent.classify:classify \\
  --eval evaluation/eval_transcripts_dev.json \\
  --out eval_runs/dev_prompt_hints.json
.venv/bin/python evaluation/scoring.py \\
  --eval evaluation/eval_transcripts_dev.json \\
  --ground-truth evaluation/dev_labels.json \\
  --predictions eval_runs/dev_prompt_hints.json
\`\`\`

## Test plan
- [x] \`make test-fast\` passes (except known-flaky \`test_classify_is_deterministic\`)
- [x] Hash guard intact (\`test_classify_unchanged\`)
- [x] Prompt template builds without error
- [ ] Dev eval composite ≥ 92.4 (verification before merge)
- [ ] CI green on this PR