### PR TITLE
Calibrate risk edge HITL handling

### DIFF
--- a/agent/nodes/risk.py
+++ b/agent/nodes/risk.py
@@ -75,6 +75,12 @@ _SOFT_ESCALATION_PATTERNS = tuple(re.compile(p, re.IGNORECASE) for p in (
     r"\bflood(ing)?\b",            # active flooding, not just water
 ))
 
+_PIPE_LEAK_WATER_VOLUME_PATTERN = re.compile(
+    r"\bflood(?:ing)?\b|\boverflow(?:ing)?\b|\bpool(?:ing)?\b|"
+    r"\bfilling\s+up\b|\bcoming\s+out\b",
+    re.IGNORECASE,
+)
+
 # Building types where occupant safety / 24-hour presence elevates risk.
 _SENSITIVE_BUILDING_TYPES = frozenset({"medical", "residential"})
 
@@ -189,6 +195,13 @@ def assign_risk(
     for cue in extraction.urgency_cues:
         bump, tier = _classify_cue(cue)
         if bump > 0:
+            if (
+                subcategory == "pipe_leak"
+                and tier == "soft"
+                and _PIPE_LEAK_WATER_VOLUME_PATTERN.search(cue)
+            ):
+                reasons.append(f"soft_cue_no_bump:{cue}:pipe_leak_water_volume")
+                continue
             if tier == "soft":
                 rank = min(rank + bump, RISK_LEVEL_RANK["HIGH"])
             else:

--- a/agent/nodes/validator.py
+++ b/agent/nodes/validator.py
@@ -227,6 +227,20 @@ def validate(
             blocker = "low_confidence"
         pause = True
         reasons.append(f"life_safety_no_autodispatch:{blocker}")
+    elif (
+        subcategory == "waste_odor"
+        and risk_level == "LOW"
+        and hazard_cue
+        and benign_override is not None
+    ):
+        # Benign smoke/odor traps are safe from autonomous 911, but the
+        # caller still mentioned smoke/fire language and explicitly
+        # ruled out a real emergency. Send to a reviewer instead of
+        # silently auto-resolving the odor ticket.
+        pause = True
+        if reasons == ["auto_resolve:no_flags_fired"]:
+            reasons = []
+        reasons.append(f"benign_smoke_odor_review:{benign_override!r}")
 
     return ValidatorResult(
         needs_human_review=pause,

--- a/tests/test_risk_assignment.py
+++ b/tests/test_risk_assignment.py
@@ -128,16 +128,14 @@ def test_hard_cues_keep_emergency_subcategory_at_emergency():
     assert r.band == "EMERGENCY"
 
 
-def test_soft_cues_capped_at_high_on_routable_base():
-    """Soft cues (flooding, getting-worse, …) may push the band UP but
-    never beyond HIGH — only hard life-safety cues are permitted to
-    reach EMERGENCY. pipe_leak (base HIGH) + "flooding" (soft +1) now
-    stays at HIGH instead of cascading to EMERGENCY, which prevents
-    false-emergency dispatches on routable-base subcategories."""
+def test_pipe_leak_water_volume_cue_does_not_bump_to_high():
+    """A water-volume cue alone is still a routable pipe leak, not a
+    reviewer-worthy HIGH-risk call. Hard life-safety cues still escalate
+    below."""
     e = _extraction(urgency_cues=["flooding"])  # soft cue: +1
     r = assign_risk(e, "pipe_leak")
-    assert r.band == "HIGH"
-    assert any("soft_cue:flooding" in reason for reason in r.reasons)
+    assert r.band == "MEDIUM"
+    assert any("soft_cue_no_bump:flooding" in reason for reason in r.reasons)
 
 
 def test_hard_cues_uncapped_can_promote_pipe_leak_to_emergency():

--- a/tests/test_validator.py
+++ b/tests/test_validator.py
@@ -80,6 +80,42 @@ def test_trap_subcategory_triggers_review():
     assert "trap_prone" in result.reasons[0]
 
 
+def test_waste_odor_benign_smoke_trap_reviews_without_911():
+    """LOW waste_odor normally auto-resolves, but benign smoke/fire
+    language should still get a human review while preserving no-911."""
+    _reset()
+    transcript = (
+        "[CALLER] Smoke alarm beeped once and there's smoke, but it was just burnt toast.\n"
+        "[AGENT] Can you confirm there's no actual fire or injury right now?\n"
+        "[CALLER] No fire, just the burnt smell."
+    )
+    result = validate(
+        subcategory="waste_odor",
+        risk_level="LOW",
+        classification_confidence=0.95,
+        fallback_invoked=False,
+        extracted_urgency_cues=["smoke"],
+        transcript_text=transcript,
+    )
+    assert result.needs_human_review is True
+    assert result.dispatched_emergency_services is False
+    assert any("benign_smoke_odor_review" in r for r in result.reasons)
+
+
+def test_routine_waste_odor_still_auto_resolves():
+    _reset()
+    result = validate(
+        subcategory="waste_odor",
+        risk_level="LOW",
+        classification_confidence=0.95,
+        fallback_invoked=False,
+        extracted_urgency_cues=[],
+        transcript_text="[CALLER] Trash room odor near the service hallway.",
+    )
+    assert result.needs_human_review is False
+    assert result.dispatched_emergency_services is False
+
+
 # ─── False-911 prevention (the −5 penalty path) ───────────────────────
 
 


### PR DESCRIPTION
## Summary
- Keep pipe-leak water-volume cues at MEDIUM unless a hard life-safety cue is present
- Send benign smoke/fire waste_odor traps to human review without dispatching 911
- Add targeted regression coverage for both edge calibrations

## Dev Eval
- gpt-4o-mini: 93.15 composite, HITL F1 80.30%, risk 88.00%, false-911 0
- gpt-4.1-mini: 93.62 composite, HITL F1 80.92%, risk 88.50%, false-911 0
- Previous dev_levers12 baseline: 92.33 composite, false-911 0

## Tests
- /Users/rohaniyer/Desktop/turing/sachit-rohan-final-proj/.venv/bin/python -m pytest tests/test_risk_assignment.py
- /Users/rohaniyer/Desktop/turing/sachit-rohan-final-proj/.venv/bin/python -m pytest tests/test_validator.py
- /Users/rohaniyer/Desktop/turing/sachit-rohan-final-proj/.venv/bin/python -m pytest tests/test_hitl.py